### PR TITLE
Store pplns for validation using user_id

### DIFF
--- a/p2poolv2_lib/src/accounting/simple_pplns/mod.rs
+++ b/p2poolv2_lib/src/accounting/simple_pplns/mod.rs
@@ -20,8 +20,31 @@ use serde::{Deserialize, Serialize};
 
 pub mod payout;
 
+/// Stored representation of a PPLNS share - persisted to database
+/// Contains only essential data to minimize storage size
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredPplnsShare {
+    pub user_id: u64,
+    pub difficulty: u64,
+    pub timestamp: u64,
+}
+
+impl StoredPplnsShare {
+    /// Serialize the stored pplns share and take a double sha256 hash for it
+    /// The result is used to identify the share uniquely and store it in store
+    pub fn hash_and_serialize(&self) -> Result<(PplnsShareBlockHash, Vec<u8>), std::io::Error> {
+        let mut serialized = Vec::new();
+        ciborium::ser::into_writer(&self, &mut serialized).unwrap();
+        let hash = PplnsShareBlockHash(bitcoin::hashes::Hash::hash(&serialized));
+        Ok((hash, serialized))
+    }
+}
+
+/// In-memory representation of a PPLNS share
+/// Contains additional fields (btcaddress, workername) for metrics and display
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SimplePplnsShare {
+    pub user_id: u64,
     pub difficulty: u64,
     pub btcaddress: String,
     pub workername: String,
@@ -29,8 +52,15 @@ pub struct SimplePplnsShare {
 }
 
 impl SimplePplnsShare {
-    pub fn new(difficulty: u64, btcaddress: String, workername: String, timestamp: u64) -> Self {
+    pub fn new(
+        user_id: u64,
+        difficulty: u64,
+        btcaddress: String,
+        workername: String,
+        timestamp: u64,
+    ) -> Self {
         SimplePplnsShare {
+            user_id,
             difficulty,
             btcaddress,
             workername,
@@ -38,13 +68,19 @@ impl SimplePplnsShare {
         }
     }
 
+    /// Convert to stored representation for database persistence
+    pub fn to_stored(&self) -> StoredPplnsShare {
+        StoredPplnsShare {
+            user_id: self.user_id,
+            difficulty: self.difficulty,
+            timestamp: self.timestamp,
+        }
+    }
+
     /// Serialize the pplns share and take a double sha256 hash for it
     /// The result is used to identify the share uniquely and store it in store
     pub fn hash_and_serialize(&self) -> Result<(PplnsShareBlockHash, Vec<u8>), std::io::Error> {
-        let mut serialized = Vec::new();
-        ciborium::ser::into_writer(&self, &mut serialized).unwrap();
-        let hash = PplnsShareBlockHash(bitcoin::hashes::Hash::hash(&serialized));
-        Ok((hash, serialized))
+        self.to_stored().hash_and_serialize()
     }
 }
 

--- a/p2poolv2_lib/src/accounting/simple_pplns/payout.rs
+++ b/p2poolv2_lib/src/accounting/simple_pplns/payout.rs
@@ -199,24 +199,28 @@ mod tests {
         // Create shares with total difficulty of 1000
         let shares = vec![
             SimplePplnsShare::new(
+                1,
                 400,
                 "addr1".to_string(),
                 "worker1".to_string(),
                 (current_time - 1800) * 1_000_000,
             ), // 30 min ago
             SimplePplnsShare::new(
+                2,
                 300,
                 "addr2".to_string(),
                 "worker2".to_string(),
                 (current_time - 2400) * 1_000_000,
             ), // 40 min ago
             SimplePplnsShare::new(
+                3,
                 200,
                 "addr3".to_string(),
                 "worker3".to_string(),
                 (current_time - 3000) * 1_000_000,
             ), // 50 min ago
             SimplePplnsShare::new(
+                4,
                 100,
                 "addr4".to_string(),
                 "worker4".to_string(),
@@ -259,24 +263,28 @@ mod tests {
 
         let shares = vec![
             SimplePplnsShare::new(
+                1,
                 400,
                 "addr1".to_string(),
                 "worker1".to_string(),
                 (current_time - 1800) * 1_000_000,
             ),
             SimplePplnsShare::new(
+                2,
                 300,
                 "addr2".to_string(),
                 "worker2".to_string(),
                 (current_time - 2400) * 1_000_000,
             ),
             SimplePplnsShare::new(
+                3,
                 200,
                 "addr3".to_string(),
                 "worker3".to_string(),
                 (current_time - 3000) * 1_000_000,
             ),
             SimplePplnsShare::new(
+                4,
                 100,
                 "addr4".to_string(),
                 "worker4".to_string(),
@@ -315,12 +323,14 @@ mod tests {
 
         let shares = vec![
             SimplePplnsShare::new(
+                1,
                 100,
                 "addr1".to_string(),
                 "worker1".to_string(),
                 (current_time - 1800) * 1_000_000,
             ),
             SimplePplnsShare::new(
+                2,
                 200,
                 "addr2".to_string(),
                 "worker2".to_string(),
@@ -382,6 +392,7 @@ mod tests {
         let mut store = ChainStore::default();
 
         let shares = vec![SimplePplnsShare::new(
+            1,
             1500,
             "addr1".to_string(),
             "worker1".to_string(),
@@ -416,24 +427,28 @@ mod tests {
         // Create shares spanning 300 seconds (3 batches)
         let shares = vec![
             SimplePplnsShare::new(
+                1,
                 100,
                 "addr1".to_string(),
                 "worker1".to_string(),
                 (current_time - 50) * 1_000_000,
             ), // 50s ago
             SimplePplnsShare::new(
+                2,
                 200,
                 "addr2".to_string(),
                 "worker2".to_string(),
                 (current_time - 150) * 1_000_000,
             ), // 150s ago
             SimplePplnsShare::new(
+                3,
                 300,
                 "addr3".to_string(),
                 "worker3".to_string(),
                 (current_time - 250) * 1_000_000,
             ), // 250s ago
             SimplePplnsShare::new(
+                4,
                 400,
                 "addr4".to_string(),
                 "worker4".to_string(),
@@ -488,6 +503,7 @@ mod tests {
         let mut store = ChainStore::default();
 
         let shares = vec![SimplePplnsShare::new(
+            1,
             1000,
             "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq".to_string(),
             "worker1".to_string(),
@@ -530,12 +546,14 @@ mod tests {
 
         let shares = vec![
             SimplePplnsShare::new(
+                1,
                 600,
                 "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq".to_string(),
                 "worker1".to_string(),
                 (current_time - 1800) * 1_000_000,
             ),
             SimplePplnsShare::new(
+                2,
                 400,
                 "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4".to_string(),
                 "worker2".to_string(),
@@ -596,18 +614,21 @@ mod tests {
         // Multiple shares from same address should be aggregated
         let shares = vec![
             SimplePplnsShare::new(
+                1,
                 300,
                 "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq".to_string(),
                 "worker1".to_string(),
                 (current_time - 1800) * 1_000_000,
             ),
             SimplePplnsShare::new(
+                1,
                 200,
                 "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq".to_string(),
                 "worker2".to_string(),
                 (current_time - 2400) * 1_000_000,
             ),
             SimplePplnsShare::new(
+                2,
                 500,
                 "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4".to_string(),
                 "worker3".to_string(),
@@ -673,9 +694,9 @@ mod tests {
     #[tokio::test]
     async fn test_group_shares_by_address() {
         let shares = vec![
-            SimplePplnsShare::new(100, "addr1".to_string(), "worker1".to_string(), 1000),
-            SimplePplnsShare::new(200, "addr2".to_string(), "worker2".to_string(), 2000),
-            SimplePplnsShare::new(300, "addr1".to_string(), "worker3".to_string(), 3000),
+            SimplePplnsShare::new(1, 100, "addr1".to_string(), "worker1".to_string(), 1000),
+            SimplePplnsShare::new(2, 200, "addr2".to_string(), "worker2".to_string(), 2000),
+            SimplePplnsShare::new(1, 300, "addr1".to_string(), "worker3".to_string(), 3000),
         ];
 
         let result = Payout::group_shares_by_address(&shares);

--- a/p2poolv2_lib/src/accounting/stats/metrics.rs
+++ b/p2poolv2_lib/src/accounting/stats/metrics.rs
@@ -575,6 +575,7 @@ mod tests {
             .unwrap();
         let _ = handle
             .record_share_accepted(SimplePplnsShare {
+                user_id: 1,
                 difficulty: 100,
                 btcaddress: "user1".to_string(),
                 workername: "worker1".to_string(),
@@ -591,6 +592,7 @@ mod tests {
         // Test that highest difficulty is updated correctly
         let _ = handle
             .record_share_accepted(SimplePplnsShare {
+                user_id: 1,
                 difficulty: 50,
                 btcaddress: "user1".to_string(),
                 workername: "worker1".to_string(),
@@ -604,6 +606,7 @@ mod tests {
 
         let _ = handle
             .record_share_accepted(SimplePplnsShare {
+                user_id: 1,
                 difficulty: 200,
                 btcaddress: "user1".to_string(),
                 workername: "worker1".to_string(),
@@ -644,6 +647,7 @@ mod tests {
 
         let _ = handle
             .record_share_accepted(SimplePplnsShare {
+                user_id: 1,
                 difficulty: 1000,
                 btcaddress: "user1".to_string(),
                 workername: "worker1".to_string(),
@@ -652,6 +656,7 @@ mod tests {
             .await;
         let _ = handle
             .record_share_accepted(SimplePplnsShare {
+                user_id: 1,
                 difficulty: 2000,
                 btcaddress: "user1".to_string(),
                 workername: "worker1".to_string(),
@@ -813,6 +818,7 @@ mod tests {
 
         let _ = handle
             .record_share_accepted(SimplePplnsShare {
+                user_id: 1,
                 difficulty: 123,
                 btcaddress: "user1".to_string(),
                 workername: "worker1".to_string(),
@@ -865,6 +871,7 @@ mod tests {
 
         let _ = handle
             .record_share_accepted(SimplePplnsShare {
+                user_id: 1,
                 difficulty: 77,
                 btcaddress: btcaddress.clone(),
                 workername: workername.clone(),
@@ -902,6 +909,7 @@ mod tests {
 
         let _ = handle
             .record_share_accepted(SimplePplnsShare {
+                user_id: 1,
                 difficulty: 10,
                 btcaddress: "userA".to_string(),
                 workername: "workerA1".to_string(),
@@ -910,6 +918,7 @@ mod tests {
             .await;
         let _ = handle
             .record_share_accepted(SimplePplnsShare {
+                user_id: 1,
                 difficulty: 20,
                 btcaddress: "userA".to_string(),
                 workername: "workerA2".to_string(),
@@ -918,6 +927,7 @@ mod tests {
             .await;
         let _ = handle
             .record_share_accepted(SimplePplnsShare {
+                user_id: 1,
                 difficulty: 30,
                 btcaddress: "userB".to_string(),
                 workername: "workerB1".to_string(),

--- a/p2poolv2_lib/src/cli_commands/pplns_shares.rs
+++ b/p2poolv2_lib/src/cli_commands/pplns_shares.rs
@@ -95,8 +95,8 @@ mod tests {
 
         // Add test shares
         let shares = vec![
-            SimplePplnsShare::new(100, "addr1".to_string(), "worker1".to_string(), 1000),
-            SimplePplnsShare::new(200, "addr2".to_string(), "worker2".to_string(), 2000),
+            SimplePplnsShare::new(1, 100, "addr1".to_string(), "worker1".to_string(), 1000),
+            SimplePplnsShare::new(2, 200, "addr2".to_string(), "worker2".to_string(), 2000),
         ];
 
         for share in &shares {

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -248,6 +248,7 @@ mod tests {
 
             // Send back a test response
             let test_shares = vec![SimplePplnsShare::new(
+                1,
                 100,
                 "addr1".to_string(),
                 "worker1".to_string(),

--- a/p2poolv2_lib/src/shares/chain/chain_store.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store.rs
@@ -442,10 +442,6 @@ impl ChainStore {
     pub fn store_user(&self, btcaddress: String) -> Result<u64, Box<dyn Error>> {
         self.store.store_user(btcaddress)
     }
-
-    pub fn store_worker(&self, user_id: u64, workername: String) -> Result<u64, Box<dyn Error>> {
-        self.store.store_worker(user_id, workername)
-    }
 }
 
 #[cfg(test)]

--- a/p2poolv2_lib/src/store/column_families.rs
+++ b/p2poolv2_lib/src/store/column_families.rs
@@ -29,9 +29,7 @@ pub enum ColumnFamily {
     Share,
     Job,
     User,
-    Worker,
     UserIndex,
-    WorkerIndex,
     Metadata,
 }
 
@@ -50,9 +48,7 @@ impl ColumnFamily {
             ColumnFamily::Share => "share",
             ColumnFamily::Job => "job",
             ColumnFamily::User => "user",
-            ColumnFamily::Worker => "worker",
             ColumnFamily::UserIndex => "user_index",
-            ColumnFamily::WorkerIndex => "worker_index",
             ColumnFamily::Metadata => "metadata",
         }
     }

--- a/p2poolv2_lib/src/store/user.rs
+++ b/p2poolv2_lib/src/store/user.rs
@@ -43,33 +43,3 @@ impl StoredUser {
         }
     }
 }
-
-/// Represents a stored worker with internal ID and worker name
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct StoredWorker {
-    /// Internal unique ID for the worker
-    pub worker_id: u64,
-    /// Internal user ID that this worker belongs to
-    pub user_id: u64,
-    /// Name of the worker
-    pub workername: String,
-    /// Timestamp when the worker was first stored (microseconds since epoch)
-    pub created_at: u64,
-}
-
-impl StoredWorker {
-    /// Create a new StoredWorker with current timestamp
-    pub fn new(worker_id: u64, user_id: u64, workername: String) -> Self {
-        let created_at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_micros() as u64;
-
-        Self {
-            worker_id,
-            user_id,
-            workername,
-            created_at,
-        }
-    }
-}

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -99,6 +99,7 @@ pub async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
         .unwrap()
         .as_secs();
     let stratum_share = SimplePplnsShare::new(
+        session.user_id.unwrap(),
         session.difficulty_adjuster.get_current_difficulty(),
         session.btcaddress.clone().unwrap_or_default(),
         session.workername.clone().unwrap_or_default(),
@@ -231,6 +232,7 @@ mod handle_submit_tests {
             u32::from_le_bytes(hex::decode(enonce1).unwrap().as_slice().try_into().unwrap());
         session.enonce1_hex = enonce1.to_string();
         session.btcaddress = Some("tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string());
+        session.user_id = Some(1);
 
         let job_id = JobId(u64::from_str_radix(&notify.params.job_id, 16).unwrap());
 
@@ -321,6 +323,7 @@ mod handle_submit_tests {
             u32::from_le_bytes(hex::decode(enonce1).unwrap().as_slice().try_into().unwrap());
         session.enonce1_hex = enonce1.to_string();
         session.btcaddress = Some("tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string());
+        session.user_id = Some(1);
 
         let job_id = JobId(u64::from_str_radix(&notify.params.job_id, 16).unwrap());
 
@@ -411,6 +414,7 @@ mod handle_submit_tests {
             u32::from_le_bytes(hex::decode(enonce1).unwrap().as_slice().try_into().unwrap());
         session.enonce1_hex = enonce1.to_string();
         session.btcaddress = Some("tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string());
+        session.user_id = Some(1);
 
         let job_id = JobId(u64::from_str_radix(&notify.params.job_id, 16).unwrap());
 
@@ -511,6 +515,7 @@ mod handle_submit_tests {
             u32::from_le_bytes(hex::decode(enonce1).unwrap().as_slice().try_into().unwrap());
         session.enonce1_hex = enonce1.to_string();
         session.btcaddress = Some("tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string());
+        session.user_id = Some(1);
 
         let job_id = JobId(u64::from_str_radix(&notify.params.job_id, 16).unwrap());
 
@@ -591,6 +596,7 @@ mod handle_submit_tests {
             u32::from_le_bytes(hex::decode(enonce1).unwrap().as_slice().try_into().unwrap());
         session.enonce1_hex = enonce1.to_string();
         session.btcaddress = Some("tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string());
+        session.user_id = Some(1);
 
         let (shares_tx, _shares_rx) = mpsc::channel(10);
         let stats_dir = tempfile::tempdir().unwrap();

--- a/p2poolv2_lib/src/stratum/work/notify.rs
+++ b/p2poolv2_lib/src/stratum/work/notify.rs
@@ -296,6 +296,7 @@ mod tests {
         let mut store = ChainStore::default();
 
         let shares = vec![SimplePplnsShare {
+            user_id: 1,
             difficulty: 100,
             btcaddress: "bcrt1qe2qaq0e8qlp425pxytrakala7725dynwhknufr".to_string(),
             workername: "".to_string(),
@@ -377,6 +378,7 @@ mod tests {
         let mut store = ChainStore::default();
 
         let shares = vec![SimplePplnsShare {
+            user_id: 1,
             difficulty: 100,
             btcaddress: "bcrt1qe2qaq0e8qlp425pxytrakala7725dynwhknufr".to_string(),
             workername: "".to_string(),
@@ -501,6 +503,7 @@ mod tests {
         let mut store = ChainStore::default();
 
         let shares = vec![SimplePplnsShare {
+            user_id: 1,
             difficulty: 100,
             btcaddress: "tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string(),
             workername: "".to_string(),


### PR DESCRIPTION
Storing btcaddress and workername would take way more space. 65 bytes only for btcaddress vs 8 bytes for the user id only.

Also, worker tracking is not required for pplns tracking.