### PR TITLE
Improve pplns share key, use rocksdb range query

### DIFF
--- a/p2poolv2_lib/src/accounting/simple_pplns/mod.rs
+++ b/p2poolv2_lib/src/accounting/simple_pplns/mod.rs
@@ -69,7 +69,7 @@ impl SimplePplnsShare {
         key
     }
 
-    /// Parse key made by make_key2
+    /// Parse key made by make_key
     ///
     /// Three 8 byte components, n_time, user_id and sequence
     /// Returns n_time and user_id

--- a/p2poolv2_lib/src/store/pplns_shares.rs
+++ b/p2poolv2_lib/src/store/pplns_shares.rs
@@ -62,11 +62,9 @@ impl Store {
         let use_limit = limit.unwrap_or(INITIAL_SHARE_VEC_CAPACITY);
         let mut shares: Vec<SimplePplnsShare> = Vec::with_capacity(use_limit);
 
-        for item in iter.take(use_limit) {
-            if let Ok((_key, value)) = item {
-                if let Ok(share) = ciborium::de::from_reader(&value[..]) {
-                    shares.push(share);
-                }
+        for (_key, value) in iter.take(use_limit).flatten() {
+            if let Ok(share) = ciborium::de::from_reader(&value[..]) {
+                shares.push(share);
             }
         }
 

--- a/p2poolv2_lib/src/utils/snowflake_simplified.rs
+++ b/p2poolv2_lib/src/utils/snowflake_simplified.rs
@@ -26,6 +26,10 @@ const CUSTOM_EPOCH: u64 = 1735689600000; // 2025-01-01 in ms
 ///
 /// We retain the benefits of sorted ids and avoid any conflicts in
 /// the same millisecond by using the atomic u32 sequence.
+///
+/// Generates an 8 byte id, with ms timestamp and ~4M sequence per ms
+/// Depends on global atomic, so if we use it in a lot of places, we
+/// can stripe it into key type
 pub fn get_next_id() -> u64 {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
We reduced the size of the key and are now able to do a range query for pplns share in rocksdb as opposed to in our code.