### PR TITLE
Add duplicate detection

### DIFF
--- a/p2poolv2_lib/src/stratum/work/tracker/mod.rs
+++ b/p2poolv2_lib/src/stratum/work/tracker/mod.rs
@@ -277,6 +277,10 @@ impl TrackerHandle {
 
     /// Add a share for duplicate detection
     /// Returns true if share is newly inserted, false if job not found or share already exists
+    ///
+    /// If a client sends same share with an earlier job_id, the share
+    /// validation will fail as the blocktemplate's nTime will be
+    /// different and the share's nonce will not meet the current difficulty
     pub async fn add_share(&self, job_id: JobId, blockhash: BlockHash) -> Result<bool, String> {
         let (resp_tx, resp_rx) = oneshot::channel();
 


### PR DESCRIPTION
Duplicate shares for the same job are rejected. When job changes, clients submitting duplicate shares across jobids will fail as the template's ntime for different jobs will be different.