### PR TITLE
Authorize failure follows two strike policy

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ docker-explore: (docker-run "--entrypoint bash")
 
 # For log level use RUST_LOG=<<level>> just run
 run config="config.toml":
-	cargo run -p p2poolv2_node -- --config={{ config }}
+    cargo run -p p2poolv2_node -- --config={{ config }}
 
 alias dash := dashboard
 

--- a/p2poolv2_lib/src/stratum/session.rs
+++ b/p2poolv2_lib/src/stratum/session.rs
@@ -60,6 +60,8 @@ pub struct Session<D: DifficultyAdjusterTrait> {
     pub connected_at: SystemTime,
     /// Instant when the last valid share was submitted
     pub last_share_time: Option<SystemTime>,
+    /// Authorization failed once
+    pub auth_failed_once: bool,
 }
 
 impl<D: DifficultyAdjusterTrait> Session<D> {
@@ -89,6 +91,7 @@ impl<D: DifficultyAdjusterTrait> Session<D> {
             suggested_difficulty: None,
             connected_at: now,
             last_share_time: None,
+            auth_failed_once: false,
         }
     }
 


### PR DESCRIPTION
- first failure: shows failure reason to user
- second failure: disconnects