### PR TITLE
Don't maintain chain in standalone mode

### DIFF
--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -154,7 +154,7 @@ impl NodeActor {
                     match buf {
                         Some(emission) => {
                             debug!("Sending share to peers");
-                              if let Ok(Some(share_block)) = handle_stratum_share(emission, self.node.chain_store.clone(), self.node.config.stratum.network) {
+                            if let Ok(Some(share_block)) = handle_stratum_share(emission, self.node.chain_store.clone(), self.node.config.stratum.network, self.node.p2p_enabled) {
                                 if let Err(e) = self.node.send_to_all_peers(Message::ShareBlock(share_block)) {
                                     error!("Error sending share to all peers {e}");
                                 }

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -94,6 +94,8 @@ struct Node {
         Box<dyn Error + Send + Sync>,
     >,
     config: Config,
+    /// If p2poolv2 is enabled or are we running as a standalone pool
+    p2p_enabled: bool,
 }
 
 impl Node {
@@ -189,6 +191,7 @@ impl Node {
         let service =
             build_service::<ResponseChannel<Message>, _>(config.network.clone(), swarm_tx.clone());
 
+        let p2p_enabled = !config.network.listen_address.is_empty();
         Ok(Self {
             swarm,
             swarm_tx,
@@ -196,6 +199,7 @@ impl Node {
             chain_store,
             service,
             config,
+            p2p_enabled,
         })
     }
 


### PR DESCRIPTION
We need to write to chain only in p2pool mode. In hydrapool mode, we only need to store the PPLNS shares.

This is a stop gap change for hydrapool and will come back as weighted scores instead of storing all PPLNS shares.