### PR TITLE
Fix: Change the share value to 1 BTC 

### DIFF
--- a/p2poolv2_lib/src/shares/share_block/mod.rs
+++ b/p2poolv2_lib/src/shares/share_block/mod.rs
@@ -400,7 +400,7 @@ mod tests {
 
         // Verify the output is a P2PKH to the miner's public key
         let output = &share_block.transactions[0].output[0];
-        assert_eq!(output.value.to_sat(), 1);
+        assert_eq!(output.value.to_sat(), 100_000_000);
 
         // Verify the output script is P2PKH for the miner's pubkey
         let expected_address = bitcoin::Address::p2pkh(pubkey, bitcoin::Network::Regtest);

--- a/p2poolv2_lib/src/shares/transactions/coinbase.rs
+++ b/p2poolv2_lib/src/shares/transactions/coinbase.rs
@@ -16,7 +16,7 @@
 
 use bitcoin::{Address, CompressedPublicKey, Network, Transaction, TxOut};
 
-const SHARE_VALUE: u64 = 100_000_000;
+const SHARE_VALUE: u64 = 1; // 1_000_000_000 satoshi == 1 BTC == 1 share
 
 /// Create a P2PKH coinbase transaction for the given public key and amount
 /// For now, all shares are equal value, so the amount is 1 unit share coin.
@@ -29,7 +29,7 @@ pub fn create_coinbase_transaction(pubkey: &CompressedPublicKey, network: Networ
 
     // Create TxOut with script_pubkey and amount of 1 satoshi
     let tx_out = TxOut {
-        value: bitcoin::Amount::from_sat(SHARE_VALUE),
+        value: bitcoin::Amount::from_int_btc(SHARE_VALUE),
         script_pubkey,
     };
 
@@ -73,7 +73,7 @@ mod tests {
 
         // Verify output properties
         let output = &transaction.output[0];
-        assert_eq!(output.value, bitcoin::Amount::from_sat(SHARE_VALUE));
+        assert_eq!(output.value, bitcoin::Amount::from_int_btc(SHARE_VALUE));
 
         // Verify output goes to correct address
         let expected_address = Address::p2pkh(pubkey, Network::Regtest);


### PR DESCRIPTION
Set the share value to 1 BTC, enabling partial shares to be used for fee payment in the transaction engine.