### PR TITLE
clean up log levels to keep normal runs quiet

### DIFF
--- a/p2poolv2_api/src/api/server.rs
+++ b/p2poolv2_api/src/api/server.rs
@@ -32,7 +32,7 @@ use p2poolv2_lib::{
 use serde::Deserialize;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::oneshot;
-use tracing::info;
+use tracing::debug;
 
 #[derive(Clone)]
 pub(crate) struct AppState {
@@ -110,18 +110,18 @@ pub async fn start_api_server(
         Err(e) => return Err(e),
     };
 
-    info!("API server listening on {}", addr);
+    debug!("API server listening on {}", addr);
 
     tokio::spawn(async move {
         axum::serve(listener, app)
             .with_graceful_shutdown(async move {
                 let _ = shutdown_rx.await;
-                info!("API server shutdown signal received");
+                debug!("API server shutdown signal received");
             })
             .await
             .map_err(|e| ApiError::ServerError(e.to_string()))?;
 
-        info!("API server stopped");
+        debug!("API server stopped");
         Ok::<(), ApiError>(())
     });
     Ok(shutdown_tx)

--- a/p2poolv2_lib/src/cli_commands/mod.rs
+++ b/p2poolv2_lib/src/cli_commands/mod.rs
@@ -25,7 +25,7 @@ pub mod store {
 
     /// Open a store from the given path
     pub fn open_store(store_path: String) -> Result<Store, StoreError> {
-        tracing::info!("Opening store in read-only mode: {:?}", store_path);
+        tracing::debug!("Opening store in read-only mode: {:?}", store_path);
 
         Store::new(store_path, true).map_err(|e| {
             tracing::error!("Failed to open store: {}", e);

--- a/p2poolv2_lib/src/logging.rs
+++ b/p2poolv2_lib/src/logging.rs
@@ -16,7 +16,7 @@
 
 use crate::config::LoggingConfig;
 use std::error::Error;
-use tracing::info;
+use tracing::debug;
 use tracing_appender::non_blocking;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{EnvFilter, Registry, fmt, layer::SubscriberExt, util::SubscriberInitExt};
@@ -65,7 +65,7 @@ pub fn setup_logging(
     };
 
     let (file_layer, guard) = if let Some(file_path) = &logging_config.file {
-        info!("File logging is enabled, writing to: {}", file_path);
+        debug!("File logging is enabled, writing to: {}", file_path);
         // Create directory structure if it doesn't exist
         if let Some(parent) = std::path::Path::new(file_path).parent() {
             std::fs::create_dir_all(parent)?;
@@ -81,7 +81,7 @@ pub fn setup_logging(
             .to_str()
             .unwrap_or("p2pool.log");
 
-        info!(
+        debug!(
             "Logging to directory: {}, filename: {}",
             directory.display(),
             filename

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -32,7 +32,7 @@ use crate::stratum::emission::EmissionReceiver;
 use libp2p::futures::StreamExt;
 use std::error::Error;
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 /// NodeHandle provides an interface to interact with a Node running in a separate task
 #[derive(Clone)]
@@ -196,7 +196,7 @@ impl NodeActor {
                         }
                         Some(SwarmSend::Inv(_share_block)) => {
                             // Handle inventory message (optional logging or processing)
-                            tracing::info!("Received SwarmSend::Inv message");
+                            tracing::debug!("Received SwarmSend::Inv message");
                         }
                         Some(SwarmSend::Disconnect(peer_id)) => {
                             if let Err(_e) = self.node.swarm.disconnect_peer_id(peer_id) {
@@ -216,7 +216,7 @@ impl NodeActor {
                             }
                         }
                         None => {
-                            info!("Stopping node actor on swarm channel close");
+                            debug!("Stopping node actor on swarm channel close");
                             if self.stopping_tx.send(()).is_err() {
                                 error!("Failed to send stopping signal - receiver dropped");
                             }
@@ -266,7 +266,7 @@ impl NodeActor {
                             return;
                         },
                         Some(Command::GetPplnsShares(query, tx)) => {
-                            info!(
+                            debug!(
                                 "Received GetPplnsShares command with limit: {}",
                                 query.limit
                             );
@@ -276,7 +276,7 @@ impl NodeActor {
                             }
                         },
                         None => {
-                            info!("Stopping node actor on channel close");
+                            debug!("Stopping node actor on channel close");
                             if self.stopping_tx.send(()).is_err() {
                                 error!("Failed to send stopping signal - receiver dropped");
                             }
@@ -294,7 +294,7 @@ impl NodeActor {
                             return;
                         }
                         Ok(Ok(())) => {
-                            info!("Organise worker stopped cleanly");
+                            debug!("Organise worker stopped cleanly");
                         }
                         Err(e) => {
                             error!("Organise worker panicked: {e}");

--- a/p2poolv2_lib/src/node/emission_worker.rs
+++ b/p2poolv2_lib/src/node/emission_worker.rs
@@ -32,7 +32,7 @@ use crate::shares::handle_stratum_share::handle_stratum_share;
 use crate::stratum::emission::EmissionReceiver;
 use libp2p::request_response::ResponseChannel;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 /// Worker that processes emissions from the stratum server.
 ///
@@ -66,7 +66,7 @@ impl EmissionWorker {
 
     /// Runs the emission worker until the emissions channel is closed.
     pub async fn run(mut self) {
-        info!("Emission worker started");
+        debug!("Emission worker started");
         while let Some(emission) = self.emissions_rx.recv().await {
             debug!("Processing emission");
             // Pass a references to chain store handle to avoid clones on each loop
@@ -102,6 +102,6 @@ impl EmissionWorker {
                 }
             }
         }
-        info!("Emission worker stopped - channel closed");
+        debug!("Emission worker stopped - channel closed");
     }
 }

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -137,7 +137,7 @@ impl Node {
             match config.network.listen_address.parse() {
                 Ok(addr) => match swarm.listen_on(addr) {
                     Ok(_) => {
-                        info!("Node listening on {}", config.network.listen_address);
+                        debug!("Node listening on {}", config.network.listen_address);
                     }
                     Err(e) => {
                         error!(
@@ -170,7 +170,7 @@ impl Node {
                         if let Err(e) = swarm.dial(remote) {
                             debug!("Failed to dial {}: {}", peer_addr, e);
                         } else {
-                            info!("Dialed {}", peer_addr);
+                            debug!("Dialed {}", peer_addr);
                         }
                     }
                     Err(e) => debug!("Invalid multiaddr {}: {}", peer_addr, e),
@@ -226,7 +226,7 @@ impl Node {
         peer_id: &libp2p::PeerId,
         message: Message,
     ) -> Result<(), Box<dyn Error>> {
-        info!("Sending message to peer: {peer_id}, message: {message:?}");
+        debug!("Sending message to peer: {peer_id}, message: {message:?}");
         self.swarm
             .behaviour_mut()
             .request_response
@@ -253,7 +253,7 @@ impl Node {
     ) -> Result<(), Box<dyn Error>> {
         match event {
             SwarmEvent::NewListenAddr { address, .. } => {
-                info!("Listening on {address:?}");
+                debug!("Listening on {address:?}");
                 Ok(())
             }
             SwarmEvent::ConnectionEstablished {
@@ -323,7 +323,7 @@ impl Node {
     fn handle_identify_event(&mut self, event: identify::Event) {
         match event {
             identify::Event::Received { peer_id, info } => {
-                info!(
+                debug!(
                     "Identified Peer {} with protocol version {}",
                     peer_id, info.protocol_version
                 );
@@ -335,12 +335,12 @@ impl Node {
                         .add_address(&peer_id, addr.clone());
                 }
                 // Also add our observed address to Kademlia so other peers can reach us
-                info!("Peer {} observed us as {}", peer_id, info.observed_addr);
+                debug!("Peer {} observed us as {}", peer_id, info.observed_addr);
                 self.swarm.add_external_address(info.observed_addr);
                 if let Err(e) = self.swarm.behaviour_mut().kademlia.bootstrap() {
                     warn!("Failed to bootstrap Kademlia: {}", e);
                 } else {
-                    info!("Successfully started Kademlia bootstrap");
+                    debug!("Successfully started Kademlia bootstrap");
                 }
             }
             _ => {
@@ -359,7 +359,7 @@ impl Node {
                 bucket_range,
                 old_peer,
             } => {
-                info!(
+                debug!(
                     "Routing updated for peer: {peer}, is_new_peer: {is_new_peer}, addresses: {addresses:?}, bucket_range: {bucket_range:?}, old_peer: {old_peer:?}"
                 );
             }
@@ -378,7 +378,7 @@ impl Node {
 
     /// Handle connection established events, these are events that are generated when a connection is established
     async fn handle_connection_established(&mut self, peer_id: libp2p::PeerId) {
-        info!("Connection established with peer: {peer_id}");
+        debug!("Connection established with peer: {peer_id}");
         let _ = send_blocks_inventory::<ResponseChannel<Message>>(
             peer_id,
             self.chain_store_handle.clone(),

--- a/p2poolv2_lib/src/node/organise_worker.rs
+++ b/p2poolv2_lib/src/node/organise_worker.rs
@@ -30,7 +30,7 @@ use crate::shares::share_block::{ShareBlock, ShareHeader};
 use crate::store::writer::StoreError;
 use std::fmt;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 /// Channel capacity for shares pending organisation.
 const ORGANISE_CHANNEL_CAPACITY: usize = 256;
@@ -94,7 +94,7 @@ impl OrganiseWorker {
     /// Returns `Ok(())` on clean shutdown (channel closed).
     /// Returns `Err(OrganiseError)` on fatal failure (store writer dead).
     pub async fn run(mut self) -> Result<(), OrganiseError> {
-        info!("Organise worker started");
+        debug!("Organise worker started");
         while let Some(event) = self.organise_rx.recv().await {
             match event {
                 OrganiseEvent::Header(header) => {
@@ -131,7 +131,7 @@ impl OrganiseWorker {
                 }
             }
         }
-        info!("Organise worker stopped - channel closed");
+        debug!("Organise worker stopped - channel closed");
         Ok(())
     }
 }

--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -32,7 +32,7 @@ use receivers::share_blocks::handle_share_block;
 use receivers::share_headers::handle_share_headers;
 use std::error::Error;
 use tokio::sync::mpsc;
-use tracing::{error, info};
+use tracing::{debug, error};
 
 const MAX_HEADERS_IN_RESPONSE: usize = 2000;
 
@@ -40,7 +40,7 @@ const MAX_HEADERS_IN_RESPONSE: usize = 2000;
 pub async fn handle_request<C: Send + Sync, T: TimeProvider + Send + Sync>(
     ctx: RequestContext<C, T>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    info!("Handling request {} from peer: {}", ctx.request, ctx.peer);
+    debug!("Handling request {} from peer: {}", ctx.request, ctx.peer);
     match ctx.request {
         Message::GetShareHeaders(block_hashes, stop_block_hash) => {
             handle_getheaders(
@@ -63,13 +63,13 @@ pub async fn handle_request<C: Send + Sync, T: TimeProvider + Send + Sync>(
             .await
         }
         Message::Inventory(inventory) => {
-            info!("Received inventory: {:?}", inventory);
+            debug!("Received inventory: {:?}", inventory);
             match inventory {
                 InventoryMessage::BlockHashes(have_blocks) => {
-                    info!("Received share block inventory: {:?}", have_blocks);
+                    debug!("Received share block inventory: {:?}", have_blocks);
                 }
                 InventoryMessage::TransactionHashes(have_transactions) => {
-                    info!(
+                    debug!(
                         "Received share transaction inventory: {:?}",
                         have_transactions
                     );
@@ -78,27 +78,27 @@ pub async fn handle_request<C: Send + Sync, T: TimeProvider + Send + Sync>(
             Ok(())
         }
         Message::NotFound(_) => {
-            info!("Received not found message");
+            debug!("Received not found message");
             Ok(())
         }
         Message::GetData(get_data) => {
-            info!("Received get data: {:?}", get_data);
+            debug!("Received get data: {:?}", get_data);
             match get_data {
                 GetData::Block(block_hash) => {
-                    info!("Received block hash: {:?}", block_hash);
+                    debug!("Received block hash: {:?}", block_hash);
                 }
                 GetData::Txid(txid) => {
-                    info!("Received txid: {:?}", txid);
+                    debug!("Received txid: {:?}", txid);
                 }
             }
             Ok(())
         }
         Message::Transaction(transaction) => {
-            info!("Received transaction: {:?}", transaction);
+            debug!("Received transaction: {:?}", transaction);
             Ok(())
         }
         other => {
-            info!("Unexpected request type {other}");
+            debug!("Unexpected request type {other}");
             Ok(())
         }
     }
@@ -121,7 +121,7 @@ pub async fn handle_response<C: Send + Sync, T: TimeProvider + Send + Sync>(
     time_provider: &T,
     swarm_tx: mpsc::Sender<SwarmSend<C>>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    info!("Handling response {} from peer: {}", response, peer);
+    debug!("Handling response {} from peer: {}", response, peer);
     match response {
         Message::ShareHeaders(share_headers) => {
             handle_share_headers(peer, share_headers, chain_store_handle, swarm_tx)
@@ -140,15 +140,15 @@ pub async fn handle_response<C: Send + Sync, T: TimeProvider + Send + Sync>(
                 })
         }
         Message::Inventory(inventory) => {
-            info!("Received inventory response: {:?}", inventory);
+            debug!("Received inventory response: {:?}", inventory);
             Ok(())
         }
         Message::NotFound(_) => {
-            info!("Received not found response from peer: {}", peer);
+            debug!("Received not found response from peer: {}", peer);
             Ok(())
         }
         other => {
-            info!("Unexpected response type from peer {}: {}", peer, other);
+            debug!("Unexpected response type from peer {}: {}", peer, other);
             Ok(())
         }
     }

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -26,7 +26,7 @@ use crate::shares::validation::validate_share_header;
 use bitcoin::{BlockHash, hashes::Hash};
 use std::error::Error;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info};
+use tracing::{debug, error, warn};
 
 /// Handle ShareHeaders received from a peer.
 ///
@@ -51,7 +51,7 @@ pub async fn handle_share_headers<C: Send + Sync>(
         .all(|header| validate_share_header(header, &chain_store_handle).is_ok());
     if !all_valid {
         // TODO - Request headers from another peer
-        info!("Peer sent invalid share headers. We should try a different peer");
+        warn!("Peer sent invalid share headers. We should try a different peer");
     }
 
     for header in &share_headers {

--- a/p2poolv2_lib/src/node/p2p_message_handlers/senders/inventory.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/senders/inventory.rs
@@ -24,7 +24,7 @@ use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use libp2p::PeerId;
 use std::error::Error;
 use tokio::sync::mpsc;
-use tracing::{debug, info};
+use tracing::debug;
 
 /// Send blocks inventory update to a peer. This is not a response, but is triggered
 /// by the node when it has new data to share.
@@ -33,7 +33,7 @@ pub async fn send_blocks_inventory<C: 'static + Send + Sync>(
     chain_store_handle: ChainStoreHandle,
     swarm_tx: mpsc::Sender<SwarmSend<C>>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    info!("Sending inventory update to peer: {:?}", peer_id);
+    debug!("Sending inventory update to peer: {:?}", peer_id);
     let locator = chain_store_handle
         .build_locator()
         .map_err(|e| format!("Failed to build locator {e}"))?;

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -27,7 +27,7 @@ use crate::store::writer::{StoreError, StoreHandle};
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, Work};
 use std::collections::{HashMap, HashSet};
-use tracing::{debug, info};
+use tracing::debug;
 
 /// The minimum number of shares that must be on the chain for a share to be considered confirmed
 const MIN_CONFIRMATION_DEPTH: usize = 100;
@@ -354,7 +354,7 @@ impl ChainStoreHandle {
     ) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError> {
         let blockhash = header.block_hash();
         let result = self.store_handle.organise_header(header).await?;
-        info!("Organised header {blockhash} into candidate chain: {result:?}");
+        debug!("Organised header {blockhash} into candidate chain: {result:?}");
         Ok(result)
     }
 
@@ -362,7 +362,7 @@ impl ChainStoreHandle {
     /// Returns the confirmed chain height after organising, if changed.
     pub async fn organise_block(&self) -> Result<Option<u32>, StoreError> {
         let height = self.store_handle.organise_block().await?;
-        info!("Organised block at confirmed height {height:?}");
+        debug!("Organised block at confirmed height {height:?}");
         Ok(height)
     }
 

--- a/p2poolv2_lib/src/store/background_tasks.rs
+++ b/p2poolv2_lib/src/store/background_tasks.rs
@@ -20,7 +20,7 @@ use crate::store::column_families::ColumnFamily;
 use crate::store::writer::StoreError;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 const MIN_TIMESTAMP: u64 = 0;
 
@@ -65,7 +65,7 @@ impl Store {
             .as_micros() as u64;
         let cutoff_micros = now.saturating_sub(pplns_ttl.as_micros() as u64);
 
-        info!(
+        debug!(
             "Cleaning up PPLNS shares older than {} seconds (cutoff: {})",
             pplns_ttl.as_secs(),
             cutoff_micros
@@ -82,7 +82,7 @@ impl Store {
         self.db
             .delete_range_cf(&pplns_share_cf, &start_key, &end_key)?;
 
-        info!("Deleted PPLNS shares older than cutoff time");
+        debug!("Deleted PPLNS shares older than cutoff time");
 
         Ok(())
     }
@@ -101,7 +101,7 @@ impl Store {
             .as_micros() as u64;
         let cutoff_micros = now.saturating_sub(job_ttl.as_micros() as u64);
 
-        info!(
+        debug!(
             "Cleaning up jobs older than {} seconds (cutoff: {})",
             job_ttl.as_secs(),
             cutoff_micros
@@ -116,7 +116,7 @@ impl Store {
         // delete_range_cf deletes all keys in [start_key, end_key)
         self.db.delete_range_cf(&job_cf, &start_key, &end_key)?;
 
-        info!("Deleted jobs older than cutoff time");
+        debug!("Deleted jobs older than cutoff time");
 
         Ok(())
     }

--- a/p2poolv2_lib/src/store/writer/mod.rs
+++ b/p2poolv2_lib/src/store/writer/mod.rs
@@ -36,7 +36,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::sync::mpsc;
 use tokio::sync::oneshot;
-use tracing::{debug, info};
+use tracing::debug;
 
 /// Error type for store operations
 #[derive(Debug, Clone)]
@@ -176,13 +176,13 @@ impl StoreWriter {
     ///
     /// This is a blocking function - spawn with `tokio::task::spawn_blocking`.
     pub fn run(self) {
-        info!("Store writer started on dedicated thread");
+        debug!("Store writer started on dedicated thread");
 
         while let Ok(cmd) = self.command_rx.recv() {
             self.handle_command(cmd);
         }
 
-        info!("Store writer stopped - channel closed");
+        debug!("Store writer stopped - channel closed");
     }
 
     /// Handle a single write command

--- a/p2poolv2_lib/src/stratum/difficulty_adjuster/mod.rs
+++ b/p2poolv2_lib/src/stratum/difficulty_adjuster/mod.rs
@@ -24,7 +24,7 @@ use crate::accounting::calc::{decay_time, sane_time_diff, time_bias};
 #[cfg(test)]
 use mockall::automock;
 use std::time::SystemTime;
-use tracing::{debug, info};
+use tracing::debug;
 
 /// The target Difficulty Rate Ratio (DRR) for standard clients
 /// This aims for about 1 share every 3.33 seconds
@@ -292,7 +292,7 @@ impl DifficultyAdjusterTrait for DifficultyAdjuster {
                 self.last_difficulty_change_timestamp = Some(current_timestamp); // Update last difficulty change time
                 self.last_diff_change_job_id = Some(job_id);
 
-                info!(
+                debug!(
                     "Difficulty changed from {} to {} based on DRR calculation",
                     self.old_difficulty, self.current_difficulty
                 );

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -109,6 +109,7 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
     }
 
     if validation_result.meets_bitcoin_difficulty {
+        info!("Bitcoin block found! Hash: {}", validation_result.header.block_hash());
         // Submit block asap - decode transactions only for this rare case
         let block = build_full_block(
             validation_result.header,
@@ -156,11 +157,13 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
         || truediff >= session.difficulty_adjuster.get_current_difficulty() as u128;
 
     if meets_session_difficulty {
+        info!("P2Pool share found! Hash: {}", validation_result.header.block_hash());
         let _ = stratum_context
             .metrics
             .record_share_accepted(stratum_share, truediff as u64)
             .await;
     } else {
+        info!("P2Pool share rejected (below difficulty)! Hash: {}", validation_result.header.block_hash());
         let _ = stratum_context.metrics.record_share_rejected().await;
     }
 

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -188,7 +188,7 @@ impl StratumServer {
         bitcoinrpc_config: BitcoinRpcConfig,
         metrics: metrics::MetricsHandle,
     ) -> Result<(), Box<dyn std::error::Error + Send>> {
-        info!("Starting Stratum server at {}:{}", self.hostname, self.port);
+        debug!("Starting Stratum server at {}:{}", self.hostname, self.port);
 
         let bind_address = format!("{}:{}", self.hostname, self.port);
         let listener = match TcpListener::bind(&bind_address).await {
@@ -201,7 +201,7 @@ impl StratumServer {
 
         if let Some(ready_tx) = ready_tx {
             // Notify that the server is ready to accept connections
-            info!(
+            debug!(
                 "Stratum server is ready to accept connections on {}",
                 bind_address
             );
@@ -211,7 +211,7 @@ impl StratumServer {
             tokio::select! {
                 // Check for shutdown signal
                 _ = &mut self.shutdown_rx => {
-                    info!("Shutdown signal received");
+                    debug!("Shutdown signal received");
                     break;
                 }
                 connection = listener.accept() => {
@@ -265,7 +265,7 @@ impl StratumServer {
                             });
                         }
                         Err(e) => {
-                            info!("Connection failed: {}", e);
+                            debug!("Connection failed: {}", e);
                             continue;
                         }
                     }
@@ -333,7 +333,7 @@ where
         tokio::select! {
             // Check for shutdown signal
             _ = &mut shutdown_rx => {
-                info!("Shutdown signal received, closing connection from {}", addr);
+                debug!("Shutdown signal received, closing connection from {}", addr);
                 break;
             }
             // receive a message on the channel used by server to send_to_all
@@ -341,7 +341,7 @@ where
                 if session.username.is_none() {
                     continue; // Ignore messages until the user has authorized
                 }
-                info!("Tx {addr} {message:?}");
+                debug!("Tx {addr} {message:?}");
                 if let Err(e) = writer.write_all(format!("{message}\n").as_bytes()).await {
                     error!("Failed to write to {}: {}", addr, e);
                     break;
@@ -349,7 +349,7 @@ where
             }
             // Read a line from the stream
             line = framed.next() => {
-                info!("Rx {} {:?}", addr, line);
+                debug!("Rx {} {:?}", addr, line);
                 match line {
                     Some(Ok(line)) => {
                         if line.is_empty() {
@@ -429,7 +429,7 @@ where
                         }
                     };
 
-                    info!("Tx {addr} {response_json:?}");
+                    debug!("Tx {addr} {response_json:?}");
                     if let Err(e) = writer
                         .write_all(format!("{response_json}\n").as_bytes())
                         .await

--- a/p2poolv2_lib/src/stratum/work/difficulty/validate.rs
+++ b/p2poolv2_lib/src/stratum/work/difficulty/validate.rs
@@ -23,7 +23,7 @@ use bitcoin::consensus::Decodable;
 use bitcoin::hex::DisplayHex;
 use hex::FromHex;
 use std::str::FromStr;
-use tracing::{debug, info};
+use tracing::debug;
 
 /// Share validation result
 ///
@@ -157,7 +157,7 @@ pub fn validate_submission_difficulty(
 
     let meets_bitcoin_difficulty = match header.validate_pow(target) {
         Ok(_) => {
-            info!("Header meets current bitcoin target");
+            debug!("Header meets current bitcoin target");
             true
         }
         Err(e) => {

--- a/p2poolv2_lib/src/stratum/zmq_listener.rs
+++ b/p2poolv2_lib/src/stratum/zmq_listener.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
-use tracing::info;
+use tracing::error;
 
 const BLOCK_HASH_SIZE: usize = 32;
 
@@ -76,12 +76,12 @@ impl ZmqListenerTrait for ZmqListener {
                             continue; // Skip empty messages
                         }
                         if let Err(e) = rt.block_on(tx.send(())) {
-                            info!("Failed to send ZMQ message: {}", e);
+                            error!("Failed to send ZMQ message: {}", e);
                             break; // Exit if the channel is closed
                         }
                     }
                     Err(e) => {
-                        info!("Failed to receive ZMQ message: {}", e);
+                        error!("Failed to receive ZMQ message: {}", e);
                     }
                 }
             }

--- a/p2poolv2_node/src/signal.rs
+++ b/p2poolv2_node/src/signal.rs
@@ -18,7 +18,7 @@
 use tokio::signal::unix::{self, SignalKind};
 
 use tokio::{sync::watch, task::JoinHandle};
-use tracing::info;
+use tracing::debug;
 
 /// Reason for shutdown - used to determine exit code
 /// Correct exit code will help service runners
@@ -50,7 +50,7 @@ pub fn setup_signal_handler(exit_sender: watch::Sender<ShutdownReason>) -> JoinH
         };
 
         if let Some(sig) = sig {
-            info!("Received signal {sig:?}. Stopping...");
+            debug!("Received signal {sig:?}. Stopping...");
             let _ = exit_sender.send(ShutdownReason::Signal);
         };
     })
@@ -63,7 +63,7 @@ pub fn setup_signal_handler(exit_sender: watch::Sender<ShutdownReason>) -> JoinH
         tokio::select! {
             _ = exit_receiver.changed() => {},
             _ = tokio::signal::ctrl_c() => {
-                info!("Received ctrl-c signal. Stopping...");
+                debug!("Received ctrl-c signal. Stopping...");
                 let _ = exit_sender.send(ShutdownReason::Signal);
             },
         };


### PR DESCRIPTION
Fixes #341 

Demoted all noisy startup and routine operational logs to debug! to ensure the standard output stays completely quiet during a normal run. Promoted core events back to info! (like blocks found/submitted and peer connections/disconnections)