### PR TITLE
Validate transactions prevout spends

### DIFF
--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
@@ -295,7 +295,7 @@ impl BlockReceiver {
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
         if let Err(error) = self
             .chain_store_handle
-            .add_share_block_and_organise_header(share_block, true)
+            .add_share_block_and_organise_header(share_block)
             .await
         {
             error!("Failed to store and organise block {block_hash}: {error}");
@@ -789,7 +789,7 @@ mod tests {
             .returning(move |_| Ok(parent_header_clone.clone()));
         mock_store
             .expect_add_share_block_and_organise_header()
-            .returning(|_, _| Ok(None));
+            .returning(|_| Ok(None));
 
         let mut mock_validator = MockDefaultShareValidator::default();
         let mut pool_difficulty = PoolDifficulty::default();
@@ -956,9 +956,9 @@ mod tests {
             .returning(move |_| Ok(parent_header_clone.clone()));
         mock_store
             .expect_add_share_block_and_organise_header()
-            .with(mockall::predicate::always(), mockall::predicate::eq(true))
+            .with(mockall::predicate::always())
             .times(1)
-            .returning(|_, _| Ok(None));
+            .returning(|_| Ok(None));
 
         let mut mock_validator = MockDefaultShareValidator::default();
         let mut pool_difficulty = PoolDifficulty::default();
@@ -1136,7 +1136,7 @@ mod tests {
             .returning(move |_| Ok(root_header_clone.clone()));
         mock_store
             .expect_add_share_block_and_organise_header()
-            .returning(|_, _| Ok(None));
+            .returning(|_| Ok(None));
 
         let mut mock_validator = MockDefaultShareValidator::default();
         let mut pool_difficulty = PoolDifficulty::default();

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -615,7 +615,7 @@ mod tests {
             let mut cloned = ChainStoreHandle::default();
             cloned.expect_share_block_exists().returning(|_| false);
             cloned.expect_is_candidate().returning(|_| false);
-            cloned.expect_add_share_block().returning(|_, _| Ok(()));
+            cloned.expect_add_share_block().returning(|_| Ok(()));
             cloned
         });
 

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -76,7 +76,7 @@ impl ChainStoreHandle {
 
         if genesis_in_store.is_none() {
             // Set up new chain with genesis
-            self.add_share_block(genesis_block, true).await?;
+            self.add_share_block(genesis_block).await?;
         } else {
             // Initialize chain state from existing store data
             self.store_handle
@@ -540,11 +540,7 @@ impl ChainStoreHandle {
     /// Add a share to the chain.
     ///
     /// Calculates height and chain work and stores the share. Reorgs are handled by OrganiseWorker
-    pub async fn add_share_block(
-        &self,
-        share: ShareBlock,
-        confirm_txs: bool,
-    ) -> Result<(), StoreError> {
+    pub async fn add_share_block(&self, share: ShareBlock) -> Result<(), StoreError> {
         debug!("Adding share to chain: {:?}", share.block_hash());
 
         let share_work = share.header.get_work();
@@ -557,7 +553,7 @@ impl ChainStoreHandle {
         }
 
         // Store the share
-        self.store_handle.add_share_block(share, confirm_txs).await
+        self.store_handle.add_share_block(share).await
     }
 
     /// Atomically persist a share block and organise its header into
@@ -568,12 +564,11 @@ impl ChainStoreHandle {
     pub async fn add_share_block_and_organise_header(
         &self,
         share: ShareBlock,
-        confirm_txs: bool,
     ) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError> {
         let blockhash = share.block_hash();
         debug!("Adding share and organising header atomically: {blockhash:?}");
         self.store_handle
-            .add_share_block_and_organise_header(share, confirm_txs)
+            .add_share_block_and_organise_header(share)
             .await
     }
 
@@ -714,8 +709,8 @@ mockall::mock! {
         pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>;
         pub async fn organise_block(&self) -> Result<Option<u32>, StoreError>;
         pub async fn promote_block(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;
-        pub async fn add_share_block(&self, share: ShareBlock, confirm_txs: bool) -> Result<(), StoreError>;
-        pub async fn add_share_block_and_organise_header(&self, share: ShareBlock, confirm_txs: bool) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>;
+        pub async fn add_share_block(&self, share: ShareBlock) -> Result<(), StoreError>;
+        pub async fn add_share_block_and_organise_header(&self, share: ShareBlock) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>;
         pub async fn add_pplns_share(&self, pplns_share: SimplePplnsShare) -> Result<(), StoreError>;
         pub async fn add_user(&self, btcaddress: String) -> Result<u64, StoreError>;
     }
@@ -771,7 +766,7 @@ mod tests {
             .build();
 
         chain_handle
-            .add_share_block(share1.clone(), true)
+            .add_share_block(share1.clone())
             .await
             .unwrap();
 
@@ -829,7 +824,7 @@ mod tests {
                 .work(2)
                 .build();
             chain_handle
-                .add_share_block(share.clone(), true)
+                .add_share_block(share.clone())
                 .await
                 .unwrap();
             chain_handle
@@ -899,7 +894,7 @@ mod tests {
                 .work(2)
                 .build();
             chain_handle
-                .add_share_block(share.clone(), true)
+                .add_share_block(share.clone())
                 .await
                 .unwrap();
             chain_handle
@@ -942,7 +937,7 @@ mod tests {
             .build();
 
         chain_handle
-            .add_share_block(share1.clone(), true)
+            .add_share_block(share1.clone())
             .await
             .unwrap();
 
@@ -952,7 +947,7 @@ mod tests {
             .work(1)
             .build();
 
-        chain_handle.add_share_block(share2, true).await.unwrap();
+        chain_handle.add_share_block(share2).await.unwrap();
     }
 
     #[tokio::test]
@@ -974,7 +969,7 @@ mod tests {
                 .work(2)
                 .build();
             chain_handle
-                .add_share_block(share.clone(), true)
+                .add_share_block(share.clone())
                 .await
                 .unwrap();
             chain_handle

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -108,6 +108,27 @@ impl ChainStoreHandle {
         self.store_handle.get_all_prevouts(transaction)
     }
 
+    /// Batch check the Outputs CF: true if any outpoint is missing.
+    pub fn is_missing_any_prevout(
+        &self,
+        outpoints: &[bitcoin::OutPoint],
+    ) -> Result<bool, StoreError> {
+        self.store_handle.is_missing_any_prevout(outpoints)
+    }
+
+    /// Batch check the SpendsIndex CF: true if any outpoint is already spent.
+    pub fn is_any_prevout_spent(
+        &self,
+        outpoints: &[bitcoin::OutPoint],
+    ) -> Result<bool, StoreError> {
+        self.store_handle.is_any_prevout_spent(outpoints)
+    }
+
+    /// Returns true if every txid is on the confirmed sharechain.
+    pub fn are_all_txids_confirmed(&self, txids: &[bitcoin::Txid]) -> Result<bool, StoreError> {
+        self.store_handle.are_all_txids_confirmed(txids)
+    }
+
     /// Retrieve a single transaction output by txid and output index.
     pub fn get_output(
         &self,
@@ -673,6 +694,9 @@ mockall::mock! {
         pub fn get_blockhashes_for_height(&self, height: u32) -> Vec<BlockHash>;
         pub fn network(&self) -> bitcoin::Network;
         pub fn get_all_prevouts(&self, transaction: &bitcoin::Transaction) -> Result<Vec<(usize, bitcoin::TxOut)>, StoreError>;
+        pub fn is_missing_any_prevout(&self, outpoints: &[bitcoin::OutPoint]) -> Result<bool, StoreError>;
+        pub fn is_any_prevout_spent(&self, outpoints: &[bitcoin::OutPoint]) -> Result<bool, StoreError>;
+        pub fn are_all_txids_confirmed(&self, txids: &[bitcoin::Txid]) -> Result<bool, StoreError>;
         pub fn get_output(&self, txid: &bitcoin::Txid, vout: u32) -> Result<bitcoin::TxOut, StoreError>;
         pub fn share_block_exists(&self, blockhash: &BlockHash) -> bool;
         pub fn first_existing_share_header(&self, blockhashes: &[BlockHash]) -> Option<BlockHash>;
@@ -765,10 +789,7 @@ mod tests {
             .work(2)
             .build();
 
-        chain_handle
-            .add_share_block(share1.clone())
-            .await
-            .unwrap();
+        chain_handle.add_share_block(share1.clone()).await.unwrap();
 
         // Verify share is stored
         let stored_share = chain_handle.get_share(&share1.block_hash());
@@ -823,10 +844,7 @@ mod tests {
                 .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
                 .work(2)
                 .build();
-            chain_handle
-                .add_share_block(share.clone())
-                .await
-                .unwrap();
+            chain_handle.add_share_block(share.clone()).await.unwrap();
             chain_handle
                 .organise_header(share.header.clone())
                 .await
@@ -893,10 +911,7 @@ mod tests {
                 .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
                 .work(2)
                 .build();
-            chain_handle
-                .add_share_block(share.clone())
-                .await
-                .unwrap();
+            chain_handle.add_share_block(share.clone()).await.unwrap();
             chain_handle
                 .organise_header(share.header.clone())
                 .await
@@ -936,10 +951,7 @@ mod tests {
             .work(1)
             .build();
 
-        chain_handle
-            .add_share_block(share1.clone())
-            .await
-            .unwrap();
+        chain_handle.add_share_block(share1.clone()).await.unwrap();
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
@@ -968,10 +980,7 @@ mod tests {
                 .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
                 .work(2)
                 .build();
-            chain_handle
-                .add_share_block(share.clone())
-                .await
-                .unwrap();
+            chain_handle.add_share_block(share.clone()).await.unwrap();
             chain_handle
                 .organise_header(share.header.clone())
                 .await

--- a/p2poolv2_lib/src/shares/handle_stratum_share.rs
+++ b/p2poolv2_lib/src/shares/handle_stratum_share.rs
@@ -99,7 +99,7 @@ pub async fn handle_stratum_share(
         // Store share block via ChainStoreHandle. This is later
         // organised in emission worker once this function returns.
         chain_store_handle
-            .add_share_block(share_block.clone(), true)
+            .add_share_block(share_block.clone())
             .await
             .map_err(|e| format!("Failed to add share to chain: {e}"))?;
 
@@ -267,7 +267,7 @@ mod tests {
         // Mock add_share to succeed
         mock_chain_store
             .expect_add_share_block()
-            .returning(|_, _| Ok(()));
+            .returning(|_| Ok(()));
 
         let emission = create_test_emission_with_commitment();
 
@@ -309,7 +309,7 @@ mod tests {
         // Mock add_share to succeed
         mock_chain_store
             .expect_add_share_block()
-            .returning(|_, _| Ok(()));
+            .returning(|_| Ok(()));
 
         let emission = create_test_emission_with_commitment();
         let expected_commitment = emission.share_commitment.clone().unwrap();
@@ -347,7 +347,7 @@ mod tests {
         // Mock add_share to succeed
         mock_chain_store
             .expect_add_share_block()
-            .returning(|_, _| Ok(()));
+            .returning(|_| Ok(()));
 
         // Create emission with some bitcoin transactions
         let pplns = SimplePplnsShare {

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -780,18 +780,23 @@ impl ShareValidator for DefaultShareValidator {
 
 impl DefaultShareValidator {
     /// Validate that every input of every non-coinbase transaction in the
-    /// share block references an output that:
+    /// share block spends an output that:
     ///
-    /// 1. Belongs to a transaction on the confirmed sharechain (uncle /
-    ///    unconfirmed inclusions are ignored).
-    /// 2. Exists in the Outputs store.
+    /// 1. Exists in the `Outputs` column family.
+    /// 2. Belongs to a transaction on the confirmed sharechain *or* to
+    ///    an earlier transaction in this same share block. (Inputs that
+    ///    reference uncle / unconfirmed external inclusions are
+    ///    rejected.)
     /// 3. Has not already been spent by another transaction on the
     ///    confirmed sharechain.
+    /// 4. Is not spent by more than one input in this share block.
     ///
-    /// Inputs that reference an output produced by an earlier transaction
-    /// in the same share block are accepted without checking the store,
-    /// since the producing transaction is being introduced atomically with
-    /// the spender.
+    /// In-block prevouts (inputs whose source txid is an earlier
+    /// transaction in the same block) are exempt from the
+    /// confirmed-chain check. The producing tx is being introduced
+    /// atomically with its spender, but they are *still* checked for
+    /// existence against the `Outputs` CF, so a spender that references
+    /// a non-existent vout of an in-block producer is rejected.
     fn validate_prevouts(
         &self,
         share: &ShareBlock,
@@ -804,28 +809,34 @@ impl DefaultShareValidator {
             .map(|share_transaction| share_transaction.0.input.len())
             .sum();
         let mut all_outpoints: Vec<bitcoin::OutPoint> = Vec::with_capacity(total_inputs);
-        let mut block_txids_deduper: HashSet<bitcoin::Txid> =
+        let mut external_source_txids: HashSet<bitcoin::Txid> =
+            HashSet::with_capacity(total_inputs);
+        let mut seen_prevouts: HashSet<bitcoin::OutPoint> = HashSet::with_capacity(total_inputs);
+        let mut in_block_txids: HashSet<bitcoin::Txid> =
             HashSet::with_capacity(share.transactions.len());
         for share_transaction in &share.transactions {
             let transaction = &share_transaction.0;
             if !transaction.is_coinbase() {
                 for input in &transaction.input {
-                    if !block_txids_deduper.contains(&input.previous_output.txid) {
-                        all_outpoints.push(input.previous_output);
+                    let outpoint = input.previous_output;
+                    if !seen_prevouts.insert(outpoint) {
+                        return Err(ValidationError::new(format!(
+                            "Duplicate prevout {}:{} spent by two inputs in the same share block",
+                            outpoint.txid, outpoint.vout
+                        )));
+                    }
+                    all_outpoints.push(outpoint);
+                    if !in_block_txids.contains(&outpoint.txid) {
+                        external_source_txids.insert(outpoint.txid);
                     }
                 }
             }
-            block_txids_deduper.insert(transaction.compute_txid());
+            in_block_txids.insert(transaction.compute_txid());
         }
 
-        let source_txids: Vec<bitcoin::Txid> = all_outpoints
-            .iter()
-            .map(|outpoint| outpoint.txid)
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect();
+        let external_source_txids: Vec<bitcoin::Txid> = external_source_txids.into_iter().collect();
         if !chain_store_handle
-            .are_all_txids_confirmed(&source_txids)
+            .are_all_txids_confirmed(&external_source_txids)
             .map_err(|error| {
                 ValidationError::new(format!("Failed to query confirmed status: {error}"))
             })?
@@ -2082,23 +2093,31 @@ mod tests {
             }],
         };
 
-        // Only the producing tx's prevout (Txid::all_zeros) should reach the
-        // store; the in-block spend referencing producing_txid is skipped.
+        // The confirmation check sees only the producing tx's external
+        // prevout (Txid::all_zeros) — the in-block source txid is
+        // exempt. The existence and spent checks see *both* outpoints
+        // because in-block prevouts must still be checked against the
+        // Outputs CF (and harmlessly probed in SpendsIndex).
+        let producing_txid_for_check = producing_txid;
         chain_store_handle
             .expect_are_all_txids_confirmed()
             .withf(|txids| txids.len() == 1 && txids[0] == bitcoin::Txid::all_zeros())
             .returning(|_txids| Ok(true));
         chain_store_handle
             .expect_is_missing_any_prevout()
-            .withf(|outpoints| {
-                outpoints.len() == 1 && outpoints[0].txid == bitcoin::Txid::all_zeros()
+            .withf(move |outpoints| {
+                outpoints.len() == 2
+                    && outpoints
+                        .iter()
+                        .any(|outpoint| outpoint.txid == bitcoin::Txid::all_zeros())
+                    && outpoints
+                        .iter()
+                        .any(|outpoint| outpoint.txid == producing_txid_for_check)
             })
             .returning(|_outpoints| Ok(false));
         chain_store_handle
             .expect_is_any_prevout_spent()
-            .withf(|outpoints| {
-                outpoints.len() == 1 && outpoints[0].txid == bitcoin::Txid::all_zeros()
-            })
+            .withf(move |outpoints| outpoints.len() == 2)
             .returning(|_outpoints| Ok(false));
 
         let share = TestShareBlockBuilder::new()
@@ -2109,6 +2128,126 @@ mod tests {
 
         let result = validator().validate_prevouts(&share, &chain_store_handle);
         assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
+    }
+
+    #[test]
+    fn test_validate_prevouts_fails_when_in_block_spend_references_missing_vout() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+
+        let producing_tx = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::ONE,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: bitcoin::Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::new(),
+            }],
+            // producer has only one output (vout 0).
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+        let producing_txid = producing_tx.compute_txid();
+
+        // spender references vout 5 — does not exist.
+        let in_block_spender = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::ONE,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: producing_txid,
+                    vout: 5,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(49_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+
+        // Confirmation check passes for the external prevout.
+        chain_store_handle
+            .expect_are_all_txids_confirmed()
+            .returning(|_txids| Ok(true));
+        // Existence check returns true (something missing) because the
+        // in-block spender references a non-existent vout.
+        chain_store_handle
+            .expect_is_missing_any_prevout()
+            .returning(|_outpoints| Ok(true));
+
+        let share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .add_transaction(producing_tx)
+            .add_transaction(in_block_spender)
+            .build();
+
+        let error = validator()
+            .validate_prevouts(&share, &chain_store_handle)
+            .unwrap_err();
+        assert!(error.to_string().contains("do not exist"), "got: {error}");
+    }
+
+    #[test]
+    fn test_validate_prevouts_fails_when_two_inputs_spend_same_prevout() {
+        let chain_store_handle = ChainStoreHandle::default();
+
+        let shared_prevout = bitcoin::OutPoint {
+            txid: bitcoin::Txid::all_zeros(),
+            vout: 0,
+        };
+
+        let spender_a = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::ONE,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: shared_prevout,
+                script_sig: ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(10_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+        let spender_b = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::ONE,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: shared_prevout,
+                script_sig: ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(20_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+
+        // No store mocks set: the duplicate-prevout check rejects the
+        // share before any chain_store_handle method is called.
+        let share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .add_transaction(spender_a)
+            .add_transaction(spender_b)
+            .build();
+
+        let error = validator()
+            .validate_prevouts(&share, &chain_store_handle)
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("Duplicate prevout"),
+            "got: {error}"
+        );
     }
 
     #[test]

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -773,7 +773,84 @@ impl ShareValidator for DefaultShareValidator {
         share: &ShareBlock,
         chain_store_handle: &ChainStoreHandle,
     ) -> Result<(), ValidationError> {
-        self.validate_timestamp(share, chain_store_handle, self.time_provider.as_ref())
+        self.validate_timestamp(share, chain_store_handle, self.time_provider.as_ref())?;
+        self.validate_prevouts(share, chain_store_handle)
+    }
+}
+
+impl DefaultShareValidator {
+    /// Validate that every input of every non-coinbase transaction in the
+    /// share block references an output that:
+    ///
+    /// 1. Belongs to a transaction on the confirmed sharechain (uncle /
+    ///    unconfirmed inclusions are ignored).
+    /// 2. Exists in the Outputs store.
+    /// 3. Has not already been spent by another transaction on the
+    ///    confirmed sharechain.
+    ///
+    /// Inputs that reference an output produced by an earlier transaction
+    /// in the same share block are accepted without checking the store,
+    /// since the producing transaction is being introduced atomically with
+    /// the spender.
+    fn validate_prevouts(
+        &self,
+        share: &ShareBlock,
+        chain_store_handle: &ChainStoreHandle,
+    ) -> Result<(), ValidationError> {
+        let total_inputs: usize = share
+            .transactions
+            .iter()
+            .filter(|share_transaction| !share_transaction.0.is_coinbase())
+            .map(|share_transaction| share_transaction.0.input.len())
+            .sum();
+        let mut all_outpoints: Vec<bitcoin::OutPoint> = Vec::with_capacity(total_inputs);
+        let mut block_txids_deduper: HashSet<bitcoin::Txid> =
+            HashSet::with_capacity(share.transactions.len());
+        for share_transaction in &share.transactions {
+            let transaction = &share_transaction.0;
+            if !transaction.is_coinbase() {
+                for input in &transaction.input {
+                    if !block_txids_deduper.contains(&input.previous_output.txid) {
+                        all_outpoints.push(input.previous_output);
+                    }
+                }
+            }
+            block_txids_deduper.insert(transaction.compute_txid());
+        }
+
+        let source_txids: Vec<bitcoin::Txid> = all_outpoints
+            .iter()
+            .map(|outpoint| outpoint.txid)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        if !chain_store_handle
+            .are_all_txids_confirmed(&source_txids)
+            .map_err(|error| {
+                ValidationError::new(format!("Failed to query confirmed status: {error}"))
+            })?
+        {
+            return Err(ValidationError::new("prevout not on confirmed chain"));
+        }
+        if chain_store_handle
+            .is_missing_any_prevout(&all_outpoints)
+            .map_err(|error| ValidationError::new(format!("Failed to query Outputs: {error}")))?
+        {
+            return Err(ValidationError::new(
+                "One or more prevouts do not exist in the Outputs store",
+            ));
+        }
+        if chain_store_handle
+            .is_any_prevout_spent(&all_outpoints)
+            .map_err(|error| {
+                ValidationError::new(format!("Failed to query SpendsIndex: {error}"))
+            })?
+        {
+            return Err(ValidationError::new(
+                "One or more prevouts are already spent",
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -1201,11 +1278,8 @@ mod tests {
             .returning(|_, _| true);
         chain_store_handle
             .expect_add_share_block()
-            .with(
-                mockall::predicate::eq(share_block.clone()),
-                mockall::predicate::eq(true),
-            )
-            .returning(|_, _| Ok(()));
+            .with(mockall::predicate::eq(share_block.clone()))
+            .returning(|_| Ok(()));
         chain_store_handle
             .expect_get_share()
             .with(eq(bitcoin::BlockHash::all_zeros()))
@@ -1850,6 +1924,191 @@ mod tests {
                 .contains("Failed to look up spent outputs"),
             "Expected UTXO lookup failure, got: {error}"
         );
+    }
+
+    #[test]
+    fn test_validate_prevouts_exist_succeeds_for_coinbase_only() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_are_all_txids_confirmed()
+            .returning(|_txids| Ok(true));
+        chain_store_handle
+            .expect_is_missing_any_prevout()
+            .returning(|_outpoints| Ok(false));
+        chain_store_handle
+            .expect_is_any_prevout_spent()
+            .returning(|_outpoints| Ok(false));
+        let share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .build();
+        let result = validator().validate_prevouts(&share, &chain_store_handle);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_prevouts_exist_succeeds_when_confirmed_present_and_unspent() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        let (_spent_output, spending_tx) = build_p2sh_op_true_spent_output_and_spending_tx();
+
+        chain_store_handle
+            .expect_are_all_txids_confirmed()
+            .returning(|_txids| Ok(true));
+        chain_store_handle
+            .expect_is_missing_any_prevout()
+            .returning(|_outpoints| Ok(false));
+        chain_store_handle
+            .expect_is_any_prevout_spent()
+            .returning(|_outpoints| Ok(false));
+
+        let share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .add_transaction(spending_tx)
+            .build();
+
+        let result = validator().validate_prevouts(&share, &chain_store_handle);
+        assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
+    }
+
+    #[test]
+    fn test_validate_prevouts_exist_fails_when_source_tx_not_confirmed() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        let (_spent_output, spending_tx) = build_p2sh_op_true_spent_output_and_spending_tx();
+
+        chain_store_handle
+            .expect_are_all_txids_confirmed()
+            .returning(|_txids| Ok(false));
+
+        let share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .add_transaction(spending_tx)
+            .build();
+
+        let error = validator()
+            .validate_prevouts(&share, &chain_store_handle)
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("prevout not on confirmed chain"),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn test_validate_prevouts_exist_fails_when_prevout_missing() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        let (_spent_output, spending_tx) = build_p2sh_op_true_spent_output_and_spending_tx();
+
+        chain_store_handle
+            .expect_are_all_txids_confirmed()
+            .returning(|_txids| Ok(true));
+        chain_store_handle
+            .expect_is_missing_any_prevout()
+            .returning(|_outpoints| Ok(true));
+
+        let share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .add_transaction(spending_tx)
+            .build();
+
+        let error = validator()
+            .validate_prevouts(&share, &chain_store_handle)
+            .unwrap_err();
+        assert!(error.to_string().contains("do not exist"), "got: {error}");
+    }
+
+    #[test]
+    fn test_validate_prevouts_exist_fails_when_prevout_already_spent() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        let (_spent_output, spending_tx) = build_p2sh_op_true_spent_output_and_spending_tx();
+
+        chain_store_handle
+            .expect_are_all_txids_confirmed()
+            .returning(|_txids| Ok(true));
+        chain_store_handle
+            .expect_is_missing_any_prevout()
+            .returning(|_outpoints| Ok(false));
+        chain_store_handle
+            .expect_is_any_prevout_spent()
+            .returning(|_outpoints| Ok(true));
+
+        let share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .add_transaction(spending_tx)
+            .build();
+
+        let error = validator()
+            .validate_prevouts(&share, &chain_store_handle)
+            .unwrap_err();
+        assert!(error.to_string().contains("already spent"), "got: {error}");
+    }
+
+    #[test]
+    fn test_validate_prevouts_exist_skips_in_block_source_tx() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+
+        let producing_tx = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::ONE,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: bitcoin::Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+        let producing_txid = producing_tx.compute_txid();
+
+        let in_block_spender = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::ONE,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: producing_txid,
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(49_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+
+        // Only the producing tx's prevout (Txid::all_zeros) should reach the
+        // store; the in-block spend referencing producing_txid is skipped.
+        chain_store_handle
+            .expect_are_all_txids_confirmed()
+            .withf(|txids| txids.len() == 1 && txids[0] == bitcoin::Txid::all_zeros())
+            .returning(|_txids| Ok(true));
+        chain_store_handle
+            .expect_is_missing_any_prevout()
+            .withf(|outpoints| {
+                outpoints.len() == 1 && outpoints[0].txid == bitcoin::Txid::all_zeros()
+            })
+            .returning(|_outpoints| Ok(false));
+        chain_store_handle
+            .expect_is_any_prevout_spent()
+            .withf(|outpoints| {
+                outpoints.len() == 1 && outpoints[0].txid == bitcoin::Txid::all_zeros()
+            })
+            .returning(|_outpoints| Ok(false));
+
+        let share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .add_transaction(producing_tx)
+            .add_transaction(in_block_spender)
+            .build();
+
+        let result = validator().validate_prevouts(&share, &chain_store_handle);
+        assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
     }
 
     #[test]

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -627,15 +627,11 @@ mod tests {
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();
-        store
-            .add_share_block(&uncle1_share2, &mut batch)
-            .unwrap();
+        store.add_share_block(&uncle1_share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();
-        store
-            .add_share_block(&uncle2_share2, &mut batch)
-            .unwrap();
+        store.add_share_block(&uncle2_share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();
@@ -727,15 +723,11 @@ mod tests {
         let mut batch = rocksdb::WriteBatch::default();
         // Add all shares to store
         store.add_share_block(&share1, &mut batch).unwrap();
-        store
-            .add_share_block(&uncle1_share2, &mut batch)
-            .unwrap();
+        store.add_share_block(&uncle1_share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();
-        store
-            .add_share_block(&uncle2_share2, &mut batch)
-            .unwrap();
+        store.add_share_block(&uncle2_share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -623,23 +623,23 @@ mod tests {
 
         let mut batch = rocksdb::WriteBatch::default();
         // Add all shares to store
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();
         store
-            .add_share_block(&uncle1_share2, true, &mut batch)
+            .add_share_block(&uncle1_share2, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();
         store
-            .add_share_block(&uncle2_share2, true, &mut batch)
+            .add_share_block(&uncle2_share2, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         // Uncle block index updates are handled by organise_header, not
         // add_share_block. Manually register uncle->nephew entries here
         // since this test exercises the block index directly.
@@ -651,7 +651,7 @@ mod tests {
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
 
         store.commit_batch(batch).unwrap();
 
@@ -726,24 +726,24 @@ mod tests {
 
         let mut batch = rocksdb::WriteBatch::default();
         // Add all shares to store
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store
-            .add_share_block(&uncle1_share2, true, &mut batch)
+            .add_share_block(&uncle1_share2, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();
         store
-            .add_share_block(&uncle2_share2, true, &mut batch)
+            .add_share_block(&uncle2_share2, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
 
         store.commit_batch(batch).unwrap();
 
@@ -814,7 +814,7 @@ mod tests {
         store.commit_batch(batch).unwrap();
 
         for block in &blocks[1..] {
-            store.push_to_confirmed_chain(block, true).unwrap();
+            store.push_to_confirmed_chain(block).unwrap();
         }
 
         let stop_block = store.get_blockhashes_for_height(2)[0];
@@ -854,7 +854,7 @@ mod tests {
         store.commit_batch(batch).unwrap();
 
         for block in &blocks[1..] {
-            store.push_to_confirmed_chain(block, true).unwrap();
+            store.push_to_confirmed_chain(block).unwrap();
         }
 
         let locator = vec![blocks[0].block_hash()];
@@ -905,7 +905,7 @@ mod tests {
         store.commit_batch(batch).unwrap();
 
         for block in &blocks[1..] {
-            store.push_to_confirmed_chain(block, true).unwrap();
+            store.push_to_confirmed_chain(block).unwrap();
         }
 
         let stop_block = store.get_blockhashes_for_height(2)[0];
@@ -953,14 +953,14 @@ mod tests {
             .work(2)
             .nonce(1)
             .build();
-        store.push_to_confirmed_chain(&share_a, true).unwrap();
+        store.push_to_confirmed_chain(&share_a).unwrap();
 
         let share_b = TestShareBlockBuilder::new()
             .prev_share_blockhash(share_a.block_hash().to_string())
             .uncles(vec![uncle1.block_hash()])
             .nonce(2)
             .build();
-        store.push_to_confirmed_chain(&share_b, true).unwrap();
+        store.push_to_confirmed_chain(&share_b).unwrap();
 
         // Descendants from genesis: should get share_a, uncle1, share_b
         let descendants = store
@@ -1017,7 +1017,7 @@ mod tests {
                 .build();
 
             let mut batch = Store::get_write_batch();
-            store.add_share_block(&share, true, &mut batch).unwrap();
+            store.add_share_block(&share, &mut batch).unwrap();
             store.commit_batch(batch).unwrap();
 
             blocks.push(share.block_hash());
@@ -1067,7 +1067,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share2 = TestShareBlockBuilder::new()
@@ -1075,7 +1075,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share3 = TestShareBlockBuilder::new()
@@ -1083,7 +1083,7 @@ mod tests {
             .nonce(0xe9695794)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Test common ancestor of share3 and share2
@@ -1132,7 +1132,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let uncle1 = TestShareBlockBuilder::new()
@@ -1140,7 +1140,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, false, &mut batch).unwrap();
+        store.add_share_block(&uncle1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share2 = TestShareBlockBuilder::new()
@@ -1148,7 +1148,7 @@ mod tests {
             .nonce(0xe9695794)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Test common ancestor of share2 and uncle1 (should be genesis)
@@ -1178,12 +1178,12 @@ mod tests {
         // Create two separate chains (only for testing - wouldn't happen in real usage)
         let genesis1 = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&genesis1, true, &mut batch).unwrap();
+        store.add_share_block(&genesis1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let genesis2 = TestShareBlockBuilder::new().nonce(0xe9695792).build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&genesis2, false, &mut batch).unwrap();
+        store.add_share_block(&genesis2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Test common ancestor of two different genesis blocks (should be None)
@@ -1226,7 +1226,7 @@ mod tests {
             .nonce(100)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, false, &mut batch).unwrap();
+        store.add_share_block(&uncle1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Create share2 - sibling of uncle1
@@ -1234,7 +1234,7 @@ mod tests {
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Create share3 with uncle1 as uncle (uncle1 is sibling of share3's parent)
@@ -1243,7 +1243,7 @@ mod tests {
             .uncles(vec![uncle1.block_hash()])
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Get DAG from share3 with depth 10 (more than enough to include all blocks)
@@ -1293,7 +1293,7 @@ mod tests {
             .nonce(100)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, false, &mut batch).unwrap();
+        store.add_share_block(&uncle1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let uncle2 = TestShareBlockBuilder::new()
@@ -1301,14 +1301,14 @@ mod tests {
             .nonce(200)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle2, false, &mut batch).unwrap();
+        store.add_share_block(&uncle2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share3 = TestShareBlockBuilder::new()
@@ -1316,7 +1316,7 @@ mod tests {
             .uncles(vec![uncle1.block_hash(), uncle2.block_hash()])
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let chain = store.get_dag_for_depth(&share3.block_hash(), 10).unwrap();
@@ -1367,14 +1367,14 @@ mod tests {
             .nonce(100)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, false, &mut batch).unwrap();
+        store.add_share_block(&uncle1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // uncle2 is sibling of share3
@@ -1383,7 +1383,7 @@ mod tests {
             .nonce(200)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle2, false, &mut batch).unwrap();
+        store.add_share_block(&uncle2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // share3 has uncle1 as uncle (sibling of its parent share2)
@@ -1392,7 +1392,7 @@ mod tests {
             .uncles(vec![uncle1.block_hash()])
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // share4 has uncle2 as uncle (sibling of its parent share3)
@@ -1401,7 +1401,7 @@ mod tests {
             .uncles(vec![uncle2.block_hash()])
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share4, true, &mut batch).unwrap();
+        store.add_share_block(&share4, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let chain = store.get_dag_for_depth(&share4.block_hash(), 10).unwrap();
@@ -1454,14 +1454,14 @@ mod tests {
             .nonce(100)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, false, &mut batch).unwrap();
+        store.add_share_block(&uncle1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share3 = TestShareBlockBuilder::new()
@@ -1469,7 +1469,7 @@ mod tests {
             .uncles(vec![uncle1.block_hash()])
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // With depth=2, we should get exactly 2 main chain blocks + uncles
@@ -1534,7 +1534,7 @@ mod tests {
             .nonce(100)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, false, &mut batch).unwrap();
+        store.add_share_block(&uncle1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let uncle2 = TestShareBlockBuilder::new()
@@ -1542,14 +1542,14 @@ mod tests {
             .nonce(200)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle2, false, &mut batch).unwrap();
+        store.add_share_block(&uncle2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share3 = TestShareBlockBuilder::new()
@@ -1557,14 +1557,14 @@ mod tests {
             .uncles(vec![uncle1.block_hash(), uncle2.block_hash()])
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share4 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share3.block_hash().to_string())
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share4, true, &mut batch).unwrap();
+        store.add_share_block(&share4, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // With depth=2, we should get share4, share3 (main chain) + uncle1, uncle2
@@ -1619,14 +1619,14 @@ mod tests {
             .nonce(100)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, false, &mut batch).unwrap();
+        store.add_share_block(&uncle1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let uncle2 = TestShareBlockBuilder::new()
@@ -1634,7 +1634,7 @@ mod tests {
             .nonce(200)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle2, false, &mut batch).unwrap();
+        store.add_share_block(&uncle2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share3 = TestShareBlockBuilder::new()
@@ -1642,7 +1642,7 @@ mod tests {
             .uncles(vec![uncle1.block_hash()])
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share4 = TestShareBlockBuilder::new()
@@ -1650,7 +1650,7 @@ mod tests {
             .uncles(vec![uncle2.block_hash()])
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share4, true, &mut batch).unwrap();
+        store.add_share_block(&share4, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // With depth=3, we should get share4, share3, share2 (main chain) + uncle2, uncle1
@@ -1694,28 +1694,28 @@ mod tests {
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share3 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share4 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share3.block_hash().to_string())
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share4, true, &mut batch).unwrap();
+        store.add_share_block(&share4, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share5 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share4.block_hash().to_string())
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share5, true, &mut batch).unwrap();
+        store.add_share_block(&share5, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // With depth=3, should get exactly 3 main chain blocks
@@ -1740,7 +1740,7 @@ mod tests {
 
         let share = TestShareBlockBuilder::new().build();
         let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&share, true, &mut batch).unwrap();
+        store.add_share_block(&share, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // A share that has not been used as an uncle should return false
@@ -1756,8 +1756,8 @@ mod tests {
         let nephew = TestShareBlockBuilder::new().nonce(200).build();
 
         let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&uncle, false, &mut batch).unwrap();
-        store.add_share_block(&nephew, true, &mut batch).unwrap();
+        store.add_share_block(&uncle, &mut batch).unwrap();
+        store.add_share_block(&nephew, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Before adding to uncles index
@@ -1781,7 +1781,7 @@ mod tests {
 
         let share = TestShareBlockBuilder::new().build();
         let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&share, true, &mut batch).unwrap();
+        store.add_share_block(&share, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // A share that has not been used as an uncle should return None
@@ -1798,9 +1798,9 @@ mod tests {
         let nephew2 = TestShareBlockBuilder::new().nonce(300).build();
 
         let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&uncle, false, &mut batch).unwrap();
-        store.add_share_block(&nephew1, true, &mut batch).unwrap();
-        store.add_share_block(&nephew2, true, &mut batch).unwrap();
+        store.add_share_block(&uncle, &mut batch).unwrap();
+        store.add_share_block(&nephew1, &mut batch).unwrap();
+        store.add_share_block(&nephew2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Add uncle to uncles index with two nephews
@@ -1830,7 +1830,7 @@ mod tests {
 
         let share = TestShareBlockBuilder::new().build();
         let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&share, true, &mut batch).unwrap();
+        store.add_share_block(&share, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // No confirmed blocks, should return error
@@ -1859,8 +1859,8 @@ mod tests {
             .build();
 
         // Confirm all using push_to_confirmed_chain
-        store.push_to_confirmed_chain(&share1, true).unwrap();
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         // No unconfirmed children exist, so find_uncles should return empty
         let uncles = store.find_uncles().unwrap();
@@ -1896,7 +1896,7 @@ mod tests {
         store.store_with_valid_metadata(&uncle1);
 
         // Confirm share1 using push_to_confirmed_chain
-        store.push_to_confirmed_chain(&share1, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
 
         // find_uncles should find uncle1
         let uncles = store.find_uncles().unwrap();
@@ -1956,13 +1956,13 @@ mod tests {
         // Store uncles with Valid metadata before confirming their parent levels.
         // Uncle parents must have metadata for cumulative chain_work to be correct.
         store.store_with_valid_metadata(&uncle0);
-        store.push_to_confirmed_chain(&share1, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
 
         store.store_with_valid_metadata(&uncle1);
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         store.store_with_valid_metadata(&uncle2);
-        store.push_to_confirmed_chain(&share3, true).unwrap();
+        store.push_to_confirmed_chain(&share3).unwrap();
 
         // find_uncles should find uncle0, uncle1, uncle2
         // Sorted by chain_work descending: uncle2 (work=3), uncle1 (work=2), uncle0 (work=1)
@@ -2034,7 +2034,7 @@ mod tests {
 
         // Confirm main chain (share1 through share5) using push_to_confirmed_chain
         for share in [&share1, &share2, &share3, &share4, &share5] {
-            store.push_to_confirmed_chain(share, true).unwrap();
+            store.push_to_confirmed_chain(share).unwrap();
         }
 
         // find_uncles from share5 (height 5)
@@ -2088,8 +2088,8 @@ mod tests {
         store.store_with_valid_metadata(&uncle2);
 
         // Confirm main chain using push_to_confirmed_chain
-        store.push_to_confirmed_chain(&share1, true).unwrap();
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         // Mark uncle1 as already used as uncle
         let mut batch = rocksdb::WriteBatch::default();
@@ -2132,8 +2132,8 @@ mod tests {
             .build();
 
         // Confirm all using push_to_confirmed_chain
-        store.push_to_confirmed_chain(&share1, true).unwrap();
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         // find_uncles should return empty - share1 is child of share0 but is confirmed
         let uncles = store.find_uncles().unwrap();
@@ -2191,13 +2191,13 @@ mod tests {
         store.store_with_valid_metadata(&uncle_c);
 
         // Confirm share1 first, so uncle_d's parent has metadata
-        store.push_to_confirmed_chain(&share1, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
 
         // Now store uncle_d (its parent share1 now has metadata)
         store.store_with_valid_metadata(&uncle_d);
 
         // Confirm share2
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         // find_uncles should return exactly 3 uncles, prioritizing higher chain_work
         // uncle_d has work=2, uncle_a/b/c have default work=1
@@ -2282,21 +2282,21 @@ mod tests {
         // Store uncle shares with Valid metadata so find_uncles can discover them.
         // Uncle parents must be confirmed first so metadata chain_work is correct.
         store.store_with_valid_metadata(&uncle1);
-        store.push_to_confirmed_chain(&share1, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
 
         store.store_with_valid_metadata(&uncle2);
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         store.store_with_valid_metadata(&uncle3);
-        store.push_to_confirmed_chain(&share3, true).unwrap();
+        store.push_to_confirmed_chain(&share3).unwrap();
 
         store.store_with_valid_metadata(&uncle4);
-        store.push_to_confirmed_chain(&share4, true).unwrap();
+        store.push_to_confirmed_chain(&share4).unwrap();
 
         store.store_with_valid_metadata(&uncle5);
-        store.push_to_confirmed_chain(&share5, true).unwrap();
+        store.push_to_confirmed_chain(&share5).unwrap();
 
-        store.push_to_confirmed_chain(&share6, true).unwrap();
+        store.push_to_confirmed_chain(&share6).unwrap();
 
         // find_uncles from share6 (height 6) looks at confirmed blocks at heights 3, 4, 5
         // and finds their non-confirmed children.
@@ -2373,14 +2373,14 @@ mod tests {
         store.store_with_valid_metadata(&uncle_mid_b);
 
         // Confirm share1 so uncles at height 2 can compute their metadata
-        store.push_to_confirmed_chain(&share1, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
 
         // Store uncle shares at height 2 with Valid metadata
         store.store_with_valid_metadata(&uncle_high);
         store.store_with_valid_metadata(&uncle_low);
 
         // Confirm share2
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         let uncles = store.find_uncles().unwrap();
         assert_eq!(uncles.len(), 3);
@@ -2420,7 +2420,7 @@ mod tests {
             .prev_share_blockhash(genesis.block_hash().to_string())
             .nonce(1)
             .build();
-        store.push_to_confirmed_chain(&share1, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
 
         // fork_uncle: sibling of share2, child of share1
         let fork_uncle = TestShareBlockBuilder::new()
@@ -2433,7 +2433,7 @@ mod tests {
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(2)
             .build();
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         // Verify chain tip is share2
         assert_eq!(store.get_chain_tip().unwrap(), share2.block_hash());
@@ -2538,7 +2538,7 @@ mod tests {
         let shares = [&share0, &share1, &share2];
         for (height, share) in shares.iter().enumerate() {
             let mut batch = Store::get_write_batch();
-            store.add_share_block(share, true, &mut batch).unwrap();
+            store.add_share_block(share, &mut batch).unwrap();
             let mut metadata = BlockMetadata {
                 expected_height: Some(height as u32),
                 chain_work: share.header.get_work(),
@@ -2579,7 +2579,7 @@ mod tests {
         let shares = [&share0, &share1, &share2];
         for (height, share) in shares.iter().enumerate() {
             let mut batch = Store::get_write_batch();
-            store.add_share_block(share, true, &mut batch).unwrap();
+            store.add_share_block(share, &mut batch).unwrap();
             let mut metadata = BlockMetadata {
                 expected_height: Some(height as u32),
                 chain_work: share.header.get_work(),

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -299,6 +299,9 @@ impl Store {
         self.update_block_metadata(&blockhash, &metadata, batch)?;
 
         *self.genesis_blockhash.write().unwrap() = Some(blockhash);
+
+        // Genesis is coinbase-only. No need to make sure to call
+        // `add_spends_for_block`.
         self.append_to_confirmed(&blockhash, 0, &mut metadata, batch)?;
         Ok(())
     }
@@ -337,10 +340,7 @@ impl Store {
     /// Push a share to the confirmed chain: organise header, store
     /// the full block, then promote candidates to confirmed.
     /// Returns the new confirmed height if changed, or None.
-    pub fn push_to_confirmed_chain(
-        &self,
-        share: &ShareBlock,
-    ) -> Result<Option<u32>, StoreError> {
+    pub fn push_to_confirmed_chain(&self, share: &ShareBlock) -> Result<Option<u32>, StoreError> {
         self.push_to_candidate_chain(share)?;
         let mut batch = Store::get_write_batch();
         self.add_share_block(share, &mut batch)?;

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -288,7 +288,7 @@ impl Store {
         let blockhash = genesis.block_hash();
         let genesis_work = genesis.header.get_work();
         self.add_share_header(&genesis.header, batch)?;
-        self.add_share_block(genesis, true, batch)?;
+        self.add_share_block(genesis, batch)?;
 
         self.set_height_to_blockhash(&blockhash, 0, batch)?;
         let mut metadata = BlockMetadata {
@@ -340,11 +340,10 @@ impl Store {
     pub fn push_to_confirmed_chain(
         &self,
         share: &ShareBlock,
-        confirm_txs: bool,
     ) -> Result<Option<u32>, StoreError> {
         self.push_to_candidate_chain(share)?;
         let mut batch = Store::get_write_batch();
-        self.add_share_block(share, confirm_txs, &mut batch)?;
+        self.add_share_block(share, &mut batch)?;
         self.commit_batch(batch)?;
         let mut batch = Store::get_write_batch();
         let result = self.organise_block(&mut batch)?;
@@ -372,7 +371,7 @@ impl Store {
             Err(_) => (1, share_work),
         };
         let mut batch = Store::get_write_batch();
-        self.add_share_block(share, true, &mut batch).unwrap();
+        self.add_share_block(share, &mut batch).unwrap();
         self.set_height_to_blockhash(&blockhash, height, &mut batch)
             .unwrap();
         let metadata = BlockMetadata {
@@ -456,10 +455,10 @@ mod tests {
         assert_eq!(store.get_chain_tip().unwrap(), genesis_hash);
 
         // Push share2 to confirmed (extends confirmed to height 1)
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         // Push share3 to confirmed (extends confirmed to height 2)
-        store.push_to_confirmed_chain(&share3, true).unwrap();
+        store.push_to_confirmed_chain(&share3).unwrap();
 
         // Test initialization from store
         store.init_chain_state_from_store(genesis_hash).unwrap();

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -302,6 +302,11 @@ impl Store {
 
         // Genesis is coinbase-only. No need to make sure to call
         // `add_spends_for_block`.
+        assert_eq!(
+            genesis.transactions.iter().len(),
+            1,
+            "Genesis should only have one transaction, the coinbase."
+        );
         self.append_to_confirmed(&blockhash, 0, &mut metadata, batch)?;
         Ok(())
     }

--- a/p2poolv2_lib/src/store/organise/candidate.rs
+++ b/p2poolv2_lib/src/store/organise/candidate.rs
@@ -803,7 +803,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share, true, &mut batch).unwrap();
+        store.add_share_block(&share, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         assert!(!store.is_candidate(&share.block_hash()));

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -106,9 +106,12 @@ impl Store {
         })?;
         let reorged_out_chain = self.get_confirmed_chain(fork_point, Some(top_confirmed))?;
 
-        // Delete old confirmed index entries and set reorged-out shares to Candidate
+        // Delete old confirmed index entries, remove their spends from
+        // SpendsIndex, and set reorged-out shares to HeaderValid.
         for (height, unconfirm) in &reorged_out_chain {
             self.delete_confirmed_entry(*height, batch);
+            let reorged_out_txs = self.get_txs_by_blockhash_index(unconfirm)?;
+            self.remove_spends_for_block(&reorged_out_txs, batch);
             let mut metadata = self.get_block_metadata(unconfirm)?;
 
             // Mark as valid, because Candidate status is limited to those on candidate chain
@@ -126,7 +129,7 @@ impl Store {
                     "Block metadata missing expected_height for confirmed reorg".into(),
                 )
             })?;
-            self.put_confirmed_entry(height, to_confirm, batch);
+            self.put_confirmed_entry(height, to_confirm, batch)?;
 
             metadata.status = Status::Confirmed;
             self.update_block_metadata(to_confirm, &metadata, batch)?;
@@ -138,17 +141,31 @@ impl Store {
         Ok(Some(new_top_height))
     }
 
-    /// Write a confirmed index entry directly into the batch.
+    /// Write a confirmed index entry and record every spend that the
+    /// block's transactions make into `SpendsIndex`.
+    ///
+    /// This is the single point where "a block just became confirmed" is
+    /// expressed. `SpendsIndex` presence therefore means exactly
+    /// "spent by a transaction on the confirmed sharechain".
+    ///
+    /// The tx list is loaded from the committed store via
+    /// `get_sharechain_txs_by_blockhash_index`. Callers must ensure the
+    /// block's tx data has already been committed in a prior batch - the
+    /// read against a pending `WriteBatch` will not see its contents.
     pub(super) fn put_confirmed_entry(
         &self,
         height: Height,
         blockhash: &BlockHash,
         batch: &mut rocksdb::WriteBatch,
-    ) {
+    ) -> Result<(), StoreError> {
         let block_height_cf = self.db.cf_handle(&ColumnFamily::BlockHeight).unwrap();
         let key = height_to_key_with_suffix(height, CONFIRMED_SUFFIX);
         let serialized = consensus::serialize(blockhash);
         batch.put_cf(&block_height_cf, key, serialized);
+
+        let txs = self.get_txs_by_blockhash_index(blockhash)?;
+        self.add_spends_for_block(&txs, batch)?;
+        Ok(())
     }
 
     /// Delete a confirmed index entry from the batch.
@@ -253,7 +270,7 @@ impl Store {
             return Err(StoreError::Database("Incorrect confirmation".into()));
         }
 
-        self.put_confirmed_entry(height, blockhash, batch);
+        self.put_confirmed_entry(height, blockhash, batch)?;
         self.set_top_confirmed_height(height, batch);
 
         metadata.status = Status::Confirmed;
@@ -330,7 +347,7 @@ impl Store {
         batch: &mut rocksdb::WriteBatch,
     ) -> Result<Option<Height>, StoreError> {
         for (candidate_height, candidate_hash) in candidates {
-            self.put_confirmed_entry(*candidate_height, candidate_hash, batch);
+            self.put_confirmed_entry(*candidate_height, candidate_hash, batch)?;
             let mut metadata = self.get_block_metadata(candidate_hash)?;
             metadata.status = crate::store::block_tx_metadata::Status::Confirmed;
             self.update_block_metadata(candidate_hash, &metadata, batch)?;
@@ -536,12 +553,8 @@ mod tests {
 
         // Add shares first
         let mut batch = Store::get_write_batch();
-        store
-            .add_share_block(&candidate_share, &mut batch)
-            .unwrap();
-        store
-            .add_share_block(&confirmed_share, &mut batch)
-            .unwrap();
+        store.add_share_block(&candidate_share, &mut batch).unwrap();
+        store.add_share_block(&confirmed_share, &mut batch).unwrap();
         let mut candidate_metadata = BlockMetadata {
             expected_height: Some(0),
             chain_work: candidate_share.header.get_work(),
@@ -1207,9 +1220,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store
-            .add_share_block(&fork_share, &mut batch)
-            .unwrap();
+        store.add_share_block(&fork_share, &mut batch).unwrap();
         let mut fork_metadata = BlockMetadata {
             expected_height: Some(1),
             chain_work: fork_share.header.get_work(),
@@ -1487,9 +1498,7 @@ mod tests {
             .nonce(0xe9695795)
             .build();
         let mut batch = Store::get_write_batch();
-        store
-            .add_share_block(&fork_share, &mut batch)
-            .unwrap();
+        store.add_share_block(&fork_share, &mut batch).unwrap();
         let mut fork_metadata = BlockMetadata {
             expected_height: Some(1),
             chain_work: fork_share.header.get_work(),
@@ -1604,9 +1613,7 @@ mod tests {
             .nonce(0xe9695794)
             .build();
         let mut batch = Store::get_write_batch();
-        store
-            .add_share_block(&fork_share, &mut batch)
-            .unwrap();
+        store.add_share_block(&fork_share, &mut batch).unwrap();
         let mut fork_metadata = BlockMetadata {
             expected_height: Some(2),
             chain_work: metadata_a.chain_work + fork_share.header.get_work(),
@@ -1673,5 +1680,147 @@ mod tests {
         let mut batch = Store::get_write_batch();
         let result = store.reorg_confirmed(&top_confirmed, &candidates, &mut batch);
         assert!(result.is_err());
+    }
+
+    // -- SpendsIndex confirmation-gating integration test --
+
+    /// End-to-end regression for the "SpendsIndex is gated on
+    /// confirmation" change: confirming a share writes spends, reorging
+    /// it out removes them, re-confirming a replacement re-adds them.
+    #[test]
+    fn test_spends_index_follows_confirmation_state() {
+        use bitcoin::hashes::Hash;
+
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Build a spending tx whose prevout points at a fabricated
+        // outpoint. SpendsIndex doesn't care whether the prevout
+        // actually exists as an output — it only records the spend.
+        let fabricated_prevout_txid: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([0xaa; 32]).into();
+        let prevout = bitcoin::OutPoint::new(fabricated_prevout_txid, 0);
+        let spending_tx = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::ONE,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: prevout,
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(1_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+
+        // Block A at height 1 containing the spender.
+        let share_a = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695792)
+            .add_transaction(spending_tx.clone())
+            .build();
+        let mut batch = Store::get_write_batch();
+        store.add_share_block(&share_a, &mut batch).unwrap();
+        let mut metadata_a = BlockMetadata {
+            expected_height: Some(1),
+            chain_work: share_a.header.get_work(),
+            status: Status::HeaderValid,
+        };
+        store
+            .update_block_metadata(&share_a.block_hash(), &metadata_a, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Pre-confirmation: no SpendsIndex entry.
+        assert!(!store.is_any_prevout_spent(&[prevout]).unwrap());
+
+        // Confirm A. put_confirmed_entry should populate SpendsIndex.
+        let mut batch = Store::get_write_batch();
+        store
+            .append_to_confirmed(&share_a.block_hash(), 1, &mut metadata_a, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+        assert!(store.is_any_prevout_spent(&[prevout]).unwrap());
+
+        // Build a heavier fork at height 1 that does NOT contain the
+        // spender. Reorg confirms the fork and unconfirms A; the
+        // reorg-out path should clear the SpendsIndex entry.
+        let fork_1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .work(4)
+            .nonce(0xe9695793)
+            .build();
+        let mut batch = Store::get_write_batch();
+        store.add_share_block(&fork_1, &mut batch).unwrap();
+        let mut fork_1_metadata = BlockMetadata {
+            expected_height: Some(1),
+            chain_work: fork_1.header.get_work(),
+            status: Status::HeaderValid,
+        };
+        store
+            .update_block_metadata(&fork_1.block_hash(), &fork_1_metadata, &mut batch)
+            .unwrap();
+        store
+            .append_to_candidates(&fork_1.block_hash(), 1, &mut fork_1_metadata, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let top_confirmed = store.get_top_confirmed().unwrap();
+        let candidates = vec![(1, fork_1.block_hash())];
+        let mut batch = Store::get_write_batch();
+        store
+            .reorg_confirmed(&top_confirmed, &candidates, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        assert_eq!(
+            store.get_confirmed_at_height(1).unwrap(),
+            fork_1.block_hash()
+        );
+        assert!(!store.is_any_prevout_spent(&[prevout]).unwrap());
+
+        // Build a second fork that extends the new confirmed chain with
+        // a block containing the same spender tx, and reorg again so it
+        // becomes confirmed.
+        let fork_2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_1.block_hash().to_string())
+            .work(8)
+            .nonce(0xe9695794)
+            .add_transaction(spending_tx)
+            .build();
+        let mut batch = Store::get_write_batch();
+        store.add_share_block(&fork_2, &mut batch).unwrap();
+        let mut fork_2_metadata = BlockMetadata {
+            expected_height: Some(2),
+            chain_work: fork_1_metadata.chain_work + fork_2.header.get_work(),
+            status: Status::HeaderValid,
+        };
+        store
+            .update_block_metadata(&fork_2.block_hash(), &fork_2_metadata, &mut batch)
+            .unwrap();
+        store
+            .append_to_candidates(&fork_2.block_hash(), 2, &mut fork_2_metadata, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Extend confirmed by promoting fork_2.
+        let mut batch = Store::get_write_batch();
+        store
+            .extend_confirmed(2, &vec![(2, fork_2.block_hash())], &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        assert_eq!(
+            store.get_confirmed_at_height(2).unwrap(),
+            fork_2.block_hash()
+        );
+        assert!(store.is_any_prevout_spent(&[prevout]).unwrap());
     }
 }

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -253,12 +253,7 @@ impl Store {
             return Err(StoreError::Database("Incorrect confirmation".into()));
         }
 
-        let block_height_cf = self.db.cf_handle(&ColumnFamily::BlockHeight).unwrap();
-        let key = height_to_key_with_suffix(height, CONFIRMED_SUFFIX);
-
-        let serialized_blockhash = consensus::serialize(blockhash);
-        batch.put_cf(&block_height_cf, key, serialized_blockhash);
-
+        self.put_confirmed_entry(height, blockhash, batch);
         self.set_top_confirmed_height(height, batch);
 
         metadata.status = Status::Confirmed;

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -149,7 +149,7 @@ impl Store {
     /// "spent by a transaction on the confirmed sharechain".
     ///
     /// The tx list is loaded from the committed store via
-    /// `get_sharechain_txs_by_blockhash_index`. Callers must ensure the
+    /// `get_txs_by_blockhash_index`. Callers must ensure the
     /// block's tx data has already been committed in a prior batch - the
     /// read against a pending `WriteBatch` will not see its contents.
     pub(super) fn put_confirmed_entry(

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -357,7 +357,7 @@ mod tests {
         let share2 = TestShareBlockBuilder::new().nonce(0xe9695792).build();
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         let mut metadata1 = BlockMetadata {
             expected_height: Some(0),
             chain_work: share1.header.get_work(),
@@ -376,7 +376,7 @@ mod tests {
         assert_eq!(confirmed, share1.block_hash());
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         let mut metadata2 = BlockMetadata {
             expected_height: Some(1),
             chain_work: share2.header.get_work(),
@@ -425,9 +425,9 @@ mod tests {
 
         // Add all shares first
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, false, &mut batch).unwrap();
-        store.add_share_block(&share2, false, &mut batch).unwrap();
-        store.add_share_block(&share3, false, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
         let mut metadata1 = BlockMetadata {
             expected_height: Some(0),
             chain_work: share1.header.get_work(),
@@ -488,8 +488,8 @@ mod tests {
 
         // Add shares first
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share0, false, &mut batch).unwrap();
-        store.add_share_block(&share2, false, &mut batch).unwrap();
+        store.add_share_block(&share0, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         let mut metadata0 = BlockMetadata {
             expected_height: Some(0),
             chain_work: share0.header.get_work(),
@@ -537,10 +537,10 @@ mod tests {
         // Add shares first
         let mut batch = Store::get_write_batch();
         store
-            .add_share_block(&candidate_share, false, &mut batch)
+            .add_share_block(&candidate_share, &mut batch)
             .unwrap();
         store
-            .add_share_block(&confirmed_share, false, &mut batch)
+            .add_share_block(&confirmed_share, &mut batch)
             .unwrap();
         let mut candidate_metadata = BlockMetadata {
             expected_height: Some(0),
@@ -665,7 +665,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Don't mark it as confirmed - is_confirmed should return false
@@ -696,7 +696,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Mark share2 as confirmed at height 1
@@ -744,7 +744,7 @@ mod tests {
 
         // append_to_confirmed checks top height against DB, so commit between each
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share0, false, &mut batch).unwrap();
+        store.add_share_block(&share0, &mut batch).unwrap();
         let mut m0 = BlockMetadata {
             expected_height: Some(0),
             chain_work: share0.header.get_work(),
@@ -759,7 +759,7 @@ mod tests {
         store.commit_batch(batch).unwrap();
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, false, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         let mut m1 = BlockMetadata {
             expected_height: Some(1),
             chain_work: share1.header.get_work(),
@@ -774,7 +774,7 @@ mod tests {
         store.commit_batch(batch).unwrap();
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, false, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         let mut m2 = BlockMetadata {
             expected_height: Some(2),
             chain_work: share2.header.get_work(),
@@ -1054,7 +1054,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&fork, true, &mut batch).unwrap();
+        store.add_share_block(&fork, &mut batch).unwrap();
         let fork_metadata = BlockMetadata {
             expected_height: Some(1),
             chain_work: fork.header.get_work(),
@@ -1127,7 +1127,7 @@ mod tests {
             .nonce(0xe9695794)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&fork1, true, &mut batch).unwrap();
+        store.add_share_block(&fork1, &mut batch).unwrap();
         let fork1_metadata = BlockMetadata {
             expected_height: Some(1),
             chain_work: fork1.header.get_work(),
@@ -1144,7 +1144,7 @@ mod tests {
             .nonce(0xe9695795)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&fork2, true, &mut batch).unwrap();
+        store.add_share_block(&fork2, &mut batch).unwrap();
         let fork2_metadata = BlockMetadata {
             expected_height: Some(2),
             chain_work: fork1_metadata.chain_work + fork2.header.get_work(),
@@ -1184,7 +1184,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&a, true, &mut batch).unwrap();
+        store.add_share_block(&a, &mut batch).unwrap();
         let mut metadata_a = BlockMetadata {
             expected_height: Some(1),
             chain_work: a.header.get_work(),
@@ -1208,7 +1208,7 @@ mod tests {
             .build();
         let mut batch = Store::get_write_batch();
         store
-            .add_share_block(&fork_share, true, &mut batch)
+            .add_share_block(&fork_share, &mut batch)
             .unwrap();
         let mut fork_metadata = BlockMetadata {
             expected_height: Some(1),
@@ -1282,7 +1282,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share_a, true, &mut batch).unwrap();
+        store.add_share_block(&share_a, &mut batch).unwrap();
         let mut metadata_a = BlockMetadata {
             expected_height: Some(1),
             chain_work: share_a.header.get_work(),
@@ -1301,7 +1301,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share_b, true, &mut batch).unwrap();
+        store.add_share_block(&share_b, &mut batch).unwrap();
         let mut metadata_b = BlockMetadata {
             expected_height: Some(2),
             chain_work: metadata_a.chain_work + share_b.header.get_work(),
@@ -1323,7 +1323,7 @@ mod tests {
             .nonce(0xe9695794)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&fork_1, true, &mut batch).unwrap();
+        store.add_share_block(&fork_1, &mut batch).unwrap();
         let mut fork_1_metadata = BlockMetadata {
             expected_height: Some(1),
             chain_work: fork_1.header.get_work(),
@@ -1343,7 +1343,7 @@ mod tests {
             .nonce(0xe9695795)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&fork_2, true, &mut batch).unwrap();
+        store.add_share_block(&fork_2, &mut batch).unwrap();
         let mut fork_2_metadata = BlockMetadata {
             expected_height: Some(2),
             chain_work: fork_1_metadata.chain_work + fork_2.header.get_work(),
@@ -1426,7 +1426,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share_a, true, &mut batch).unwrap();
+        store.add_share_block(&share_a, &mut batch).unwrap();
         let mut metadata_a = BlockMetadata {
             expected_height: Some(1),
             chain_work: share_a.header.get_work(),
@@ -1445,7 +1445,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share_b, true, &mut batch).unwrap();
+        store.add_share_block(&share_b, &mut batch).unwrap();
         let mut metadata_b = BlockMetadata {
             expected_height: Some(2),
             chain_work: metadata_a.chain_work + share_b.header.get_work(),
@@ -1464,7 +1464,7 @@ mod tests {
             .nonce(0xe9695794)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share_c, true, &mut batch).unwrap();
+        store.add_share_block(&share_c, &mut batch).unwrap();
         let mut metadata_c = BlockMetadata {
             expected_height: Some(3),
             chain_work: metadata_b.chain_work + share_c.header.get_work(),
@@ -1488,7 +1488,7 @@ mod tests {
             .build();
         let mut batch = Store::get_write_batch();
         store
-            .add_share_block(&fork_share, true, &mut batch)
+            .add_share_block(&fork_share, &mut batch)
             .unwrap();
         let mut fork_metadata = BlockMetadata {
             expected_height: Some(1),
@@ -1562,7 +1562,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share_a, true, &mut batch).unwrap();
+        store.add_share_block(&share_a, &mut batch).unwrap();
         let mut metadata_a = BlockMetadata {
             expected_height: Some(1),
             chain_work: share_a.header.get_work(),
@@ -1581,7 +1581,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share_b, true, &mut batch).unwrap();
+        store.add_share_block(&share_b, &mut batch).unwrap();
         let mut metadata_b = BlockMetadata {
             expected_height: Some(2),
             chain_work: metadata_a.chain_work + share_b.header.get_work(),
@@ -1605,7 +1605,7 @@ mod tests {
             .build();
         let mut batch = Store::get_write_batch();
         store
-            .add_share_block(&fork_share, true, &mut batch)
+            .add_share_block(&fork_share, &mut batch)
             .unwrap();
         let mut fork_metadata = BlockMetadata {
             expected_height: Some(2),

--- a/p2poolv2_lib/src/store/organise/mod.rs
+++ b/p2poolv2_lib/src/store/organise/mod.rs
@@ -183,7 +183,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // share3 extends share2 and is NOT on candidate chain
@@ -192,7 +192,7 @@ mod tests {
             .nonce(0xe9695794)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, true, &mut batch).unwrap();
+        store.add_share_block(&share3, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Branch from share3 should be [share1, share2, share3]
@@ -228,7 +228,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Branch from share2 should be just [share1, share2]

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -193,9 +193,7 @@ mod tests {
             .work(2)
             .nonce(0xe9695793)
             .build();
-        store
-            .push_to_confirmed_chain(&share_to_organise)
-            .unwrap();
+        store.push_to_confirmed_chain(&share_to_organise).unwrap();
 
         // Candidates coexist with confirmed
         assert!(store.get_top_candidate().is_ok());

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -87,7 +87,7 @@ mod tests {
             .prev_share_blockhash(genesis.block_hash().to_string())
             .nonce(0xe9695792)
             .build();
-        let result = store.push_to_confirmed_chain(&share, true).unwrap();
+        let result = store.push_to_confirmed_chain(&share).unwrap();
         assert_eq!(result, Some(1));
         assert_eq!(store.get_top_confirmed_height().unwrap(), 1);
 
@@ -143,7 +143,7 @@ mod tests {
         // setup_genesis does not call append_to_candidate, so no top candidate
         assert!(store.get_top_candidate().is_err());
 
-        store.push_to_confirmed_chain(&share, true).unwrap();
+        store.push_to_confirmed_chain(&share).unwrap();
 
         // Candidate coexists with confirmed
         assert!(store.get_top_candidate().is_ok());
@@ -171,7 +171,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
         store.push_to_candidate_chain(&share1).unwrap();
 
@@ -194,7 +194,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         store
-            .push_to_confirmed_chain(&share_to_organise, true)
+            .push_to_confirmed_chain(&share_to_organise)
             .unwrap();
 
         // Candidates coexist with confirmed
@@ -282,7 +282,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
         store.push_to_candidate_chain(&share1).unwrap();
 
@@ -318,7 +318,7 @@ mod tests {
         store.store_with_valid_metadata(&fork_share);
 
         // push_to_confirmed_chain reorgs candidate chain and promotes to confirmed
-        store.push_to_confirmed_chain(&fork_share, true).unwrap();
+        store.push_to_confirmed_chain(&fork_share).unwrap();
 
         // After reorg + confirmed promotion: candidate chain coexists
         assert!(store.get_top_candidate().is_ok());
@@ -360,7 +360,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
         store.push_to_candidate_chain(&share1).unwrap();
 
@@ -408,7 +408,7 @@ mod tests {
         store.store_with_valid_metadata(&fork3);
 
         // push_to_confirmed_chain reorgs candidate chain and promotes to confirmed
-        store.push_to_confirmed_chain(&fork3, true).unwrap();
+        store.push_to_confirmed_chain(&fork3).unwrap();
 
         // After reorg + confirmed promotion: candidate chain coexists
         assert!(store.get_top_candidate().is_ok());
@@ -456,7 +456,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
         store.push_to_candidate_chain(&share1).unwrap();
 
@@ -485,7 +485,7 @@ mod tests {
         store.store_with_valid_metadata(&fork_share);
 
         // push_to_confirmed_chain reorgs candidate chain and promotes to confirmed
-        store.push_to_confirmed_chain(&fork_share, true).unwrap();
+        store.push_to_confirmed_chain(&fork_share).unwrap();
 
         // After reorg + confirmed promotion: candidate chain coexists
         assert!(store.get_top_candidate().is_ok());
@@ -521,7 +521,7 @@ mod tests {
             .prev_share_blockhash(genesis.block_hash().to_string())
             .nonce(0xe9695792)
             .build();
-        store.push_to_confirmed_chain(&share1, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
 
         // share1 promoted to confirmed, candidate chain coexists
         assert!(store.get_top_candidate().is_ok());
@@ -537,7 +537,7 @@ mod tests {
             .work(2)
             .nonce(0xe9695793)
             .build();
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         // candidate chain coexists with confirmed chain
         assert!(store.get_top_candidate().is_ok());
@@ -568,7 +568,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
         store.push_to_candidate_chain(&share1).unwrap();
 
@@ -591,7 +591,7 @@ mod tests {
         store.store_with_valid_metadata(&share3);
 
         // Push share2 to confirmed chain: extends candidate to h:2, forward walk picks up share3
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         // All promoted to confirmed, candidate chain coexists
         assert!(store.get_top_candidate().is_ok());
@@ -633,7 +633,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
         store.push_to_candidate_chain(&share1).unwrap();
 
@@ -665,7 +665,7 @@ mod tests {
         store.store_with_valid_metadata(&share4);
 
         // Push share2 to confirmed chain: extends to h:2, forward walk fills h:3 and h:4
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         // All promoted to confirmed, candidate chain coexists
         assert!(store.get_top_candidate().is_ok());
@@ -710,7 +710,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
         store.push_to_candidate_chain(&share1).unwrap();
 
@@ -729,7 +729,7 @@ mod tests {
             .nonce(0xe9695794)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&fork, true, &mut batch).unwrap();
+        store.add_share_block(&fork, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // fork_child: child of fork, h:3, stored as Valid with metadata.
@@ -745,7 +745,7 @@ mod tests {
         store.store_with_valid_metadata(&fork_child);
 
         // Push fork to confirmed chain: reorg replaces share2, forward walk picks up fork_child
-        store.push_to_confirmed_chain(&fork, true).unwrap();
+        store.push_to_confirmed_chain(&fork).unwrap();
 
         // All promoted to confirmed, candidate chain coexists
         assert!(store.get_top_candidate().is_ok());
@@ -815,7 +815,7 @@ mod tests {
         // candidate at h:1, forward walk discovers share2a and share2b
         // and picks share2b (higher cumulative work). Then organise_block
         // promotes candidates to confirmed.
-        store.push_to_confirmed_chain(&share1, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
 
         // share2b promoted to confirmed, candidate chain coexists
         assert!(store.get_top_candidate().is_ok());
@@ -853,7 +853,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
         store.push_to_candidate_chain(&share1).unwrap();
 
@@ -865,7 +865,7 @@ mod tests {
             .build();
 
         // Push share2 to confirmed chain: extends to h:2, no children -> stops
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         // All promoted to confirmed, candidate chain coexists, stops at h:2
         assert!(store.get_top_candidate().is_ok());

--- a/p2poolv2_lib/src/store/organise/organise_header.rs
+++ b/p2poolv2_lib/src/store/organise/organise_header.rs
@@ -287,9 +287,7 @@ mod tests {
             let height = parent_height + 1;
             let chain_work = parent_metadata.chain_work + share_work;
             let mut batch = Store::get_write_batch();
-            store
-                .add_share_block(&fork_share, &mut batch)
-                .unwrap();
+            store.add_share_block(&fork_share, &mut batch).unwrap();
             store
                 .set_height_to_blockhash(&blockhash, height, &mut batch)
                 .unwrap();

--- a/p2poolv2_lib/src/store/organise/organise_header.rs
+++ b/p2poolv2_lib/src/store/organise/organise_header.rs
@@ -161,7 +161,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share, true, &mut batch).unwrap();
+        store.add_share_block(&share, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // No top candidate before organising
@@ -257,7 +257,7 @@ mod tests {
             .nonce(0xe9695792)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
         store.push_to_candidate_chain(&share1).unwrap();
 
@@ -288,7 +288,7 @@ mod tests {
             let chain_work = parent_metadata.chain_work + share_work;
             let mut batch = Store::get_write_batch();
             store
-                .add_share_block(&fork_share, true, &mut batch)
+                .add_share_block(&fork_share, &mut batch)
                 .unwrap();
             store
                 .set_height_to_blockhash(&blockhash, height, &mut batch)
@@ -348,7 +348,7 @@ mod tests {
             .prev_share_blockhash(genesis.block_hash().to_string())
             .nonce(0xe9695792)
             .build();
-        store.push_to_confirmed_chain(&share1, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
 
         // uncle_block: fork child of genesis (sibling of share1)
         let uncle_block = TestShareBlockBuilder::new()
@@ -367,7 +367,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = Store::get_write_batch();
@@ -399,7 +399,7 @@ mod tests {
             .prev_share_blockhash(genesis.block_hash().to_string())
             .nonce(0xe9695792)
             .build();
-        store.push_to_confirmed_chain(&share1, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
 
         // Two fork blocks at h:1
         let uncle_a = TestShareBlockBuilder::new()
@@ -423,7 +423,7 @@ mod tests {
             .nonce(0xe9695793)
             .build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let mut batch = Store::get_write_batch();
@@ -453,7 +453,7 @@ mod tests {
             .prev_share_blockhash(genesis.block_hash().to_string())
             .nonce(0xe9695792)
             .build();
-        store.push_to_confirmed_chain(&share1, true).unwrap();
+        store.push_to_confirmed_chain(&share1).unwrap();
 
         // uncle_block: fork child of genesis at h:1 (sibling of share1)
         let uncle_block = TestShareBlockBuilder::new()
@@ -469,13 +469,13 @@ mod tests {
             .uncles(vec![uncle_block.block_hash()])
             .nonce(0xe9695793)
             .build();
-        store.push_to_confirmed_chain(&share2, true).unwrap();
+        store.push_to_confirmed_chain(&share2).unwrap();
 
         let share3 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .nonce(0xe9695794)
             .build();
-        store.push_to_confirmed_chain(&share3, true).unwrap();
+        store.push_to_confirmed_chain(&share3).unwrap();
 
         // find_uncles should not return uncle_block since share2
         // already included it and organise_header marked it

--- a/p2poolv2_lib/src/store/share_store.rs
+++ b/p2poolv2_lib/src/store/share_store.rs
@@ -36,7 +36,6 @@ impl Store {
     pub fn add_share_block(
         &self,
         share: &ShareBlock,
-        confirm_txs: bool,
         batch: &mut rocksdb::WriteBatch,
     ) -> Result<(), StoreError> {
         let blockhash = share.block_hash();
@@ -55,7 +54,7 @@ impl Store {
         );
 
         // Store transactions and get their metadata
-        let txs_metadata = self.add_sharechain_txs(&share.transactions, confirm_txs, batch)?;
+        let txs_metadata = self.add_sharechain_txs(&share.transactions, batch)?;
 
         let txids = Txids(txs_metadata.iter().map(|t| t.txid).collect());
         // Store block -> txids index
@@ -530,7 +529,7 @@ mod tests {
             .build();
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, true, &mut batch).unwrap();
+        store.add_share_block(&share1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Create uncle (also child of genesis)
@@ -540,7 +539,7 @@ mod tests {
             .build();
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, false, &mut batch).unwrap();
+        store.add_share_block(&uncle1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Create share2 referencing uncle1
@@ -551,7 +550,7 @@ mod tests {
             .build();
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, true, &mut batch).unwrap();
+        store.add_share_block(&share2, &mut batch).unwrap();
         // Uncle block index updates are handled by organise_header, not
         // add_share_block. Manually register uncle->nephew entries here.
         for uncle_blockhash in &share2.header.uncles {
@@ -602,7 +601,7 @@ mod tests {
         let num_txs = block.transactions.len();
         let txs = block.transactions.clone();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&block, true, &mut batch).unwrap();
+        store.add_share_block(&block, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let blockhash = block.block_hash();
@@ -621,7 +620,7 @@ mod tests {
 
         let block = TestShareBlockBuilder::new().build();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&block, true, &mut batch).unwrap();
+        store.add_share_block(&block, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let header = store.get_share_header(&block.block_hash()).unwrap();
@@ -668,7 +667,7 @@ mod tests {
         assert!(!store.share_block_exists(&blockhash));
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&block, true, &mut batch).unwrap();
+        store.add_share_block(&block, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         assert!(store.share_block_exists(&blockhash));
@@ -683,7 +682,7 @@ mod tests {
         let blockhash = block.block_hash();
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&block, true, &mut batch).unwrap();
+        store.add_share_block(&block, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Verify the header was written to the Header CF
@@ -780,13 +779,13 @@ mod tests {
 
         // First add succeeds and stores the block
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&block, true, &mut batch).unwrap();
+        store.add_share_block(&block, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
         assert!(store.get_share(&blockhash).is_some());
 
         // Second add of the same block returns Ok without error
         let mut batch = Store::get_write_batch();
-        let result = store.add_share_block(&block, true, &mut batch);
+        let result = store.add_share_block(&block, &mut batch);
         assert!(result.is_ok());
 
         // The batch should be empty (no writes for duplicate)
@@ -808,7 +807,7 @@ mod tests {
 
         let blockhash = block.block_hash();
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&block, true, &mut batch).unwrap();
+        store.add_share_block(&block, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         let share = store.get_share(&blockhash).unwrap();

--- a/p2poolv2_lib/src/store/transaction_store.rs
+++ b/p2poolv2_lib/src/store/transaction_store.rs
@@ -27,7 +27,7 @@ const OUTPOINT_SIZE: usize = 36;
 
 #[allow(dead_code)]
 impl Store {
-    /// Retrieve all previous outputs spent by a transaction's inputs.
+    /// Retrieve all previous outputs being spent by a transaction's inputs.
     ///
     /// Uses a single batch query to fetch all spent outputs, avoiding
     /// N+1 lookups. Returns a vector of (input_index, TxOut) pairs in
@@ -70,6 +70,79 @@ impl Store {
         Ok(prevouts)
     }
 
+    /// Batch check the Outputs column family: returns true if any outpoint
+    /// is missing.
+    pub(crate) fn is_missing_any_prevout(
+        &self,
+        outpoints: &[OutPoint],
+    ) -> Result<bool, StoreError> {
+        if outpoints.is_empty() {
+            return Ok(false);
+        }
+        let outputs_cf = self.db.cf_handle(&ColumnFamily::Outputs).unwrap();
+        let keys: Vec<String> = outpoints
+            .iter()
+            .map(|outpoint| format!("{}:{}", outpoint.txid, outpoint.vout))
+            .collect();
+        let cf_keys: Vec<(_, &[u8])> = keys
+            .iter()
+            .map(|key| (&outputs_cf, key.as_bytes()))
+            .collect();
+        for result in self.db.multi_get_cf(cf_keys) {
+            if result?.is_none() {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Batch check the SpendsIndex column family: returns true if any
+    /// outpoint has a stored spend entry.
+    ///
+    /// `SpendsIndex` is written only from the confirmation path
+    /// (`put_confirmed_entry`) and cleared on reorg-out, so presence in
+    /// this column family means "spent by a transaction on the confirmed
+    /// sharechain". No per-hit confirmation lookup is needed.
+    pub(crate) fn is_any_prevout_spent(&self, outpoints: &[OutPoint]) -> Result<bool, StoreError> {
+        if outpoints.is_empty() {
+            return Ok(false);
+        }
+        let spends_index_cf = self.db.cf_handle(&ColumnFamily::SpendsIndex).unwrap();
+        let keys: Vec<String> = outpoints
+            .iter()
+            .map(|outpoint| format!("{}:{}", outpoint.txid, outpoint.vout))
+            .collect();
+        let cf_keys: Vec<(_, &[u8])> = keys
+            .iter()
+            .map(|key| (&spends_index_cf, key.as_bytes()))
+            .collect();
+        for result in self.db.multi_get_cf(cf_keys) {
+            if result?.is_some() {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Returns true if every provided txid is included in at least one
+    /// block whose `BlockMetadata::status` is `Status::Confirmed`. Returns
+    /// false on the first txid that has no confirmed blockhash.
+    pub(crate) fn are_all_txids_confirmed(&self, txids: &[Txid]) -> Result<bool, StoreError> {
+        for txid in txids {
+            let blockhashes = self.get_blockhashes_for_txid(txid)?;
+            let mut confirmed = false;
+            for blockhash in &blockhashes {
+                if self.is_confirmed(blockhash) {
+                    confirmed = true;
+                }
+            }
+            if !confirmed {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
     /// Retrieve a single transaction output by txid and output index.
     ///
     /// Looks up the output in the Outputs column family using the
@@ -86,29 +159,20 @@ impl Store {
         }
     }
 
-    /// Store share chain transactions in the store
+    /// Store share chain transactions in the store.
     ///
-    /// Store inputs and outputs for each transaction in separate column families
+    /// Writes transaction metadata, each input, and each output into
+    /// their respective column families. This function is pure tx
+    /// storage and does not touch the `SpendsIndex` — chain-state
+    /// bookkeeping of spends is the responsibility of the confirmation
+    /// path (`put_confirmed_entry` / `remove_spends_for_block`).
     ///
-    /// Store txid -> transaction metadata in the tx column family
-    ///
-    /// The block -> txids store is done in
-    /// add_txids_to_block_index. This function lets us store
-    /// transactions outside of a block context
-    ///
-    /// Creates entries in spend index to track inputs spending
-    /// outputs. These transactions are saved only for valid and
-    /// candidate blocks, so the spends are valid. Their confirmation
-    /// status depends on the block confirmation status they are
-    /// included in.
-    ///
-    /// On chain reorgs this should be called again, so that any
-    /// outputs spent by different txs in the new cofirmed chain are
-    /// overwritten.
+    /// The block -> txids association is stored separately via
+    /// `add_txids_to_blocks_index`, allowing this function to persist
+    /// transactions outside of a block context.
     pub(crate) fn add_sharechain_txs(
         &self,
         transactions: &[ShareTransaction],
-        on_main_chain: bool,
         batch: &mut rocksdb::WriteBatch,
     ) -> Result<Vec<TxMetadata>, StoreError> {
         let inputs_cf = self.db.cf_handle(&ColumnFamily::Inputs).unwrap();
@@ -119,26 +183,13 @@ impl Store {
             let metadata = self.add_tx_metadata(txid, tx, false, batch)?;
             txs_metadata.push(metadata);
 
-            // Store each input for the transaction
             for (i, input) in tx.input.iter().enumerate() {
                 let input_key = format!("{txid}:{i}");
                 let mut serialized = Vec::new();
                 input.consensus_encode(&mut serialized)?;
                 batch.put_cf::<&[u8], Vec<u8>>(&inputs_cf, input_key.as_ref(), serialized);
-
-                if on_main_chain {
-                    // Add spends for transaction, confirmed or not.
-                    self.add_spend(
-                        &input.previous_output.txid,
-                        input.previous_output.vout,
-                        &txid,
-                        i as u32,
-                        batch,
-                    )?;
-                }
             }
 
-            // Store each output for the transaction
             for (i, output) in tx.output.iter().enumerate() {
                 let output_key = format!("{txid}:{i}");
                 let mut serialized = Vec::new();
@@ -243,11 +294,7 @@ impl Store {
 
     /// Delete every `SpendsIndex` entry that `add_spends_for_block` would
     /// have written for `txs`. Used by the reorg-out path.
-    pub(crate) fn remove_spends_for_block(
-        &self,
-        txs: &[ShareTransaction],
-        batch: &mut WriteBatch,
-    ) {
+    pub(crate) fn remove_spends_for_block(&self, txs: &[ShareTransaction], batch: &mut WriteBatch) {
         for share_transaction in txs {
             let transaction = &share_transaction.0;
             if !transaction.is_coinbase() {
@@ -484,17 +531,164 @@ impl Store {
         Ok(transaction)
     }
 
+    /// Batch load `TxMetadata` for a list of txids via a single
+    /// `multi_get_cf` on the `Tx` column family. Result order matches
+    /// the input order. Errors on any missing txid.
+    pub(crate) fn get_metadata_for_txids(
+        &self,
+        txids: &[Txid],
+    ) -> Result<Vec<TxMetadata>, StoreError> {
+        if txids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let tx_cf = self.db.cf_handle(&ColumnFamily::Tx).unwrap();
+        let keys: Vec<(_, &[u8])> = txids.iter().map(|txid| (&tx_cf, txid.as_ref())).collect();
+        let results = self.db.multi_get_cf(keys);
+        let mut metadatas: Vec<TxMetadata> = Vec::with_capacity(txids.len());
+        for (index, result) in results.into_iter().enumerate() {
+            let bytes = result?.ok_or_else(|| {
+                StoreError::NotFound(format!(
+                    "Transaction metadata not found for txid: {}",
+                    txids[index]
+                ))
+            })?;
+            let metadata: TxMetadata = encode::deserialize(&bytes).map_err(|_| {
+                StoreError::Serialization("Failed to deserialize tx metadata".to_string())
+            })?;
+            metadatas.push(metadata);
+        }
+        Ok(metadatas)
+    }
+
+    /// Batch load transaction inputs for every `(txid, metadata)` pair
+    /// via a single `multi_get_cf` on the `Inputs` column family. Returns
+    /// a per-tx `Vec<TxIn>` in the same order as `txids`. `txids` and
+    /// `metadatas` must have the same length.
+    pub(crate) fn get_inputs(
+        &self,
+        txids: &[Txid],
+        metadatas: &[TxMetadata],
+    ) -> Result<Vec<Vec<bitcoin::TxIn>>, StoreError> {
+        let inputs_cf = self.db.cf_handle(&ColumnFamily::Inputs).unwrap();
+        let mut keys: Vec<String> = Vec::new();
+        // Use offsets to track inputs for various txids to avoid using hashmap here
+        let mut offsets: Vec<usize> = Vec::with_capacity(txids.len() + 1);
+        offsets.push(0);
+        for (index, metadata) in metadatas.iter().enumerate() {
+            let txid = &txids[index];
+            for input_index in 0..metadata.input_count {
+                keys.push(format!("{txid}:{input_index}"));
+            }
+            offsets.push(keys.len());
+        }
+
+        let cf_keys: Vec<(_, &[u8])> = keys
+            .iter()
+            .map(|key| (&inputs_cf, key.as_bytes()))
+            .collect();
+        let results = self.db.multi_get_cf(cf_keys);
+        let mut decoded: Vec<bitcoin::TxIn> = Vec::with_capacity(keys.len());
+        for (index, result) in results.into_iter().enumerate() {
+            let bytes = result?.ok_or_else(|| {
+                StoreError::NotFound(format!("Input not found for {}", keys[index]))
+            })?;
+            decoded.push(encode::deserialize(&bytes).map_err(|_| {
+                StoreError::Serialization("Failed to deserialize input".to_string())
+            })?);
+        }
+
+        // group the offset based inputs for each txid
+        let mut grouped: Vec<Vec<bitcoin::TxIn>> = Vec::with_capacity(txids.len());
+        for index in 0..txids.len() {
+            grouped.push(decoded[offsets[index]..offsets[index + 1]].to_vec());
+        }
+        Ok(grouped)
+    }
+
+    /// Batch load transaction outputs for every `(txid, metadata)` pair
+    /// via a single `multi_get_cf` on the `Outputs` column family.
+    /// Returns a per-tx `Vec<TxOut>` in the same order as `txids`.
+    /// `txids` and `metadatas` must have the same length.
+    pub(crate) fn get_outputs(
+        &self,
+        txids: &[Txid],
+        metadatas: &[TxMetadata],
+    ) -> Result<Vec<Vec<bitcoin::TxOut>>, StoreError> {
+        let outputs_cf = self.db.cf_handle(&ColumnFamily::Outputs).unwrap();
+        let mut keys: Vec<String> = Vec::new();
+        // Use offsets to track ouputs for various txids to avoid using hashmap here
+        let mut offsets: Vec<usize> = Vec::with_capacity(txids.len() + 1);
+        offsets.push(0);
+        for (index, metadata) in metadatas.iter().enumerate() {
+            let txid = &txids[index];
+            for output_index in 0..metadata.output_count {
+                keys.push(format!("{txid}:{output_index}"));
+            }
+            offsets.push(keys.len());
+        }
+
+        let cf_keys: Vec<(_, &[u8])> = keys
+            .iter()
+            .map(|key| (&outputs_cf, key.as_bytes()))
+            .collect();
+        let results = self.db.multi_get_cf(cf_keys);
+        let mut decoded: Vec<bitcoin::TxOut> = Vec::with_capacity(keys.len());
+        for (index, result) in results.into_iter().enumerate() {
+            let bytes = result?.ok_or_else(|| {
+                StoreError::NotFound(format!("Output not found for {}", keys[index]))
+            })?;
+            decoded.push(encode::deserialize(&bytes).map_err(|_| {
+                StoreError::Serialization("Failed to deserialize output".to_string())
+            })?);
+        }
+
+        // group the offset based outputs for each txid
+        let mut grouped: Vec<Vec<bitcoin::TxOut>> = Vec::with_capacity(txids.len());
+        for index in 0..txids.len() {
+            grouped.push(decoded[offsets[index]..offsets[index + 1]].to_vec());
+        }
+        Ok(grouped)
+    }
+
+    /// Batch load transactions for a list of txids.
+    ///
+    /// Composes `get_metadata_for_txids`, `get_inputs`, and
+    /// `get_outputs`: three `multi_get_cf` calls total, one per column
+    /// family, independent of how many transactions are requested.
+    pub(crate) fn get_txs(&self, txids: &[Txid]) -> Result<Vec<Transaction>, StoreError> {
+        if txids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let metadatas = self.get_metadata_for_txids(txids)?;
+        let inputs = self.get_inputs(txids, &metadatas)?;
+        let outputs = self.get_outputs(txids, &metadatas)?;
+        let mut txs = Vec::with_capacity(txids.len());
+        for (metadata, (tx_inputs, tx_outputs)) in metadatas
+            .into_iter()
+            .zip(inputs.into_iter().zip(outputs.into_iter()))
+        {
+            txs.push(Transaction {
+                version: metadata.version,
+                lock_time: metadata.lock_time,
+                input: tx_inputs,
+                output: tx_outputs,
+            });
+        }
+        Ok(txs)
+    }
+
     /// Get transactions by blockhash index for sharechain transactions
-    pub(crate) fn get_sharechain_txs_by_blockhash_index(
+    pub(crate) fn get_txs_by_blockhash_index(
         &self,
         blockhash: &BlockHash,
     ) -> Result<Vec<ShareTransaction>, StoreError> {
         let txids = self.get_txids_for_blockhash(blockhash);
-        let mut txs = Vec::with_capacity(txids.0.len());
-        for txid in txids.0 {
-            txs.push(ShareTransaction(self.get_tx(&txid)?));
+        let txs = self.get_txs(&txids.0)?;
+        let mut share_txs = Vec::with_capacity(txs.len());
+        for tx in txs {
+            share_txs.push(ShareTransaction(tx));
         }
-        Ok(txs)
+        Ok(share_txs)
     }
 }
 
@@ -515,7 +709,7 @@ mod tests {
         let mut batch = Store::get_write_batch();
 
         let metadata = store
-            .add_sharechain_txs(&block.transactions, false, &mut batch)
+            .add_sharechain_txs(&block.transactions, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -524,6 +718,100 @@ mod tests {
             let tx = store.get_tx(&tx_meta.txid).unwrap();
             assert_eq!(tx.compute_txid(), tx_meta.txid);
         }
+    }
+
+    #[test]
+    fn test_get_txs_returns_empty_for_empty_input() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+        assert!(store.get_txs(&[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_get_txs_returns_every_requested_transaction() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let tx_a = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(
+                    bitcoin::hashes::sha256d::Hash::from_byte_array([0x01; 32]).into(),
+                    0,
+                ),
+                ..Default::default()
+            }],
+            output: vec![
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(100),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(200),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
+            ],
+        };
+        let tx_b = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![
+                bitcoin::TxIn {
+                    previous_output: bitcoin::OutPoint::new(
+                        bitcoin::hashes::sha256d::Hash::from_byte_array([0x02; 32]).into(),
+                        5,
+                    ),
+                    ..Default::default()
+                },
+                bitcoin::TxIn {
+                    previous_output: bitcoin::OutPoint::new(
+                        bitcoin::hashes::sha256d::Hash::from_byte_array([0x03; 32]).into(),
+                        1,
+                    ),
+                    ..Default::default()
+                },
+            ],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(300),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let txid_a = tx_a.compute_txid();
+        let txid_b = tx_b.compute_txid();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .add_sharechain_txs(
+                &[
+                    ShareTransaction(tx_a.clone()),
+                    ShareTransaction(tx_b.clone()),
+                ],
+                &mut batch,
+            )
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let loaded = store.get_txs(&[txid_a, txid_b]).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0], tx_a);
+        assert_eq!(loaded[1], tx_b);
+
+        // Order of the request drives the order of the result.
+        let reversed = store.get_txs(&[txid_b, txid_a]).unwrap();
+        assert_eq!(reversed[0], tx_b);
+        assert_eq!(reversed[1], tx_a);
+    }
+
+    #[test]
+    fn test_get_txs_errors_when_any_txid_unknown() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let unknown_txid: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([0x99; 32]).into();
+        let result = store.get_txs(&[unknown_txid]);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -551,7 +839,7 @@ mod tests {
 
         let mut batch = Store::get_write_batch();
         store
-            .add_sharechain_txs(&[ShareTransaction(funding_tx)], false, &mut batch)
+            .add_sharechain_txs(&[ShareTransaction(funding_tx)], &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -603,6 +891,241 @@ mod tests {
     }
 
     #[test]
+    fn test_is_missing_any_prevout_returns_false_for_empty_input() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+        assert!(!store.is_missing_any_prevout(&[]).unwrap());
+    }
+
+    #[test]
+    fn test_is_missing_any_prevout_returns_false_when_all_present() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let funding_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(1_000_000),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(2_000_000),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
+            ],
+        };
+        let funding_txid = funding_tx.compute_txid();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .add_sharechain_txs(&[ShareTransaction(funding_tx)], &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let outpoints = vec![
+            bitcoin::OutPoint::new(funding_txid, 0),
+            bitcoin::OutPoint::new(funding_txid, 1),
+        ];
+        assert!(!store.is_missing_any_prevout(&outpoints).unwrap());
+    }
+
+    #[test]
+    fn test_is_missing_any_prevout_returns_true_when_one_missing() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let funding_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(1_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let funding_txid = funding_tx.compute_txid();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .add_sharechain_txs(&[ShareTransaction(funding_tx)], &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let unknown_txid: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([7u8; 32]).into();
+        let outpoints = vec![
+            bitcoin::OutPoint::new(funding_txid, 0),
+            bitcoin::OutPoint::new(unknown_txid, 0),
+        ];
+        assert!(store.is_missing_any_prevout(&outpoints).unwrap());
+    }
+
+    #[test]
+    fn test_is_any_prevout_spent_returns_false_for_empty_input() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+        assert!(!store.is_any_prevout_spent(&[]).unwrap());
+    }
+
+    #[test]
+    fn test_is_any_prevout_spent_reflects_spends_index_presence() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let funding_txid: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([41u8; 32]).into();
+        let spending_txid: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([42u8; 32]).into();
+
+        // No SpendsIndex entries yet.
+        assert!(
+            !store
+                .is_any_prevout_spent(&[bitcoin::OutPoint::new(funding_txid, 0)])
+                .unwrap()
+        );
+
+        // Record vout 0 as spent via the confirmation-path helper.
+        let mut batch = rocksdb::WriteBatch::default();
+        store
+            .add_spend(&funding_txid, 0, &spending_txid, 0, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        assert!(
+            store
+                .is_any_prevout_spent(&[bitcoin::OutPoint::new(funding_txid, 0)])
+                .unwrap()
+        );
+        assert!(
+            !store
+                .is_any_prevout_spent(&[bitcoin::OutPoint::new(funding_txid, 1)])
+                .unwrap()
+        );
+        // Mixed batch with one present should report true.
+        assert!(
+            store
+                .is_any_prevout_spent(&[
+                    bitcoin::OutPoint::new(funding_txid, 1),
+                    bitcoin::OutPoint::new(funding_txid, 0),
+                ])
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_are_all_txids_confirmed_returns_true_for_empty_input() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+        assert!(store.are_all_txids_confirmed(&[]).unwrap());
+    }
+
+    #[test]
+    fn test_are_all_txids_confirmed_true_when_all_confirmed() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let txid_a: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([1u8; 32]).into();
+        let txid_b: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([2u8; 32]).into();
+
+        let blockhash = TestShareBlockBuilder::new().build().block_hash();
+        let mut batch = Store::get_write_batch();
+        store
+            .update_block_metadata(
+                &blockhash,
+                &BlockMetadata {
+                    expected_height: Some(1),
+                    chain_work: Work::from_le_bytes([1u8; 32]),
+                    status: Status::Confirmed,
+                },
+                &mut batch,
+            )
+            .unwrap();
+        store
+            .add_txids_to_blocks_index(&blockhash, &Txids(vec![txid_a, txid_b]), &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        assert!(store.are_all_txids_confirmed(&[txid_a, txid_b]).unwrap());
+    }
+
+    #[test]
+    fn test_are_all_txids_confirmed_false_when_any_uncle_only() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let txid_confirmed: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([3u8; 32]).into();
+        let txid_uncle_only: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([4u8; 32]).into();
+
+        let confirmed_blockhash = TestShareBlockBuilder::new()
+            .nonce(0xaaaa0001)
+            .build()
+            .block_hash();
+        let uncle_blockhash = TestShareBlockBuilder::new()
+            .nonce(0xaaaa0002)
+            .build()
+            .block_hash();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .update_block_metadata(
+                &confirmed_blockhash,
+                &BlockMetadata {
+                    expected_height: Some(1),
+                    chain_work: Work::from_le_bytes([1u8; 32]),
+                    status: Status::Confirmed,
+                },
+                &mut batch,
+            )
+            .unwrap();
+        store
+            .update_block_metadata(
+                &uncle_blockhash,
+                &BlockMetadata {
+                    expected_height: Some(1),
+                    chain_work: Work::from_le_bytes([1u8; 32]),
+                    status: Status::Candidate,
+                },
+                &mut batch,
+            )
+            .unwrap();
+        store
+            .add_txids_to_blocks_index(
+                &confirmed_blockhash,
+                &Txids(vec![txid_confirmed]),
+                &mut batch,
+            )
+            .unwrap();
+        store
+            .add_txids_to_blocks_index(&uncle_blockhash, &Txids(vec![txid_uncle_only]), &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        assert!(store.are_all_txids_confirmed(&[txid_confirmed]).unwrap());
+        assert!(!store.are_all_txids_confirmed(&[txid_uncle_only]).unwrap());
+        assert!(
+            !store
+                .are_all_txids_confirmed(&[txid_confirmed, txid_uncle_only])
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_are_all_txids_confirmed_false_when_unknown() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+        let unknown_txid: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([9u8; 32]).into();
+        assert!(!store.are_all_txids_confirmed(&[unknown_txid]).unwrap());
+    }
+
+    #[test]
     fn test_get_output_succeeds_for_stored_output() {
         let temp_dir = tempdir().unwrap();
         let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
@@ -626,7 +1149,7 @@ mod tests {
         let txid = tx.compute_txid();
         let mut batch = Store::get_write_batch();
         store
-            .add_sharechain_txs(&[ShareTransaction(tx)], false, &mut batch)
+            .add_sharechain_txs(&[ShareTransaction(tx)], &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -658,7 +1181,7 @@ mod tests {
         let blockhash = block.block_hash();
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&block, true, &mut batch).unwrap();
+        store.add_share_block(&block, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Verify block -> txids index (forward lookup)
@@ -711,7 +1234,7 @@ mod tests {
         let blockhash1 = block1.block_hash();
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&block1, true, &mut batch).unwrap();
+        store.add_share_block(&block1, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Verify the txid maps to the first blockhash
@@ -732,7 +1255,7 @@ mod tests {
         );
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&block2, false, &mut batch).unwrap();
+        store.add_share_block(&block2, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Verify the txid now maps to both blockhashes
@@ -755,7 +1278,7 @@ mod tests {
         let blockhash3 = block3.block_hash();
 
         let mut batch = Store::get_write_batch();
-        store.add_share_block(&block3, false, &mut batch).unwrap();
+        store.add_share_block(&block3, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         // Verify the txid now maps to all three blockhashes
@@ -896,9 +1419,7 @@ mod tests {
 
         // Add transactions to store
         let mut batch = rocksdb::WriteBatch::default();
-        store
-            .add_sharechain_txs(&transactions, true, &mut batch)
-            .unwrap();
+        store.add_sharechain_txs(&transactions, &mut batch).unwrap();
         store.db.write(batch).unwrap();
 
         // Verify transactions were stored correctly by retrieving them by txid
@@ -940,7 +1461,7 @@ mod tests {
         let txid = tx.compute_txid();
         let mut batch = rocksdb::WriteBatch::default();
         let res = store
-            .add_sharechain_txs(&[ShareTransaction(tx.clone())], true, &mut batch)
+            .add_sharechain_txs(&[ShareTransaction(tx.clone())], &mut batch)
             .unwrap();
         store.db.write(batch).unwrap();
 
@@ -963,86 +1484,6 @@ mod tests {
         assert_eq!(tx.output.len(), 1);
         assert_eq!(tx.output[0].value, bitcoin::Amount::from_sat(1000000));
         assert_eq!(tx.output[0].script_pubkey, script_true);
-    }
-
-    #[test]
-    fn test_confirm_transaction() {
-        let temp_dir = tempdir().unwrap();
-        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
-
-        // Create a previous transaction with outputs
-        let prev_tx = Transaction {
-            version: bitcoin::transaction::Version(1),
-            lock_time: bitcoin::absolute::LockTime::ZERO,
-            input: vec![],
-            output: vec![
-                bitcoin::TxOut {
-                    value: bitcoin::Amount::from_sat(1000000),
-                    script_pubkey: bitcoin::ScriptBuf::new(),
-                },
-                bitcoin::TxOut {
-                    value: bitcoin::Amount::from_sat(2000000),
-                    script_pubkey: bitcoin::ScriptBuf::new(),
-                },
-            ],
-        };
-
-        let prev_txid = prev_tx.compute_txid();
-
-        // Add the previous transaction and update spends index
-        let mut batch = rocksdb::WriteBatch::default();
-        store
-            .add_tx_metadata(prev_txid, &prev_tx, false, &mut batch)
-            .unwrap();
-        store.db.write(batch).unwrap();
-
-        // Verify outputs are not yet spent
-        assert!(store.is_spent(&prev_txid, 0).unwrap().is_none());
-        assert!(store.is_spent(&prev_txid, 1).unwrap().is_none());
-
-        // Create a new transaction that spends the previous outputs
-        let tx = Transaction {
-            version: bitcoin::transaction::Version(1),
-            lock_time: bitcoin::absolute::LockTime::ZERO,
-            input: vec![
-                bitcoin::TxIn {
-                    previous_output: bitcoin::OutPoint::new(prev_txid, 0),
-                    script_sig: bitcoin::ScriptBuf::new(),
-                    sequence: bitcoin::Sequence::MAX,
-                    witness: bitcoin::Witness::new(),
-                },
-                bitcoin::TxIn {
-                    previous_output: bitcoin::OutPoint::new(prev_txid, 1),
-                    script_sig: bitcoin::ScriptBuf::new(),
-                    sequence: bitcoin::Sequence::MAX,
-                    witness: bitcoin::Witness::new(),
-                },
-            ],
-            output: vec![bitcoin::TxOut {
-                value: bitcoin::Amount::from_sat(2900000),
-                script_pubkey: bitcoin::ScriptBuf::new(),
-            }],
-        };
-
-        let txid = tx.compute_txid();
-
-        // Confirm the transaction (should add to spend index)
-        let mut batch = rocksdb::WriteBatch::default();
-        store
-            .add_sharechain_txs(&[ShareTransaction(tx)], true, &mut batch)
-            .unwrap();
-        store.db.write(batch).unwrap();
-
-        // Verify the previous outputs are now in spends index
-        let stored = store.is_spent(&prev_txid, 0).unwrap();
-        assert!(stored.is_some());
-        assert_eq!(txid, stored.unwrap().txid);
-        assert_eq!(0, stored.unwrap().vout);
-
-        let stored_second = store.is_spent(&prev_txid, 1).unwrap();
-        assert!(stored_second.is_some());
-        assert_eq!(txid, stored_second.unwrap().txid);
-        assert_eq!(1, stored_second.unwrap().vout);
     }
 
     #[test]
@@ -1114,10 +1555,7 @@ mod tests {
         let mut batch = rocksdb::WriteBatch::default();
         store
             .add_spends_for_block(
-                &[
-                    ShareTransaction(coinbase_tx),
-                    ShareTransaction(spending_tx),
-                ],
+                &[ShareTransaction(coinbase_tx), ShareTransaction(spending_tx)],
                 &mut batch,
             )
             .unwrap();

--- a/p2poolv2_lib/src/store/transaction_store.rs
+++ b/p2poolv2_lib/src/store/transaction_store.rs
@@ -182,19 +182,84 @@ impl Store {
     /// We need to add a transaction id -> blockhash index
     pub(crate) fn add_spend(
         &self,
-        input_txid: &Txid,
-        input_vout: u32,
+        prevout_txid: &Txid,
+        prevout_index: u32,
         spending_txid: &Txid,
         spending_index: u32,
         batch: &mut WriteBatch,
     ) -> Result<(), StoreError> {
-        let key = format!("{input_txid}:{input_vout}");
+        let key = format!("{prevout_txid}:{prevout_index}");
         let spends_index_cf = self.db.cf_handle(&ColumnFamily::SpendsIndex).unwrap();
         let mut serialized = Vec::with_capacity(OUTPOINT_SIZE);
         spending_txid.consensus_encode(&mut serialized)?;
         spending_index.consensus_encode(&mut serialized)?;
         batch.put_cf::<&[u8], Vec<u8>>(&spends_index_cf, key.as_ref(), serialized);
         Ok(())
+    }
+
+    /// Delete a `SpendsIndex` entry for `(prevout_txid, prevout_index)`.
+    ///
+    /// Used by the reorg-out path when a block that previously recorded
+    /// the spend is no longer on the confirmed sharechain. `delete_cf`
+    /// leaves a RocksDB tombstone; this is acceptable at `SpendsIndex`
+    /// cardinality (bounded by inputs in reorged blocks).
+    pub(crate) fn remove_spend(
+        &self,
+        prevout_txid: &Txid,
+        prevout_index: u32,
+        batch: &mut WriteBatch,
+    ) {
+        let key = format!("{prevout_txid}:{prevout_index}");
+        let spends_index_cf = self.db.cf_handle(&ColumnFamily::SpendsIndex).unwrap();
+        batch.delete_cf::<&[u8]>(&spends_index_cf, key.as_ref());
+    }
+
+    /// Write `SpendsIndex` entries for every non-coinbase input of every
+    /// transaction in `txs`. Intended to be called from the confirmation
+    /// path so that `SpendsIndex` presence means "spent on the confirmed
+    /// sharechain".
+    pub(crate) fn add_spends_for_block(
+        &self,
+        txs: &[ShareTransaction],
+        batch: &mut WriteBatch,
+    ) -> Result<(), StoreError> {
+        for share_transaction in txs {
+            let transaction = &share_transaction.0;
+            if !transaction.is_coinbase() {
+                let spending_txid = transaction.compute_txid();
+                for (spending_index, input) in transaction.input.iter().enumerate() {
+                    self.add_spend(
+                        &input.previous_output.txid,
+                        input.previous_output.vout,
+                        &spending_txid,
+                        spending_index as u32,
+                        batch,
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Delete every `SpendsIndex` entry that `add_spends_for_block` would
+    /// have written for `txs`. Used by the reorg-out path.
+    pub(crate) fn remove_spends_for_block(
+        &self,
+        txs: &[ShareTransaction],
+        batch: &mut WriteBatch,
+    ) {
+        for share_transaction in txs {
+            let transaction = &share_transaction.0;
+            if !transaction.is_coinbase() {
+                for input in &transaction.input {
+                    self.remove_spend(
+                        &input.previous_output.txid,
+                        input.previous_output.vout,
+                        batch,
+                    );
+                }
+            }
+        }
     }
 
     /// Check if txid:vout outpoint is spent
@@ -436,8 +501,10 @@ impl Store {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store::block_tx_metadata::{BlockMetadata, Status};
     use crate::test_utils::TestShareBlockBuilder;
     use bitcoin::hashes::Hash;
+    use bitcoin::pow::Work;
     use tempfile::tempdir;
 
     #[test]
@@ -976,5 +1043,173 @@ mod tests {
         assert!(stored_second.is_some());
         assert_eq!(txid, stored_second.unwrap().txid);
         assert_eq!(1, stored_second.unwrap().vout);
+    }
+
+    #[test]
+    fn test_remove_spend_clears_spends_index_entry() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let prev_txid: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([11u8; 32]).into();
+        let spending_txid: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([12u8; 32]).into();
+
+        let mut batch = rocksdb::WriteBatch::default();
+        store
+            .add_spend(&prev_txid, 0, &spending_txid, 0, &mut batch)
+            .unwrap();
+        store.db.write(batch).unwrap();
+        assert!(store.is_spent(&prev_txid, 0).unwrap().is_some());
+
+        let mut batch = rocksdb::WriteBatch::default();
+        store.remove_spend(&prev_txid, 0, &mut batch);
+        store.db.write(batch).unwrap();
+        assert!(store.is_spent(&prev_txid, 0).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_add_spends_for_block_populates_non_coinbase_inputs() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let funding_txid: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([21u8; 32]).into();
+        let other_txid: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([22u8; 32]).into();
+
+        let coinbase_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::null(),
+                ..Default::default()
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(5_000_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+
+        let spending_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![
+                bitcoin::TxIn {
+                    previous_output: bitcoin::OutPoint::new(funding_txid, 0),
+                    ..Default::default()
+                },
+                bitcoin::TxIn {
+                    previous_output: bitcoin::OutPoint::new(other_txid, 3),
+                    ..Default::default()
+                },
+            ],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(900_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let spending_txid = spending_tx.compute_txid();
+
+        let mut batch = rocksdb::WriteBatch::default();
+        store
+            .add_spends_for_block(
+                &[
+                    ShareTransaction(coinbase_tx),
+                    ShareTransaction(spending_tx),
+                ],
+                &mut batch,
+            )
+            .unwrap();
+        store.db.write(batch).unwrap();
+
+        let spent_a = store.is_spent(&funding_txid, 0).unwrap().unwrap();
+        assert_eq!(spent_a.txid, spending_txid);
+        assert_eq!(spent_a.vout, 0);
+
+        let spent_b = store.is_spent(&other_txid, 3).unwrap().unwrap();
+        assert_eq!(spent_b.txid, spending_txid);
+        assert_eq!(spent_b.vout, 1);
+
+        // Coinbase input's null prevout must not have been written.
+        assert!(
+            store
+                .is_spent(&bitcoin::Txid::all_zeros(), u32::MAX)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_remove_spends_for_block_clears_every_non_coinbase_input() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let funding_txid: bitcoin::Txid =
+            bitcoin::hashes::sha256d::Hash::from_byte_array([31u8; 32]).into();
+
+        let spending_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![
+                bitcoin::TxIn {
+                    previous_output: bitcoin::OutPoint::new(funding_txid, 0),
+                    ..Default::default()
+                },
+                bitcoin::TxIn {
+                    previous_output: bitcoin::OutPoint::new(funding_txid, 1),
+                    ..Default::default()
+                },
+            ],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(900_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let txs = vec![ShareTransaction(spending_tx)];
+
+        let mut batch = rocksdb::WriteBatch::default();
+        store.add_spends_for_block(&txs, &mut batch).unwrap();
+        store.db.write(batch).unwrap();
+        assert!(store.is_spent(&funding_txid, 0).unwrap().is_some());
+        assert!(store.is_spent(&funding_txid, 1).unwrap().is_some());
+
+        let mut batch = rocksdb::WriteBatch::default();
+        store.remove_spends_for_block(&txs, &mut batch);
+        store.db.write(batch).unwrap();
+        assert!(store.is_spent(&funding_txid, 0).unwrap().is_none());
+        assert!(store.is_spent(&funding_txid, 1).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_add_spends_for_block_is_noop_for_coinbase_only() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let coinbase_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::null(),
+                ..Default::default()
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(5_000_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+
+        let mut batch = rocksdb::WriteBatch::default();
+        store
+            .add_spends_for_block(&[ShareTransaction(coinbase_tx)], &mut batch)
+            .unwrap();
+        store.db.write(batch).unwrap();
+
+        assert!(
+            store
+                .is_spent(&bitcoin::Txid::all_zeros(), u32::MAX)
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/p2poolv2_lib/src/store/writer/handle.rs
+++ b/p2poolv2_lib/src/store/writer/handle.rs
@@ -63,6 +63,27 @@ impl StoreHandle {
         self.store.get_all_prevouts(transaction)
     }
 
+    /// Batch check the Outputs CF: true if any outpoint is missing.
+    pub fn is_missing_any_prevout(
+        &self,
+        outpoints: &[bitcoin::OutPoint],
+    ) -> Result<bool, StoreError> {
+        self.store.is_missing_any_prevout(outpoints)
+    }
+
+    /// Batch check the SpendsIndex CF: true if any outpoint is already spent.
+    pub fn is_any_prevout_spent(
+        &self,
+        outpoints: &[bitcoin::OutPoint],
+    ) -> Result<bool, StoreError> {
+        self.store.is_any_prevout_spent(outpoints)
+    }
+
+    /// Returns true if every txid is on the confirmed sharechain.
+    pub fn are_all_txids_confirmed(&self, txids: &[bitcoin::Txid]) -> Result<bool, StoreError> {
+        self.store.are_all_txids_confirmed(txids)
+    }
+
     /// Retrieve a single transaction output by txid and output index.
     pub fn get_output(
         &self,
@@ -209,16 +230,11 @@ impl StoreHandle {
     // ========================================================================
 
     /// Add a share to the store.
-    pub async fn add_share_block(
-        &self,
-        share: ShareBlock,
-        confirm_txs: bool,
-    ) -> Result<(), StoreError> {
+    pub async fn add_share_block(&self, share: ShareBlock) -> Result<(), StoreError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.write_tx
             .send(WriteCommand::AddShareBlock {
                 share,
-                confirm_txs,
                 reply: reply_tx,
             })
             .map_err(|_| StoreError::ChannelClosed)?;
@@ -230,13 +246,11 @@ impl StoreHandle {
     pub async fn add_share_block_and_organise_header(
         &self,
         share: ShareBlock,
-        confirm_txs: bool,
     ) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.write_tx
             .send(WriteCommand::AddShareBlockAndOrganiseHeader {
                 share,
-                confirm_txs,
                 reply: reply_tx,
             })
             .map_err(|_| StoreError::ChannelClosed)?;
@@ -362,8 +376,8 @@ mockall::mock! {
         // Serialized writes (async)
         pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>;
         pub async fn organise_block(&self) -> Result<Option<u32>, StoreError>;
-        pub async fn add_share_block(&self, share: ShareBlock, confirm_txs: bool) -> Result<(), StoreError>;
-        pub async fn add_share_block_and_organise_header(&self, share: ShareBlock, confirm_txs: bool) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>;
+        pub async fn add_share_block(&self, share: ShareBlock) -> Result<(), StoreError>;
+        pub async fn add_share_block_and_organise_header(&self, share: ShareBlock) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>;
         pub async fn setup_genesis(&self, genesis: ShareBlock) -> Result<(), StoreError>;
         pub async fn init_chain_state_from_store(&self, genesis_hash: BlockHash) -> Result<(), StoreError>;
         pub async fn add_user(&self, btcaddress: String) -> Result<u64, StoreError>;

--- a/p2poolv2_lib/src/store/writer/mod.rs
+++ b/p2poolv2_lib/src/store/writer/mod.rs
@@ -91,7 +91,6 @@ pub enum WriteCommand {
     /// Add a share to the store
     AddShareBlock {
         share: ShareBlock,
-        confirm_txs: bool,
         reply: oneshot::Sender<Result<(), StoreError>>,
     },
 
@@ -101,7 +100,6 @@ pub enum WriteCommand {
     /// not organised.
     AddShareBlockAndOrganiseHeader {
         share: ShareBlock,
-        confirm_txs: bool,
         reply: oneshot::Sender<Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>>,
     },
 
@@ -191,25 +189,17 @@ impl StoreWriter {
     /// Handle a single write command
     fn handle_command(&self, cmd: WriteCommand) {
         match cmd {
-            WriteCommand::AddShareBlock {
-                share,
-                confirm_txs,
-                reply,
-            } => {
+            WriteCommand::AddShareBlock { share, reply } => {
                 debug!("Writing share: {:?}", share.block_hash());
                 let mut batch = Store::get_write_batch();
                 let result = self
                     .store
-                    .add_share_block(&share, confirm_txs, &mut batch)
+                    .add_share_block(&share, &mut batch)
                     .and_then(|_| self.store.commit_batch(batch).map_err(StoreError::from));
                 let _ = reply.send(result);
             }
 
-            WriteCommand::AddShareBlockAndOrganiseHeader {
-                share,
-                confirm_txs,
-                reply,
-            } => {
+            WriteCommand::AddShareBlockAndOrganiseHeader { share, reply } => {
                 debug!(
                     "Writing share and organising header atomically: {:?}",
                     share.block_hash()
@@ -217,7 +207,7 @@ impl StoreWriter {
                 let mut batch = Store::get_write_batch();
                 let result = self
                     .store
-                    .add_share_block(&share, confirm_txs, &mut batch)
+                    .add_share_block(&share, &mut batch)
                     .and_then(|_| self.store.organise_header(&share.header, &mut batch))
                     .and_then(|organise_result| {
                         self.store.commit_batch(batch).map_err(StoreError::from)?;

--- a/p2poolv2_tests/src/node_swarm_test.rs
+++ b/p2poolv2_tests/src/node_swarm_test.rs
@@ -261,7 +261,7 @@ async fn test_three_nodes_share_sync() {
     // Seed non-genesis shares from fixture into store 1
     for share_block in &fixture_blocks[1..] {
         chain_store_handle1
-            .add_share_block(share_block.clone(), true)
+            .add_share_block(share_block.clone())
             .await
             .unwrap();
         chain_store_handle1


### PR DESCRIPTION
Validate prevouts:

- all prevouts are confirmed
- all prevouts exist
- no prevouts are already spent
- allows txs to spend txs earlier in the same block

To support efficient prevout validations, spending index is updated when outputs are spent by txs on confirmed chain, and removed from spent when unconfirmed.