### PR TITLE
Build run with just and bring back jmeter load testing

### DIFF
--- a/load-tests/jmeter-testing/README.adoc
+++ b/load-tests/jmeter-testing/README.adoc
@@ -1,122 +1,142 @@
 == Load Tests For Stratum
 
-We use jmeter to run load tests for our implmentation of the Stratum protocol.
+We use jmeter to run load tests for our implmentation of the Stratum
+protocol.
 
 The load test is repeated with the same parameters as CKPool's stratum
 implementation. The goal of the comparison is to show that our
 implementation can handle the same load as CKPool's implementation
-with similar degradation in performance as the load increases, if any.
+with similar degradation in performance as the load increases.
+
+P2Poolv2 submit handling emits the share to share chain and handle p2p
+communication using tokio async. The submit block control flow fires
+events for handling p2p and share chare communication on an async
+tokio task. The submit loop is able to submit a share to bitcoind rpc
+and the latencies reported are as seen by the client submitting a
+share.
 
 == Results
 
 All times are round-trip latency in milliseconds as measured by the
 jmeter client. Each thread connects, subscribes, authorizes once, then
 submits shares every 3 seconds in a loop for the duration of the test.
+Every submit triggers a `submitblock` RPC call to the mock bitcoind,
+exercising the full block submission path.
 
-=== 1,000 threads, 60 second duration, 10 second ramp-up (with submitblock)
+Test machine: AMD Ryzen 7 8745H (16 cores), 13 GB RAM, Arch Linux.
 
-==== P2Poolv2 (default build) -- 19,374 samples, 52 errors
+=== 100 miners, 60 second duration, 10 second ramp-up
 
-----
-Sampler      Avg     p50     p95     p99     Max
-Subscribe    898.6   102     463     30031   30032
-Authorize    784.0   1       42      30030   30031
-Submit       0.4     0       1       2       45
-----
-
-==== P2Poolv2 (native build) -- 19,405 samples, 48 errors
+==== P2Poolv2 (default build) -- 1,977 samples, 0 errors
 
 ----
 Sampler      Avg     p50     p95     p99     Max
-Subscribe    838.0   102     423     30031   30034
-Authorize    724.1   1       44      30030   30032
-Submit       0.5     0       1       2       43
+Subscribe    115.6   103     111     450     547
+Authorize    2.8     1       2       37      37
+Submit       1.3     1       2       3       30
 ----
 
-==== CKPool -- 18,511 samples, 160 errors
-
-----
-Sampler      Avg     p50     p95     p99     Max
-Subscribe    2513.9  101     30030   30030   30033
-Authorize    2406.3  1       30030   30030   30032
-Submit       0.6     0       1       3       45
-----
-
-About 2.5% of P2Poolv2 connections and 8.0% of CKPool connections
-time out during the 10 second ramp-up storm (the 30s socket timeout
-is visible as 30,030ms in p99). Once connected, all three servers
-perform identically with sub-millisecond median submit latency.
-Default and native P2Poolv2 builds show no measurable difference --
-the stratum workload is I/O-bound, not CPU-bound. CKPool's
-single-threaded accept loop is slower under concurrent connection
-storms, while P2Poolv2's async runtime handles them more
-efficiently.
-
-=== 5,000 threads, 300 second duration, 60 second ramp-up
-
-==== P2Poolv2 (native build) -- 457,845 samples, 0 errors
+==== P2Poolv2 (native build) -- 1,977 samples, 0 errors
 
 ----
 Sampler      Avg     p50     p95     p99     Max
-Subscribe    5.4     2       2       57      650
-Authorize    0.4     0       1       24      29
-Submit       0.1     0       1       1       32
+Subscribe    115.9   103     110     454     550
+Authorize    3.0     1       2       38      38
+Submit       1.3     1       2       3       28
 ----
 
-==== CKPool -- 457,840 samples, 81,423 errors (18% on submit)
+==== CKPool -- 1,977 samples, 0 errors
 
 ----
 Sampler      Avg     p50     p95     p99     Max
-Subscribe    4.3     1       1       61      646
-Authorize    0.4     0       1       16      30
-Submit       0.2     0       1       1       40
+Subscribe    114.3   102     110     444     541
+Authorize    2.9     1       2       40      40
+Submit       1.3     1       2       2       27
+----
+
+All three servers perform identically at 100 concurrent miners with
+zero errors. Submit latency is 1.3ms avg across the board with
+`submitblock` exercised on every share.
+
+=== 1,000 miners, 60 second duration, 10 second ramp-up
+
+==== P2Poolv2 (default build) -- 19,452 samples, 42 errors
+
+----
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    748.1   102     401     30030   30031
+Authorize    633.7   1       42      30030   30031
+Submit       0.4     0       1       1       61
+----
+
+==== P2Poolv2 (native build) -- 19,436 samples, 44 errors
+
+----
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    773.8   102     333     30030   30031
+Authorize    664.2   1       56      30030   30031
+Submit       0.4     0       1       2       57
+----
+
+==== CKPool -- 18,523 samples, 158 errors
+
+----
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    2478.4  101     30026   30031   30032
+Authorize    2375.5  1       30030   30031   30032
+Submit       0.4     0       1       2       41
+----
+
+About 2% of P2Poolv2 connections and 8% of CKPool connections time
+out during the 10 second ramp-up storm (the 30s socket timeout is
+visible as 30,030ms in p99). Once connected, all three servers perform
+identically with sub-millisecond median submit latency. Default and
+native P2Poolv2 builds show no measurable difference -- the stratum
+workload is I/O-bound, not CPU-bound. CKPool's single-threaded accept
+loop is slower under concurrent connection storms, while P2Poolv2's
+async runtime handles them more efficiently.
+
+=== 5,000 miners, 300 second duration, 90 second ramp-up
+
+==== P2Poolv2 (default build) -- 432,710 samples, 0 errors
+
+----
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    104.5   101     103     112     818
+Authorize    0.6     0       1       2       44
+Submit       0.3     0       1       1       39
+----
+
+==== P2Poolv2 (native build) -- 432,712 samples, 0 errors
+
+----
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    104.0   101     103     112     754
+Authorize    0.9     0       1       3       87
+Submit       0.3     0       1       2       92
+----
+
+==== CKPool -- 432,694 samples, 112,865 errors (27% on submit)
+
+----
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    103.4   100     102     110     799
+Authorize    0.7     0       1       2       49
+Submit       0.4     0       1       2       35
 ----
 
 P2Poolv2 handles 5,000 concurrent miners for 5 minutes with zero
-errors. CKPool shows 18% submit errors under the same load -- all
-subscribe and authorize calls succeed, but CKPool rejects a portion
-of the dummy submit parameters under higher concurrency. Both servers
-maintain sub-millisecond median latency across all operations.
-
-=== 100 threads, 30 second duration, 10 second ramp-up (with submitblock)
-
-This test uses a block template with very low difficulty so every
-submit triggers a `submitblock` RPC call to the mock bitcoind,
-exercising the full block submission path.
-
-==== P2Poolv2 (default build) -- 977 samples, 0 errors
-
-----
-Sampler      Avg     p50     p95     p99     Max
-Subscribe    118.5   103     131     507     606
-Authorize    2.9     1       33      33      34
-Submit       1.4     1       2       11      38
-----
-
-==== P2Poolv2 (native build) -- 978 samples, 0 errors
-
-----
-Sampler      Avg     p50     p95     p99     Max
-Subscribe    116.8   103     140     476     572
-Authorize    3.4     1       13      45      45
-Submit       1.4     1       2       9       30
-----
-
-==== CKPool -- 979 samples, 0 errors
-
-----
-Sampler      Avg     p50     p95     p99     Max
-Subscribe    117.2   102     133     500     597
-Authorize    3.8     1       49      49      49
-Submit       1.2     1       2       11      30
-----
-
-With `submitblock` exercised on every share, P2Poolv2 and CKPool show
-nearly identical submit latency (1.2-1.4ms avg, p50=1ms).
+errors across 430K+ samples. All three servers show identical
+subscribe and authorize performance. CKPool rejects 27% of submits
+due to stale job IDs -- under load with 5,000 miners, some submits
+race with new `mining.notify` messages. The client drains pending
+notifies before each submit, but some arrive between the drain and
+the send. P2Poolv2 is more tolerant of slightly stale job IDs.
 
 == Setup
 
-The load tests uses jmeter to support spawning thousands of threads acting as ASIC miner clients.
+The load tests uses jmeter to support spawning thousands of threads
+acting as ASIC miner clients.
 
 We simulate 10,000 ASIC miners, connecting over a ramp-up time period
 of 10 seconds. Once all clients are connected, each submits a share to
@@ -254,10 +274,5 @@ Results are saved as timestamped `.jtl` files in the `results/` directory.
 
 Use the jmeter GUI to modify the load test file as needed. You can
 open the file `load-tests/stratum.jmx` in jmeter and make changes to
-the test parameters, such as the number of threads, ramp-up time, and
-other settings.
-
-[,shell]
-----
-./load-tests/run_jmeter.sh
-----
+the test parameters, such as the number of threads (miners), ramp-up
+time, and other settings.

--- a/load-tests/jmeter-testing/README.adoc
+++ b/load-tests/jmeter-testing/README.adoc
@@ -15,28 +15,42 @@ submits shares every 3 seconds in a loop for the duration of the test.
 
 === 1,000 threads, 60 second duration, 10 second ramp-up
 
-==== P2Poolv2 (native build) -- 19,822 samples, 0 errors
+==== P2Poolv2 (default build) -- 19,451 samples, 46 errors
 
 ----
-Sampler      Avg     p50     p95     Max
-Subscribe    16.8    2       53      527
-Authorize    1.5     0       21      28
-Submit       0.3     0       1       27
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    708.3   2       280     30030   30031
+Authorize    692.1   0       23      30030   30031
+Submit       0.2     0       1       1       28
 ----
 
-==== CKPool -- 19,821 samples, 0 errors
+==== P2Poolv2 (native build) -- 19,439 samples, 48 errors
 
 ----
-Sampler      Avg     p50     p95     Max
-Subscribe    17.0    1       67      549
-Authorize    1.3     0       16      23
-Submit       0.3     0       1       41
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    738.8   2       299     30031   30034
+Authorize    722.2   0       23      30030   30032
+Submit       0.2     0       1       1       32
 ----
 
-Both servers handle the load with zero errors. At 1,000 concurrent
-miners, P2Poolv2 and CKPool show nearly identical performance with
-sub-millisecond median submit latency and ~330 requests/second
-throughput.
+==== CKPool -- 18,558 samples, 158 errors
+
+----
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    2387.9  1       30030   30031   30034
+Authorize    2373.7  0       30030   30030   30031
+Submit       0.3     0       1       1       33
+----
+
+About 2.3% of P2Poolv2 connections and 7.9% of CKPool connections
+time out during the 10 second ramp-up storm (the 30s socket timeout
+is visible as 30,030ms in p99). Once connected, all three servers
+perform identically with sub-millisecond median submit latency.
+Default and native P2Poolv2 builds show no measurable difference --
+the stratum workload is I/O-bound, not CPU-bound. CKPool's
+single-threaded accept loop is slower under concurrent connection
+storms, while P2Poolv2's async runtime handles them more
+efficiently.
 
 === 5,000 threads, 300 second duration, 60 second ramp-up
 

--- a/load-tests/jmeter-testing/README.adoc
+++ b/load-tests/jmeter-testing/README.adoc
@@ -13,36 +13,36 @@ All times are round-trip latency in milliseconds as measured by the
 jmeter client. Each thread connects, subscribes, authorizes once, then
 submits shares every 3 seconds in a loop for the duration of the test.
 
-=== 1,000 threads, 60 second duration, 10 second ramp-up
+=== 1,000 threads, 60 second duration, 10 second ramp-up (with submitblock)
 
-==== P2Poolv2 (default build) -- 19,451 samples, 46 errors
-
-----
-Sampler      Avg     p50     p95     p99     Max
-Subscribe    708.3   2       280     30030   30031
-Authorize    692.1   0       23      30030   30031
-Submit       0.2     0       1       1       28
-----
-
-==== P2Poolv2 (native build) -- 19,439 samples, 48 errors
+==== P2Poolv2 (default build) -- 19,374 samples, 52 errors
 
 ----
 Sampler      Avg     p50     p95     p99     Max
-Subscribe    738.8   2       299     30031   30034
-Authorize    722.2   0       23      30030   30032
-Submit       0.2     0       1       1       32
+Subscribe    898.6   102     463     30031   30032
+Authorize    784.0   1       42      30030   30031
+Submit       0.4     0       1       2       45
 ----
 
-==== CKPool -- 18,558 samples, 158 errors
+==== P2Poolv2 (native build) -- 19,405 samples, 48 errors
 
 ----
 Sampler      Avg     p50     p95     p99     Max
-Subscribe    2387.9  1       30030   30031   30034
-Authorize    2373.7  0       30030   30030   30031
-Submit       0.3     0       1       1       33
+Subscribe    838.0   102     423     30031   30034
+Authorize    724.1   1       44      30030   30032
+Submit       0.5     0       1       2       43
 ----
 
-About 2.3% of P2Poolv2 connections and 7.9% of CKPool connections
+==== CKPool -- 18,511 samples, 160 errors
+
+----
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    2513.9  101     30030   30030   30033
+Authorize    2406.3  1       30030   30030   30032
+Submit       0.6     0       1       3       45
+----
+
+About 2.5% of P2Poolv2 connections and 8.0% of CKPool connections
 time out during the 10 second ramp-up storm (the 30s socket timeout
 is visible as 30,030ms in p99). Once connected, all three servers
 perform identically with sub-millisecond median submit latency.
@@ -77,6 +77,42 @@ errors. CKPool shows 18% submit errors under the same load -- all
 subscribe and authorize calls succeed, but CKPool rejects a portion
 of the dummy submit parameters under higher concurrency. Both servers
 maintain sub-millisecond median latency across all operations.
+
+=== 100 threads, 30 second duration, 10 second ramp-up (with submitblock)
+
+This test uses a block template with very low difficulty so every
+submit triggers a `submitblock` RPC call to the mock bitcoind,
+exercising the full block submission path.
+
+==== P2Poolv2 (default build) -- 977 samples, 0 errors
+
+----
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    118.5   103     131     507     606
+Authorize    2.9     1       33      33      34
+Submit       1.4     1       2       11      38
+----
+
+==== P2Poolv2 (native build) -- 978 samples, 0 errors
+
+----
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    116.8   103     140     476     572
+Authorize    3.4     1       13      45      45
+Submit       1.4     1       2       9       30
+----
+
+==== CKPool -- 979 samples, 0 errors
+
+----
+Sampler      Avg     p50     p95     p99     Max
+Subscribe    117.2   102     133     500     597
+Authorize    3.8     1       49      49      49
+Submit       1.2     1       2       11      30
+----
+
+With `submitblock` exercised on every share, P2Poolv2 and CKPool show
+nearly identical submit latency (1.2-1.4ms avg, p50=1ms).
 
 == Setup
 

--- a/load-tests/jmeter-testing/benchmark.sh
+++ b/load-tests/jmeter-testing/benchmark.sh
@@ -28,7 +28,7 @@ MOCK_BITCOIND_DIR="${SCRIPT_DIR}/mock-bitcoind"
 JMX_FILE="${SCRIPT_DIR}/stratum.jmx"
 CKPOOL_CONFIG="${SCRIPT_DIR}/ckpool-testnet4-solo.json"
 
-CONFIG="${PROJECT_ROOT}/config-load-test.toml"
+CONFIG="./config-load-test.toml"
 SKIP_DEFAULT=false
 SKIP_NATIVE=false
 CKPOOL_BIN=""

--- a/load-tests/jmeter-testing/benchmark.sh
+++ b/load-tests/jmeter-testing/benchmark.sh
@@ -206,8 +206,9 @@ start_ckpool() {
 
 run_jmeter() {
     local output_file="$1"
+    local jmeter_log="${output_file%.jtl}-jmeter.log"
     log "Running jmeter load test -> ${output_file}"
-    jmeter -n -t "${JMX_FILE}" -l "${output_file}" 2>&1
+    jmeter -n -t "${JMX_FILE}" -l "${output_file}" -j "${jmeter_log}" 2>&1 | grep "^summary"
     log "jmeter complete"
 }
 

--- a/load-tests/jmeter-testing/config-load-test.toml
+++ b/load-tests/jmeter-testing/config-load-test.toml
@@ -1,0 +1,76 @@
+[network]
+listen_address = "/ip4/127.0.0.1/tcp/6884"
+dial_peers = []
+max_pending_incoming = 10
+max_pending_outgoing = 10
+max_established_incoming = 50
+max_established_outgoing = 50
+max_established_per_peer = 1
+max_workbase_per_second = 10
+max_userworkbase_per_second = 10
+max_miningshare_per_second = 100
+max_inventory_per_second = 100
+max_transaction_per_second = 100
+rate_limit_window_secs = 1
+max_requests_per_second = 1
+peer_inactivity_timeout_secs = 60
+dial_timeout_secs = 30
+
+[store]
+path = "./store.db"
+background_task_frequency_hours = 24
+pplns_ttl_days = 7
+
+[stratum]
+donation_address = "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk"
+donation = 10000
+# ignore_difficulty = true
+
+hostname = "0.0.0.0"
+port = 3333
+start_difficulty = 10000
+minimum_difficulty = 100
+solo_address = "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk"
+# The bitcoin address to use for first jobs when there are no shares
+bootstrap_address = "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk"
+# Any donation amount for developers to be sent to donation address. Default no donation.
+# donation_address = "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk"
+# In basis points, 1% = 100 basis points. Default 0
+# donation = 0
+# Any fee amount for node/hydrapool provider to be sent to fee address. Default no fee.
+# fee_address = "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk"
+# In basis points, 1% = 100 basis points. Default 0
+# fee = 0
+zmqpubhashblock = "tcp://127.0.0.1:28332"
+# The network can be "main", "testnet4" or "signet"
+network = "signet"
+version_mask = "1fffe000"
+# The difficulty multiplier defines the window size for calculating payout proportions
+# See https://github.com/p2poolv2/p2poolv2/wiki/Difficult-Multiplier on how to choose this
+difficulty_multiplier = 1.0
+# Add a pool signature, if you want. Comment out the line if you want
+# to mine anonymous blocks. This signature is only used to show others
+# how large your pool is, if you are running private, there is no need
+# to add a pool signature. Maximum length 16 bytes.
+pool_signature = "P2Poolv2"
+
+[bitcoinrpc]
+# RPC credentials are loaded from env vars
+url = "http://127.0.0.1:48332"
+username = "p2pool"
+password = "p2pool"
+
+[logging]
+# Specify a file path for the log file, if no log file is specified, console logging will be used
+# file = "./logs/p2pool.log"
+level = "info"
+# Pool, user and worker stats are dumped for consumption by stats tools
+stats_dir = "./logs/stats"
+
+[api]
+hostname = "127.0.0.1"
+port = 46884
+# Optional authentication credentials
+# auth_user = "admin"
+# auth_token is of the format salt:password-hmac. Use can p2poolv2_cli gen-auth to generate a token.
+# auth_token = "your_secret_token"

--- a/load-tests/jmeter-testing/flamegraph-README.adoc
+++ b/load-tests/jmeter-testing/flamegraph-README.adoc
@@ -1,0 +1,57 @@
+== Flamegraph Profiling
+
+The `flamegraph.sh` script generates a CPU flamegraph of P2Poolv2
+while it handles stratum load from jmeter. The flamegraph shows where
+CPU time is spent across all functions, making it easy to identify
+hotspots in the submit, validation, and block submission paths.
+
+=== Prerequisites
+
+- `perf` -- Linux performance counters tool
+- `cargo-flamegraph` -- install with `cargo install flamegraph`
+- `jmeter` -- load test runner (requires Java 21)
+- `node` / `npm` -- for the mock-bitcoind server
+
+=== Usage
+
+[,shell]
+----
+cd load-tests/jmeter-testing
+JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./flamegraph.sh
+----
+
+The script:
+
+1. Starts mock-bitcoind on port 48332
+2. Builds P2Poolv2 in release mode with debug symbols and frame pointers
+3. Runs P2Poolv2 under `perf record` via `cargo flamegraph`
+4. Waits for the stratum server to start listening on port 3333
+5. Runs the jmeter load test defined in `stratum.jmx`
+6. Sends SIGINT to stop perf recording
+7. Generates `flamegraph_loadtest.svg` in the project root
+
+=== Viewing the flamegraph
+
+Open the SVG in a browser for interactive exploration:
+
+[,shell]
+----
+xdg-open ../../flamegraph_loadtest.svg
+----
+
+=== Build flags
+
+The script sets these flags to ensure accurate stack traces:
+
+- `CARGO_PROFILE_RELEASE_DEBUG=true` -- includes debug symbols in the
+  release binary
+- `CARGO_PROFILE_RELEASE_STRIP=false` -- prevents stripping symbols
+- `RUSTFLAGS="-C force-frame-pointers=yes"` -- enables frame pointers
+  for accurate call graph unwinding
+
+=== Adjusting the load
+
+The jmeter test parameters (thread count, ramp-up, duration) are
+defined in `stratum.jmx`. Edit these to change the profiling
+workload. More threads and longer duration produce more samples and a
+more representative flamegraph.

--- a/load-tests/jmeter-testing/flamegraph.sh
+++ b/load-tests/jmeter-testing/flamegraph.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# Generate a flamegraph of P2Poolv2 under jmeter load.
+#
+# Prerequisites:
+#   - perf installed
+#   - cargo-flamegraph installed (cargo install flamegraph)
+#   - jmeter installed and in PATH
+#   - node/npm installed
+#
+# Usage:
+#   cd load-tests/jmeter-testing
+#   JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./flamegraph.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+MOCK_BITCOIND_DIR="${SCRIPT_DIR}/mock-bitcoind"
+JMX_FILE="${SCRIPT_DIR}/stratum.jmx"
+CONFIG="${PROJECT_ROOT}/config-load-test.toml"
+OUTPUT="flamegraph_loadtest.svg"
+
+MOCK_PID=""
+PERF_PID=""
+
+log() {
+    echo "[$(date '+%H:%M:%S')] $*"
+}
+
+cleanup() {
+    log "Cleaning up..."
+    if [[ -n "${PERF_PID}" ]]; then
+        # Find the perf record child process and send SIGINT
+        local perf_child
+        perf_child=$(pgrep -P "${PERF_PID}" -f "perf record" 2>/dev/null || true)
+        if [[ -n "${perf_child}" ]]; then
+            kill -INT "${perf_child}" 2>/dev/null || true
+        fi
+        kill -INT "${PERF_PID}" 2>/dev/null || true
+        wait "${PERF_PID}" 2>/dev/null || true
+    fi
+    if [[ -n "${MOCK_PID}" ]] && kill -0 "${MOCK_PID}" 2>/dev/null; then
+        kill "${MOCK_PID}" 2>/dev/null || true
+        wait "${MOCK_PID}" 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT
+
+# Start mock-bitcoind
+log "Starting mock-bitcoind..."
+cd "${MOCK_BITCOIND_DIR}"
+npm install --silent 2>/dev/null
+node server.js > /dev/null 2>&1 &
+MOCK_PID=$!
+cd "${SCRIPT_DIR}"
+sleep 2
+log "mock-bitcoind running (PID: ${MOCK_PID})"
+
+# Build and run P2Poolv2 under flamegraph
+log "Building P2Poolv2 with debug symbols and starting under perf..."
+cd "${PROJECT_ROOT}"
+CARGO_PROFILE_RELEASE_DEBUG=true \
+CARGO_PROFILE_RELEASE_STRIP=false \
+RUSTFLAGS="-C force-frame-pointers=yes" \
+    cargo flamegraph -p p2poolv2_node -o "${OUTPUT}" -- --config="${CONFIG}" > /tmp/flamegraph-build.log 2>&1 &
+PERF_PID=$!
+cd "${SCRIPT_DIR}"
+
+# Wait for stratum server to start listening
+log "Waiting for P2Poolv2 to start..."
+for i in $(seq 1 180); do
+    if lsof -i :3333 >/dev/null 2>&1; then
+        log "P2Poolv2 stratum listening on port 3333 (after ${i}s)"
+        break
+    fi
+    sleep 1
+done
+
+if ! lsof -i :3333 >/dev/null 2>&1; then
+    log "ERROR: P2Poolv2 did not start within 180s"
+    tail -20 /tmp/flamegraph-build.log
+    exit 1
+fi
+
+# Run jmeter load test
+log "Running jmeter load test..."
+jmeter -n -t "${JMX_FILE}" -l /tmp/flamegraph-loadtest.jtl -j /tmp/flamegraph-jmeter.log 2>&1 | grep "^summary"
+log "jmeter complete"
+
+# Stop perf recording to generate flamegraph
+log "Stopping P2Poolv2 and generating flamegraph..."
+# Find the actual perf record process (child of cargo-flamegraph)
+PERF_RECORD_PID=$(pgrep -f "perf record.*p2poolv2" 2>/dev/null || true)
+if [[ -n "${PERF_RECORD_PID}" ]]; then
+    kill -INT "${PERF_RECORD_PID}" 2>/dev/null || true
+    log "Sent SIGINT to perf record (PID: ${PERF_RECORD_PID})"
+fi
+
+log "Waiting for flamegraph generation (symbol resolution takes time)..."
+wait "${PERF_PID}" 2>/dev/null || true
+PERF_PID=""
+
+if [[ -f "${PROJECT_ROOT}/${OUTPUT}" ]]; then
+    log "Flamegraph saved to ${PROJECT_ROOT}/${OUTPUT}"
+    log "Open with: xdg-open ${PROJECT_ROOT}/${OUTPUT}"
+else
+    log "ERROR: Flamegraph was not generated"
+    tail -20 /tmp/flamegraph-build.log
+    exit 1
+fi

--- a/load-tests/jmeter-testing/mock-bitcoind/server.js
+++ b/load-tests/jmeter-testing/mock-bitcoind/server.js
@@ -4,9 +4,14 @@ const path = require('path');
 
 const gbtPath = path.join(
     __dirname,
-    "../../../p2poolv2_tests/test_data/gbt/signet/gbt-no-transactions.json",
+    "../../../p2poolv2_tests/test_data/validation/stratum/b/template.json",
 );
 const gbt = JSON.parse(fs.readFileSync(gbtPath, "utf8"));
+
+// Override difficulty to be extremely easy so every submit triggers
+// submitblock, regardless of the enonce1 assigned by the stratum server.
+gbt.bits = "2100ffff";
+gbt.target = "ffff000000000000000000000000000000000000000000000000000000000000";
 
 const methods = {
     getblocktemplate: function () {
@@ -70,7 +75,6 @@ net.createServer({ noDelay: true }, (socket) => {
         const body = buffer.subarray(bodyStart, bodyStart + contentLength).toString();
         buffer = buffer.subarray(bodyStart + contentLength);
 
-        console.log(`Received request: ${body}`);
 
         let parsed;
         try {

--- a/load-tests/jmeter-testing/stratum.jmx
+++ b/load-tests/jmeter-testing/stratum.jmx
@@ -10,9 +10,9 @@
     </TestPlan>
     <hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group">
-        <intProp name="ThreadGroup.num_threads">5000</intProp>
+        <intProp name="ThreadGroup.num_threads">1000</intProp>
         <intProp name="ThreadGroup.ramp_time">60</intProp>
-        <longProp name="ThreadGroup.duration">300</longProp>
+        <longProp name="ThreadGroup.duration">120</longProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
         <boolProp name="ThreadGroup.scheduler">true</boolProp>
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
@@ -66,6 +66,7 @@
           <stringProp name="cacheKey">true</stringProp>
           <stringProp name="script">import java.net.Socket
 import java.io.*
+import groovy.json.JsonSlurper
 
 long startTime = System.nanoTime()
 
@@ -81,13 +82,29 @@ vars.putObject(&quot;writer&quot;, writer)
 writer.print(&apos;{&quot;id&quot;:1,&quot;method&quot;:&quot;mining.subscribe&quot;,&quot;params&quot;:[&quot;jmeter/1.0&quot;]}\n&apos;)
 writer.flush()
 
+// Read subscribe response (blocking).
 def response = reader.readLine()
+
+// Drain any immediately available messages (set_difficulty, notify)
+// without blocking, and capture job ID from mining.notify.
+def parser = new JsonSlurper()
+def allResponses = [response]
+Thread.sleep(100)
+while (reader.ready()) {
+    def line = reader.readLine()
+    if (line != null) {
+        allResponses.add(line)
+        def msg = parser.parseText(line)
+        if (msg.method == &quot;mining.notify&quot;) { vars.put(&quot;jobId&quot;, msg.params[0]) }
+    }
+}
+
 long endTime = System.nanoTime()
 
 SampleResult.setLatency(((endTime - startTime) / 1_000_000) as long)
 SampleResult.sampleEnd()
 SampleResult.setSuccessful(response != null)
-SampleResult.setResponseData(response ?: &quot;no response&quot;, &quot;UTF-8&quot;)
+SampleResult.setResponseData(allResponses.join(&quot;\n&quot;), &quot;UTF-8&quot;)
 SampleResult.setResponseMessage(&quot;Subscribe response&quot;)
 SampleResult.setDataType(SampleResult.TEXT)
 SampleResult.setResponseCodeOK()
@@ -99,21 +116,49 @@ SampleResult.setResponseCodeOK()
           <stringProp name="parameters"></stringProp>
           <stringProp name="filename"></stringProp>
           <stringProp name="cacheKey">true</stringProp>
-          <stringProp name="script">def writer = vars.getObject(&quot;writer&quot;)
+          <stringProp name="script">import groovy.json.JsonSlurper
+
+def writer = vars.getObject(&quot;writer&quot;)
 def reader = vars.getObject(&quot;reader&quot;)
+
+// Drain any pending messages before sending authorize
+def parser = new JsonSlurper()
+while (reader.ready()) {
+    def line = reader.readLine()
+    if (line != null) {
+        def msg = parser.parseText(line)
+        if (msg.method == &quot;mining.notify&quot;) { vars.put(&quot;jobId&quot;, msg.params[0]) }
+    }
+}
 
 long startTime = System.nanoTime()
 
 writer.print(&apos;{&quot;id&quot;:2,&quot;method&quot;:&quot;mining.authorize&quot;,&quot;params&quot;:[&quot;tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk&quot;,&quot;x&quot;]}\n&apos;)
 writer.flush()
 
-def response = reader.readLine()
+// Read the authorize response. The server may send set_difficulty
+// or notify before the authorize response, so keep reading until
+// we find id:2.
+def authorizeResponse = null
+def allResponses = []
+
+for (int i = 0; i &lt; 5 &amp;&amp; authorizeResponse == null; i++) {
+    def line = reader.readLine()
+    if (line == null) { allResponses.add(&quot;null response&quot;); }
+    else {
+        allResponses.add(line)
+        def msg = parser.parseText(line)
+        if (msg.id == 2) { authorizeResponse = line }
+        if (msg.method == &quot;mining.notify&quot;) { vars.put(&quot;jobId&quot;, msg.params[0]) }
+    }
+}
+
 long endTime = System.nanoTime()
 
 SampleResult.setLatency(((endTime - startTime) / 1_000_000) as long)
 SampleResult.sampleEnd()
-SampleResult.setSuccessful(response != null)
-SampleResult.setResponseData(response ?: &quot;no response&quot;, &quot;UTF-8&quot;)
+SampleResult.setSuccessful(authorizeResponse != null)
+SampleResult.setResponseData(allResponses.join(&quot;\n&quot;), &quot;UTF-8&quot;)
 SampleResult.setResponseMessage(&quot;Authorize response&quot;)
 SampleResult.setDataType(SampleResult.TEXT)
 SampleResult.setResponseCodeOK()
@@ -135,17 +180,32 @@ SampleResult.setResponseCodeOK()
             <stringProp name="parameters"></stringProp>
             <stringProp name="filename"></stringProp>
             <stringProp name="cacheKey">true</stringProp>
-            <stringProp name="script">def writer = vars.getObject(&quot;writer&quot;)
+            <stringProp name="script">import groovy.json.JsonSlurper
+
+def writer = vars.getObject(&quot;writer&quot;)
 def reader = vars.getObject(&quot;reader&quot;)
+def socket = vars.getObject(&quot;socket&quot;)
+
+// Drain any pending notify messages and update the job ID
+def parser = new JsonSlurper()
+while (reader.ready()) {
+    def line = reader.readLine()
+    if (line != null) {
+        def msg = parser.parseText(line)
+        if (msg.method == &quot;mining.notify&quot;) { vars.put(&quot;jobId&quot;, msg.params[0]) }
+    }
+}
+
+def jobId = vars.get(&quot;jobId&quot;) ?: &quot;0000000000000000&quot;
 
 def submit = [
     id     : 3,
     method : &quot;mining.submit&quot;,
     params : [&quot;tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk&quot;,
-        &quot;184809ff85923e7d&quot;,
+        jobId,
         &quot;0000000000000000&quot;,
-        &quot;6849afec&quot;,
-        &quot;e33674f1&quot;
+        &quot;67b6f938&quot;,
+        &quot;f15f1590&quot;
     ]
 ]
 

--- a/load-tests/jmeter-testing/stratum.jmx
+++ b/load-tests/jmeter-testing/stratum.jmx
@@ -10,9 +10,9 @@
     </TestPlan>
     <hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group">
-        <intProp name="ThreadGroup.num_threads">1000</intProp>
-        <intProp name="ThreadGroup.ramp_time">60</intProp>
-        <longProp name="ThreadGroup.duration">120</longProp>
+        <intProp name="ThreadGroup.num_threads">100</intProp>
+        <intProp name="ThreadGroup.ramp_time">10</intProp>
+        <longProp name="ThreadGroup.duration">30</longProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
         <boolProp name="ThreadGroup.scheduler">true</boolProp>
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>

--- a/load-tests/jmeter-testing/stratum.jmx
+++ b/load-tests/jmeter-testing/stratum.jmx
@@ -10,9 +10,9 @@
     </TestPlan>
     <hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group">
-        <intProp name="ThreadGroup.num_threads">100</intProp>
-        <intProp name="ThreadGroup.ramp_time">10</intProp>
-        <longProp name="ThreadGroup.duration">30</longProp>
+        <intProp name="ThreadGroup.num_threads">5000</intProp>
+        <intProp name="ThreadGroup.ramp_time">60</intProp>
+        <longProp name="ThreadGroup.duration">300</longProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
         <boolProp name="ThreadGroup.scheduler">true</boolProp>
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>

--- a/p2poolv2_lib/src/shares/validation/bitcoin_block_validation.rs
+++ b/p2poolv2_lib/src/shares/validation/bitcoin_block_validation.rs
@@ -16,7 +16,7 @@
 
 use super::ValidationError;
 use bitcoin::consensus::encode::serialize;
-use bitcoindrpc::{BitcoinRpcConfig, BitcoindRpcClient};
+use bitcoindrpc::BitcoindRpcClient;
 use serde_json::json;
 
 /// Validate the bitcoin block.
@@ -24,7 +24,7 @@ use serde_json::json;
 #[allow(dead_code)]
 pub async fn validate_bitcoin_block(
     block: &bitcoin::Block,
-    config: &BitcoinRpcConfig,
+    bitcoindrpc_client: &BitcoindRpcClient,
 ) -> Result<bool, ValidationError> {
     // Serialize block to hex string for RPC call
     let block_hex = hex::encode(serialize(block));
@@ -35,10 +35,9 @@ pub async fn validate_bitcoin_block(
         "data": block_hex
     })];
 
-    // Call getblocktemplate RPC method using config values
-    let bitcoind = BitcoindRpcClient::new(&config.url, &config.username, &config.password)
-        .map_err(|e| ValidationError::new(format!("Bitcoin block validation failed: {e}")))?;
-    let result: Result<serde_json::Value, _> = bitcoind.request("getblocktemplate", params).await;
+    // Call getblocktemplate RPC method
+    let result: Result<serde_json::Value, _> =
+        bitcoindrpc_client.request("getblocktemplate", params).await;
 
     match result {
         Ok(response) => Ok(response == "duplicate"),
@@ -53,7 +52,7 @@ mod tests {
     use super::*;
     use base64::Engine;
     use bitcoin::consensus::Decodable;
-    use bitcoindrpc::BitcoinRpcConfig;
+    use bitcoindrpc::{BitcoinRpcConfig, BitcoindRpcClient};
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
         matchers::{body_json, header, method, path},
@@ -103,7 +102,9 @@ mod tests {
         };
 
         // Test validation
-        let result = validate_bitcoin_block(&block, &config).await;
+        let client =
+            BitcoindRpcClient::new(&config.url, &config.username, &config.password).unwrap();
+        let result = validate_bitcoin_block(&block, &client).await;
         assert!(result.is_ok());
         assert!(result.unwrap());
     }
@@ -152,7 +153,9 @@ mod tests {
         };
 
         // Test validation
-        let result = validate_bitcoin_block(&block, &config).await;
+        let client =
+            BitcoindRpcClient::new(&config.url, &config.username, &config.password).unwrap();
+        let result = validate_bitcoin_block(&block, &client).await;
         assert!(result.is_ok());
         assert!(!result.unwrap());
     }
@@ -197,7 +200,9 @@ mod tests {
         };
 
         // Test validation
-        let result = validate_bitcoin_block(&block, &config).await;
+        let client =
+            BitcoindRpcClient::new(&config.url, &config.username, &config.password).unwrap();
+        let result = validate_bitcoin_block(&block, &client).await;
         assert!(result.is_err());
     }
 }

--- a/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
@@ -135,6 +135,7 @@ mod tests {
     use crate::stratum::server::StratumContext;
     use crate::stratum::work::tracker::start_tracker_actor;
     use crate::test_utils::setup_test_chain_store_handle;
+    use bitcoindrpc::BitcoindRpcClient;
     use bitcoindrpc::test_utils::setup_mock_bitcoin_rpc;
     use tokio::sync::mpsc;
 
@@ -160,7 +161,12 @@ mod tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle,
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 1000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -253,7 +259,12 @@ mod tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle,
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 1000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -385,7 +396,12 @@ mod tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle,
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 1000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -479,7 +495,12 @@ mod tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle,
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 1000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -28,7 +28,7 @@ use crate::stratum::work::tracker::JobId;
 use bitcoin::block::Header;
 use bitcoin::blockdata::block::Block;
 use bitcoin::hashes::Hash;
-use bitcoindrpc::{BitcoinRpcConfig, BitcoindRpcClient};
+use bitcoindrpc::BitcoindRpcClient;
 use serde_json::json;
 use std::time::SystemTime;
 use tracing::{debug, error, info};
@@ -112,7 +112,7 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
             validation_result.coinbase.clone(),
             &job.blocktemplate,
         );
-        submit_block(&block, stratum_context.bitcoinrpc_config).await;
+        submit_block(&block, &stratum_context.bitcoindrpc_client).await;
     }
 
     // In p2poolv2 mode, reject shares that do not meet the pool difficulty target.
@@ -207,27 +207,15 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
     }
 }
 
-/// Submit block to bitcoind
-///
-/// Build bitcoindrpc from config and call submit block
-pub async fn submit_block(block: &Block, bitcoinrpc_config: BitcoinRpcConfig) {
+/// Submit block to bitcoind using the shared RPC client.
+pub async fn submit_block(block: &Block, bitcoindrpc_client: &BitcoindRpcClient) {
     tracing::warn!(
         "Submitting block to bitcoind: {:?}",
         block.header.block_hash()
     );
-    let rpc = BitcoindRpcClient::new(
-        &bitcoinrpc_config.url,
-        &bitcoinrpc_config.username,
-        &bitcoinrpc_config.password,
-    );
-    match rpc {
-        Ok(bitcoind) => match bitcoind.submit_block(block).await {
-            Ok(_) => info!("Block submitted successfully"),
-            Err(e) => error!("Failed to submit block: {}", e),
-        },
-        Err(e) => {
-            error!("Failed to create Bitcoind RPC client: {}", e);
-        }
+    match bitcoindrpc_client.submit_block(block).await {
+        Ok(_) => info!("Block submitted successfully"),
+        Err(e) => error!("Failed to submit block: {}", e),
     }
 }
 
@@ -331,7 +319,12 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -419,7 +412,12 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -507,7 +505,12 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -593,7 +596,12 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -655,7 +663,12 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -722,7 +735,12 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -808,7 +826,12 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx: notify_tx.clone(),
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config: bitcoinrpc_config.clone(),
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -839,7 +862,12 @@ mod handle_submit_tests {
         let ctx2 = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -912,7 +940,12 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -32,7 +32,7 @@ use crate::stratum::work::notify::NotifySender;
 use crate::stratum::work::prepared_notify::{PreparedNotifyParams, build_notify_from_prepared};
 use crate::stratum::work::tracker::JobTracker;
 use crate::utils::time_provider::{SystemTimeProvider, TimeProvider};
-use bitcoindrpc::BitcoinRpcConfig;
+use bitcoindrpc::{BitcoinRpcConfig, BitcoindRpcClient};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -192,6 +192,18 @@ impl StratumServer {
     ) -> Result<(), Box<dyn std::error::Error + Send>> {
         info!("Starting Stratum server at {}:{}", self.hostname, self.port);
 
+        let bitcoindrpc_client = BitcoindRpcClient::new(
+            &bitcoinrpc_config.url,
+            &bitcoinrpc_config.username,
+            &bitcoinrpc_config.password,
+        )
+        .map_err(|e| -> Box<dyn std::error::Error + Send> {
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to create BitcoindRpcClient: {}", e),
+            ))
+        })?;
+
         let bind_address = format!("{}:{}", self.hostname, self.port);
         let listener = match TcpListener::bind(&bind_address).await {
             Ok(listener) => listener,
@@ -232,7 +244,7 @@ impl StratumServer {
                             let ctx = StratumContext {
                                 notify_tx: notify_tx.clone(),
                                 tracker_handle: tracker_handle.clone(),
-                                bitcoinrpc_config: bitcoinrpc_config.clone(),
+                                bitcoindrpc_client: bitcoindrpc_client.clone(),
                                 start_difficulty: self.start_difficulty,
                                 minimum_difficulty: self.minimum_difficulty,
                                 maximum_difficulty: self.maximum_difficulty,
@@ -285,7 +297,7 @@ impl StratumServer {
 pub(crate) struct StratumContext {
     pub notify_tx: NotifySender,
     pub tracker_handle: Arc<JobTracker>,
-    pub bitcoinrpc_config: BitcoinRpcConfig,
+    pub bitcoindrpc_client: BitcoindRpcClient,
     pub start_difficulty: u64,
     pub minimum_difficulty: u64,
     pub maximum_difficulty: Option<u64>,
@@ -618,7 +630,12 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             metrics: metrics_handle,
             start_difficulty: 10000,
             minimum_difficulty: 1,
@@ -735,7 +752,12 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             metrics: metrics_handle,
             start_difficulty: 10000,
             minimum_difficulty: 1,
@@ -806,7 +828,12 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -882,7 +909,12 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -978,7 +1010,12 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -1093,7 +1130,12 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -1198,7 +1240,12 @@ mod stratum_server_tests {
             let ctx = StratumContext {
                 notify_tx,
                 tracker_handle: tracker_handle.clone(),
-                bitcoinrpc_config,
+                bitcoindrpc_client: BitcoindRpcClient::new(
+                    &bitcoinrpc_config.url,
+                    &bitcoinrpc_config.username,
+                    &bitcoinrpc_config.password,
+                )
+                .unwrap(),
                 metrics: metrics_handle,
                 start_difficulty: 10000,
                 minimum_difficulty: 1,
@@ -1275,7 +1322,12 @@ mod stratum_server_tests {
             let ctx = StratumContext {
                 notify_tx,
                 tracker_handle: tracker_handle.clone(),
-                bitcoinrpc_config,
+                bitcoindrpc_client: BitcoindRpcClient::new(
+                    &bitcoinrpc_config.url,
+                    &bitcoinrpc_config.username,
+                    &bitcoinrpc_config.password,
+                )
+                .unwrap(),
                 metrics: metrics_handle,
                 start_difficulty: 10000,
                 minimum_difficulty: 1,
@@ -1410,7 +1462,12 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             metrics: metrics_handle,
             start_difficulty: 10000,
             minimum_difficulty: 1,
@@ -1534,7 +1591,12 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             metrics: metrics_handle,
             start_difficulty: 10000,
             minimum_difficulty: 1,
@@ -1668,7 +1730,12 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoinrpc_config,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
             metrics: metrics_handle,
             start_difficulty: 10000,
             minimum_difficulty: 1,


### PR DESCRIPTION
Add instructions to build pool with just and cargo. This is already deprecated because the results from load testing between cpu native c rustflags and default release build show native builds are not any more performant. This is probably because bitcoin hashes uses run time detection of native sha instructions.

## Jmeter Load Testing

We bring back jmeter load testing and improve submit handling to make sure we capture the control flow to submit blocks to bitcoind. bitcoind is still mocked as as a node server that accepts all submitted blocks.

The results are in the [README.adoc](./load-tests/jmeter-testing/README.adoc). It shows P2Poolv2 stratum implementation is as performant as CKPool. This is while P2Poolv2 also handle emitting shares to share chain and p2p network. This is all possible thanks to tokio's async runtime.

## Flamegraph

We also commit a script to run perf and cargo-flamegraph while loading P2Poolv2 using jmeter. This helped us detect the incorrect usage of reqwest crate to submit blocks to bitcoind.

There's a [flamegraph-README.md]( load-tests/jmeter-testing/flamegraph-README.md) with instructions on how to run it.