### PR TITLE
Validate segwit commitment for share blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Input value sufficiency validation: non-coinbase share transactions
+  are rejected if total input value is less than total output value,
+  and total input value must not exceed `Amount::MAX_MONEY`
+  
+- Sigop cost validation: share blocks are rejected when the aggregate
+  BIP141 sigop cost exceeds `MAX_BLOCK_SIGOPS_COST` (80000), using
+  `Transaction::total_sigop_cost` with the collected spent outputs
+
+- BIP141 witness commitment on the share coinbase: the coinbase now
+  carries a second output containing `SHA256d(witness_root ||
+  reserved_value)` over wtxids of the share transactions (coinbase
+  wtxid replaced with all-zeros per BIP141), and the coinbase input
+  carries the 32-byte witness reserved value on its witness stack
+
+- `validate_share_witness_commitment` validator recomputes the
+  witness root and compares it against the embedded commitment
+
+- `StoredTxIn` wrapper persists TxIn witness data in the Inputs CF
+  (bitcoin's `TxIn::consensus_encode` does not include witness, since
+  BIP144 serializes witnesses at the Transaction level)
+
+### Changed
+
+- **Breaking database change**: the Inputs CF now stores TxIn bytes
+  followed by the witness encoding via `StoredTxIn`. Existing
+  databases populated by earlier versions cannot be read; users must
+  resync from genesis. `rm -rf store.db` and then start again.
+
+- `create_coinbase_transaction` now takes the other share
+  transactions so it can compute the BIP141 witness commitment
+
+- `validate_share_coinbase` expects two coinbase outputs (payout +
+  witness commitment) instead of one
+
+- `validate_scripts` refactored to `validate_scripts_values_and_sigops`
+  which collects spent outputs once per transaction and runs script,
+  value, and sigop validation in a single pass
+
+### Fixed
+
+- `test_three_nodes_share_sync` ignored: the
+  `test_data/share_sync/share_blocks.json` fixture predates the
+  BIP141 share coinbase format and needs regeneration
+
 ## [v0.9.1] - 2026-04-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.10.0] - 2026-04-16
+
 ### Added
 
 - Input value sufficiency validation: non-coinbase share transactions

--- a/justfile
+++ b/justfile
@@ -76,7 +76,7 @@ check:
 
 # Run cli commands using p2poolv2-cli - e.g. just cli info
 cli *args:
-    cargo run -p p2poolv2_cli -- {{ args }}
+    cargo run -p p2poolv2_node --bin p2poolv2_cli -- {{ args }}
 
 # Format source code
 fmt:

--- a/p2poolv2_lib/src/shares/handle_stratum_share.rs
+++ b/p2poolv2_lib/src/shares/handle_stratum_share.rs
@@ -49,10 +49,19 @@ pub async fn handle_stratum_share(
 
     // Send share to peers only in p2p mode, i.e. if the pool is run with a miner address that results in a commitment
     if let Some(share_commitment) = share_commitment {
-        let share_coinbase = create_coinbase_transaction(&share_commitment.miner_bitcoin_address);
+        // TODO: Get share chain transactions and use them here. When
+        // non-coinbase share transactions are added, pass them to
+        // create_coinbase_transaction so the BIP141 witness commitment
+        // covers their wtxids.
+        let other_share_transactions: Vec<ShareTransaction> = Vec::new();
+        let share_coinbase = create_coinbase_transaction(
+            &share_commitment.miner_bitcoin_address,
+            &other_share_transactions,
+        );
 
-        // TODO: Get share chain transactions and use them here.
-        let share_transactions = vec![ShareTransaction(share_coinbase)];
+        let mut share_transactions = Vec::with_capacity(1 + other_share_transactions.len());
+        share_transactions.push(ShareTransaction(share_coinbase));
+        share_transactions.extend(other_share_transactions);
 
         let txids = share_transactions
             .iter()

--- a/p2poolv2_lib/src/shares/share_block/mod.rs
+++ b/p2poolv2_lib/src/shares/share_block/mod.rs
@@ -359,7 +359,7 @@ impl ShareBlock {
             .parse::<CompressedPublicKey>()
             .unwrap();
         let btcaddress = Address::p2wpkh(&public_key, network);
-        let coinbase = transactions::coinbase::create_coinbase_transaction(&btcaddress);
+        let coinbase = transactions::coinbase::create_coinbase_transaction(&btcaddress, &[]);
         let coinbase_value = coinbase
             .output
             .iter()
@@ -589,7 +589,8 @@ mod tests {
         assert_eq!(share.header.miner_bitcoin_address, expected_address);
         assert_eq!(share.transactions.len(), 1);
         assert!(share.transactions[0].is_coinbase());
-        assert_eq!(share.transactions[0].output.len(), 1);
+        // payout output + BIP141 witness commitment output
+        assert_eq!(share.transactions[0].output.len(), 2);
         assert_eq!(share.transactions[0].input.len(), 1);
 
         let output = &share.transactions[0].output[0];
@@ -606,9 +607,11 @@ mod tests {
     fn test_share_block_new_includes_coinbase_transaction() {
         let share_block = TestShareBlockBuilder::new().build();
 
-        // Verify the coinbase transaction exists and has expected properties
+        // Verify the coinbase transaction exists and has expected properties.
+        // The share coinbase has two outputs: the payout and the BIP141
+        // witness commitment.
         assert!(share_block.transactions[0].is_coinbase());
-        assert_eq!(share_block.transactions[0].output.len(), 1);
+        assert_eq!(share_block.transactions[0].output.len(), 2);
         assert_eq!(share_block.transactions[0].input.len(), 1);
 
         let output = &share_block.transactions[0].output[0];

--- a/p2poolv2_lib/src/shares/transactions/coinbase.rs
+++ b/p2poolv2_lib/src/shares/transactions/coinbase.rs
@@ -14,35 +14,106 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
-use bitcoin::{Address, Transaction, TxOut};
+use crate::shares::share_block::ShareTransaction;
+use crate::shares::witness_commitment::{WITNESS_COMMITMENT_LENGTH, WitnessCommitment};
+use bitcoin::consensus::Encodable;
+use bitcoin::hashes::{Hash, HashEngine, sha256d};
+use bitcoin::{Address, Transaction, TxOut, WitnessMerkleNode, Wtxid, merkle_tree};
 
 const SHARE_VALUE: u64 = 1; // 100_000_000 satoshi == 1 BTC == 1 share
+/// BIP141 witness commitment header: OP_RETURN, push 36, magic "aa21a9ed".
+const BIP141_COMMITMENT_HEADER: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
+/// Witness reserved value (BIP141): 32 zero bytes, stored as the sole
+/// witness stack item of the coinbase input.
+const WITNESS_RESERVED_VALUE: [u8; 32] = [0u8; 32];
 
-/// Create a coinbase transaction for the given bitcoin address and amount.
-/// For now, all shares are equal value, so the amount is 1 unit share coin.
-pub fn create_coinbase_transaction(btcaddress: &Address) -> Transaction {
+/// Create a coinbase transaction for the given bitcoin address.
+///
+/// Builds a coinbase that pays the miner one share unit and embeds a
+/// BIP141 witness commitment covering the provided share transactions.
+/// The caller must pass every non-coinbase transaction that will be
+/// included in the share block (in order); the coinbase's own wtxid is
+/// replaced by all-zeros when computing the witness root, per BIP141.
+///
+/// Also places the 32-byte witness reserved value on the coinbase input's
+/// witness stack so validators can recompute the commitment.
+pub fn create_coinbase_transaction(
+    btcaddress: &Address,
+    other_share_transactions: &[ShareTransaction],
+) -> Transaction {
     let script_pubkey = btcaddress.script_pubkey();
 
-    // Create TxOut with script_pubkey and amount of 1 satoshi
-    let tx_out = TxOut {
+    let payout_output = TxOut {
         value: bitcoin::Amount::from_int_btc(SHARE_VALUE),
         script_pubkey,
     };
 
-    // Create input with null outpoint and empty script sig
+    let witness_commitment_output = build_witness_commitment_output(other_share_transactions);
+
+    let mut witness = bitcoin::Witness::new();
+    witness.push(WITNESS_RESERVED_VALUE);
+
     let tx_in = bitcoin::TxIn {
         previous_output: bitcoin::OutPoint::null(),
         script_sig: bitcoin::ScriptBuf::new(),
         sequence: bitcoin::Sequence::MAX,
-        witness: bitcoin::Witness::new(),
+        witness,
     };
 
     Transaction {
         version: bitcoin::transaction::Version::TWO,
         lock_time: bitcoin::absolute::LockTime::ZERO,
         input: vec![tx_in],
-        output: vec![tx_out],
+        output: vec![payout_output, witness_commitment_output],
     }
+}
+
+/// Build the BIP141 witness commitment output for a share coinbase.
+///
+/// The witness root is computed from wtxids of `other_share_transactions`,
+/// prepended with an all-zero wtxid standing in for the coinbase itself.
+fn build_witness_commitment_output(other_share_transactions: &[ShareTransaction]) -> TxOut {
+    let witness_root = compute_witness_root(other_share_transactions);
+    let commitment_hash = compute_commitment_hash(&witness_root, &WITNESS_RESERVED_VALUE);
+
+    let mut script_bytes = [0u8; WITNESS_COMMITMENT_LENGTH];
+    script_bytes[..6].copy_from_slice(&BIP141_COMMITMENT_HEADER);
+    script_bytes[6..].copy_from_slice(commitment_hash.as_byte_array());
+    let commitment = WitnessCommitment::new(script_bytes);
+
+    TxOut {
+        value: bitcoin::Amount::ZERO,
+        script_pubkey: commitment.to_script_buf(),
+    }
+}
+
+/// Compute the BIP141 witness merkle root for a share block. The coinbase
+/// wtxid is replaced with all-zeros.
+pub(crate) fn compute_witness_root(
+    other_share_transactions: &[ShareTransaction],
+) -> WitnessMerkleNode {
+    let all_zeros = Wtxid::all_zeros().to_raw_hash();
+    let hashes = std::iter::once(all_zeros).chain(
+        other_share_transactions
+            .iter()
+            .map(|share_transaction| share_transaction.compute_wtxid().to_raw_hash()),
+    );
+    merkle_tree::calculate_root(hashes)
+        .map(WitnessMerkleNode::from_raw_hash)
+        .unwrap_or_else(|| WitnessMerkleNode::from_raw_hash(all_zeros))
+}
+
+/// Compute the BIP141 commitment hash: SHA256d(witness_root || reserved_value).
+pub(crate) fn compute_commitment_hash(
+    witness_root: &WitnessMerkleNode,
+    witness_reserved_value: &[u8],
+) -> sha256d::Hash {
+    let mut engine = sha256d::Hash::engine();
+    witness_root
+        .consensus_encode(&mut engine)
+        .expect("hash engine never fails");
+    engine.input(witness_reserved_value);
+    sha256d::Hash::from_engine(engine)
 }
 
 #[cfg(test)]
@@ -57,18 +128,132 @@ mod tests {
             .unwrap();
         let address = Address::p2wpkh(&pubkey, Network::Regtest);
 
-        let transaction = create_coinbase_transaction(&address);
+        let transaction = create_coinbase_transaction(&address, &[]);
 
         assert_eq!(transaction.version, bitcoin::transaction::Version::TWO);
         assert_eq!(transaction.lock_time, bitcoin::absolute::LockTime::ZERO);
         assert_eq!(transaction.input.len(), 1);
-        assert_eq!(transaction.output.len(), 1);
+        assert_eq!(transaction.output.len(), 2);
 
         assert!(transaction.is_coinbase());
 
         let output = &transaction.output[0];
         assert_eq!(output.value, bitcoin::Amount::from_int_btc(SHARE_VALUE));
-
         assert_eq!(output.script_pubkey, address.script_pubkey());
+
+        let commitment_output = &transaction.output[1];
+        assert_eq!(commitment_output.value, bitcoin::Amount::ZERO);
+        assert_eq!(
+            commitment_output.script_pubkey.len(),
+            WITNESS_COMMITMENT_LENGTH
+        );
+        assert_eq!(
+            &commitment_output.script_pubkey.as_bytes()[..6],
+            &BIP141_COMMITMENT_HEADER
+        );
+
+        let witness_stack: Vec<_> = transaction.input[0].witness.iter().collect();
+        assert_eq!(witness_stack.len(), 1);
+        assert_eq!(witness_stack[0], &WITNESS_RESERVED_VALUE);
+    }
+
+    #[test]
+    fn test_create_share_block_coinbase_transaction_with_share_transactions() {
+        let pubkey = "020202020202020202020202020202020202020202020202020202020202020202"
+            .parse::<CompressedPublicKey>()
+            .unwrap();
+        let address = Address::p2wpkh(&pubkey, Network::Regtest);
+
+        // Build two non-coinbase share transactions with distinct witnesses,
+        // so each produces a different wtxid and contributes to the witness
+        // root.
+        let mut first_witness = bitcoin::Witness::new();
+        first_witness.push([0xAAu8; 32]);
+        let first_share_transaction = ShareTransaction(bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: bitcoin::Txid::from_raw_hash(
+                        <bitcoin::hashes::sha256d::Hash as Hash>::from_byte_array([0x11u8; 32]),
+                    ),
+                    vout: 0,
+                },
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: first_witness,
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(1_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        });
+
+        let mut second_witness = bitcoin::Witness::new();
+        second_witness.push([0xBBu8; 32]);
+        let second_share_transaction = ShareTransaction(bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: bitcoin::Txid::from_raw_hash(
+                        <bitcoin::hashes::sha256d::Hash as Hash>::from_byte_array([0x22u8; 32]),
+                    ),
+                    vout: 0,
+                },
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: second_witness,
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(2_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        });
+
+        let other_share_transactions = vec![first_share_transaction, second_share_transaction];
+        let transaction = create_coinbase_transaction(&address, &other_share_transactions);
+
+        assert_eq!(transaction.version, bitcoin::transaction::Version::TWO);
+        assert_eq!(transaction.lock_time, bitcoin::absolute::LockTime::ZERO);
+        assert_eq!(transaction.input.len(), 1);
+        assert_eq!(transaction.output.len(), 2);
+        assert!(transaction.is_coinbase());
+
+        let output = &transaction.output[0];
+        assert_eq!(output.value, bitcoin::Amount::from_int_btc(SHARE_VALUE));
+        assert_eq!(output.script_pubkey, address.script_pubkey());
+
+        let commitment_output = &transaction.output[1];
+        assert_eq!(commitment_output.value, bitcoin::Amount::ZERO);
+        assert_eq!(
+            commitment_output.script_pubkey.len(),
+            WITNESS_COMMITMENT_LENGTH
+        );
+        assert_eq!(
+            &commitment_output.script_pubkey.as_bytes()[..6],
+            &BIP141_COMMITMENT_HEADER
+        );
+
+        // Recompute the commitment independently and verify it matches the
+        // one embedded in the coinbase output.
+        let expected_root = compute_witness_root(&other_share_transactions);
+        let expected_hash = compute_commitment_hash(&expected_root, &WITNESS_RESERVED_VALUE);
+        assert_eq!(
+            &commitment_output.script_pubkey.as_bytes()[6..],
+            expected_hash.as_byte_array()
+        );
+
+        // Commitment must differ from the empty-transactions case, proving
+        // the witness root actually covers the share transactions.
+        let empty_transaction = create_coinbase_transaction(&address, &[]);
+        assert_ne!(
+            commitment_output.script_pubkey,
+            empty_transaction.output[1].script_pubkey
+        );
+
+        let witness_stack: Vec<_> = transaction.input[0].witness.iter().collect();
+        assert_eq!(witness_stack.len(), 1);
+        assert_eq!(witness_stack[0], &WITNESS_RESERVED_VALUE);
     }
 }

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -531,6 +531,51 @@ impl DefaultShareValidator {
         Ok(())
     }
 
+    /// Validate the BIP141 witness commitment in the share coinbase.
+    ///
+    /// The share coinbase must carry a 32-byte witness reserved value on
+    /// its input witness stack and a witness commitment output whose
+    /// 32-byte hash matches `SHA256d(witness_root || reserved_value)`,
+    /// where `witness_root` is the merkle root of share transaction
+    /// wtxids with the coinbase slot replaced by all-zeros (BIP141).
+    fn validate_share_witness_commitment(&self, share: &ShareBlock) -> Result<(), ValidationError> {
+        let coinbase = share
+            .transactions
+            .first()
+            .ok_or_else(|| ValidationError::new("Share block has no transactions"))?;
+
+        let witness_stack: Vec<&[u8]> = coinbase.input[0].witness.iter().collect();
+        if witness_stack.len() != 1 || witness_stack[0].len() != 32 {
+            return Err(ValidationError::new(
+                "Share coinbase input witness must be a single 32-byte reserved value",
+            ));
+        }
+        let witness_reserved_value = witness_stack[0];
+
+        // share coinbase has two outputs - a single miner output and
+        // then a witnesscommitment output
+        let commitment_script = coinbase.output[1].script_pubkey.as_bytes();
+        if commitment_script.len() != WITNESS_COMMITMENT_LENGTH
+            || commitment_script[..6] != [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed]
+        {
+            return Err(ValidationError::new(
+                "Share coinbase witness commitment output has invalid BIP141 header",
+            ));
+        }
+
+        let other_share_transactions = &share.transactions[1..];
+        let witness_root = compute_witness_root(other_share_transactions);
+        let expected_commitment = compute_commitment_hash(&witness_root, witness_reserved_value);
+
+        if commitment_script[6..] != expected_commitment.as_byte_array()[..] {
+            return Err(ValidationError::new(
+                "Share coinbase witness commitment does not match recomputed witness root",
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Validate the bitcoin coinbase by reconstructing it from the share header
     /// fields and verifying the merkle root matches the bitcoin header.
     fn validate_bitcoin_coinbase(
@@ -758,6 +803,7 @@ impl ShareValidator for DefaultShareValidator {
         self.validate_share_coinbase(share)?;
         self.validate_bitcoin_coinbase(share, pplns_window)?;
         self.validate_merkle_root(share)?;
+        self.validate_share_witness_commitment(share)?;
         self.validate_transaction_count(share)?;
         self.validate_transactions(share)?;
         self.validate_scripts_values_and_sigops(share, chain_store_handle)?;
@@ -3304,6 +3350,87 @@ mod tests {
             error.to_string().contains("sigop cost")
                 && error.to_string().contains("exceeds maximum"),
             "Expected sigop cost exceeded error, got: {error}"
+        );
+    }
+
+    #[test]
+    fn test_validate_share_witness_commitment_succeeds_for_valid_block() {
+        let share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .build();
+        let result = validator().validate_share_witness_commitment(&share);
+        assert!(
+            result.is_ok(),
+            "Expected valid witness commitment, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_validate_share_witness_commitment_fails_for_tampered_commitment() {
+        let mut share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .build();
+
+        // Flip a byte inside the 32-byte commitment hash (after the 6-byte header).
+        let mut script_bytes = share.transactions[0].output[1]
+            .script_pubkey
+            .as_bytes()
+            .to_vec();
+        script_bytes[10] ^= 0xFF;
+        share.transactions[0].0.output[1].script_pubkey = ScriptBuf::from(script_bytes);
+
+        let error = validator()
+            .validate_share_witness_commitment(&share)
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("does not match recomputed witness root"),
+            "Expected commitment mismatch error, got: {error}"
+        );
+    }
+
+    #[test]
+    fn test_validate_share_witness_commitment_fails_for_bad_bip141_header() {
+        let mut share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .build();
+
+        // Corrupt the BIP141 magic bytes in the commitment output.
+        let mut script_bytes = share.transactions[0].output[1]
+            .script_pubkey
+            .as_bytes()
+            .to_vec();
+        script_bytes[2] = 0x00;
+        share.transactions[0].0.output[1].script_pubkey = ScriptBuf::from(script_bytes);
+
+        let error = validator()
+            .validate_share_witness_commitment(&share)
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("invalid BIP141 header"),
+            "Expected BIP141 header error, got: {error}"
+        );
+    }
+
+    #[test]
+    fn test_validate_share_witness_commitment_fails_for_bad_reserved_value() {
+        let mut share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .build();
+
+        // Replace the 32-byte reserved value with a 16-byte value.
+        let mut witness = bitcoin::Witness::new();
+        witness.push([0u8; 16]);
+        share.transactions[0].0.input[0].witness = witness;
+
+        let error = validator()
+            .validate_share_witness_commitment(&share)
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("single 32-byte reserved value"),
+            "Expected reserved value error, got: {error}"
         );
     }
 }

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -504,7 +504,7 @@ impl DefaultShareValidator {
             ));
         }
 
-        // Two coinbase outputs: first to the miner and second a witness commitment ouput
+        // Two coinbase outputs: first to the miner and second a witness commitment output
         if coinbase.output.len() != 2 {
             return Err(ValidationError::new(format!(
                 "Share coinbase has {} outputs, expected 2",
@@ -554,7 +554,14 @@ impl DefaultShareValidator {
 
         // share coinbase has two outputs - a single miner output and
         // then a witnesscommitment output
-        let commitment_script = coinbase.output[1].script_pubkey.as_bytes();
+        let commitment_output = &coinbase.output[1];
+        if commitment_output.value != Amount::ZERO {
+            return Err(ValidationError::new(format!(
+                "Share coinbase witness commitment output must have zero value, got {}",
+                commitment_output.value
+            )));
+        }
+        let commitment_script = commitment_output.script_pubkey.as_bytes();
         if commitment_script.len() != WITNESS_COMMITMENT_LENGTH
             || commitment_script[..6] != [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed]
         {
@@ -3431,6 +3438,25 @@ mod tests {
         assert!(
             error.to_string().contains("single 32-byte reserved value"),
             "Expected reserved value error, got: {error}"
+        );
+    }
+
+    #[test]
+    fn test_validate_share_witness_commitment_fails_for_non_zero_commitment_value() {
+        let mut share = TestShareBlockBuilder::new()
+            .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+            .build();
+
+        // Set a non-zero value on the commitment output (BIP141 requires
+        // zero value so miners cannot burn funds into an unspendable output).
+        share.transactions[0].0.output[1].value = bitcoin::Amount::from_sat(1);
+
+        let error = validator()
+            .validate_share_witness_commitment(&share)
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("must have zero value"),
+            "Expected zero-value error, got: {error}"
         );
     }
 }

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -38,10 +38,13 @@ use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::share_block::{ShareBlock, ShareTransaction};
 use crate::shares::share_commitment::ShareCommitment;
+use crate::shares::transactions::coinbase::{compute_commitment_hash, compute_witness_root};
+use crate::shares::witness_commitment::WITNESS_COMMITMENT_LENGTH;
 use crate::store::block_tx_metadata::Status;
 use crate::stratum::work::coinbase::build_coinbase_transaction;
 use crate::stratum::work::gbt::compute_merkle_root_from_branches;
 use crate::utils::time_provider::{SystemTimeProvider, TimeProvider};
+use bitcoin::hashes::Hash as HashTrait;
 use bitcoin::script::PushBytesBuf;
 use bitcoin::{
     Address, Amount, BlockHash, CompactTarget, Target, TxMerkleNode, transaction::Version,
@@ -488,7 +491,7 @@ impl DefaultShareValidator {
     }
 
     /// Validate the share coinbase creates an output with 1 share
-    /// unit to the miner address in the header.
+    /// unit to the miner address in the header and second a witness commitment output
     fn validate_share_coinbase(&self, share: &ShareBlock) -> Result<(), ValidationError> {
         let coinbase = share
             .transactions
@@ -501,9 +504,10 @@ impl DefaultShareValidator {
             ));
         }
 
-        if coinbase.output.len() != 1 {
+        // Two coinbase outputs: first to the miner and second a witness commitment ouput
+        if coinbase.output.len() != 2 {
             return Err(ValidationError::new(format!(
-                "Share coinbase has {} outputs, expected 1",
+                "Share coinbase has {} outputs, expected 2",
                 coinbase.output.len()
             )));
         }

--- a/p2poolv2_lib/src/store/transaction_store.rs
+++ b/p2poolv2_lib/src/store/transaction_store.rs
@@ -58,6 +58,39 @@ impl Decodable for StoredTxOut {
     }
 }
 
+/// A TxIn stored in the Inputs CF together with its witness.
+///
+/// `bitcoin::TxIn::consensus_encode` does not include the witness
+/// (witness data lives at the Transaction level under BIP144).
+/// Storing the witness alongside the TxIn ensures segwit share
+/// transactions survive a store roundtrip and can be relayed to peers
+/// with their witness intact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StoredTxIn {
+    pub tx_in: bitcoin::TxIn,
+}
+
+impl Encodable for StoredTxIn {
+    fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, bitcoin::io::Error> {
+        let mut length = self.tx_in.consensus_encode(writer)?;
+        length += self.tx_in.witness.consensus_encode(writer)?;
+        Ok(length)
+    }
+}
+
+impl Decodable for StoredTxIn {
+    fn consensus_decode<R: bitcoin::io::Read + ?Sized>(
+        reader: &mut R,
+    ) -> Result<Self, bitcoin::consensus::encode::Error> {
+        let mut tx_in = bitcoin::TxIn::consensus_decode(reader)?;
+        tx_in.witness = bitcoin::Witness::consensus_decode(reader)?;
+        Ok(StoredTxIn { tx_in })
+    }
+}
+
 #[allow(dead_code)]
 impl Store {
     /// Retrieve all previous outputs being spent by a transaction's inputs.
@@ -307,8 +340,10 @@ impl Store {
 
             for (i, input) in tx.input.iter().enumerate() {
                 let input_key = format!("{txid}:{i}");
-                let mut serialized = Vec::new();
-                input.consensus_encode(&mut serialized)?;
+                let stored = StoredTxIn {
+                    tx_in: input.clone(),
+                };
+                let serialized = consensus::serialize(&stored);
                 batch.put_cf::<&[u8], Vec<u8>>(&inputs_cf, input_key.as_ref(), serialized);
             }
 
@@ -661,8 +696,8 @@ impl Store {
                 .get_cf::<&[u8]>(&inputs_cf, input_key.as_ref())
                 .unwrap()
                 .unwrap();
-            let input: bitcoin::TxIn = match encode::deserialize(&input) {
-                Ok(input) => input,
+            let input: bitcoin::TxIn = match encode::deserialize::<StoredTxIn>(&input) {
+                Ok(stored) => stored.tx_in,
                 Err(e) => {
                     tracing::error!("Error deserializing input: {e:?}");
                     return Err(e.into());
@@ -756,9 +791,10 @@ impl Store {
             let bytes = result?.ok_or_else(|| {
                 StoreError::NotFound(format!("Input not found for {}", keys[index]))
             })?;
-            decoded.push(encode::deserialize(&bytes).map_err(|_| {
+            let stored: StoredTxIn = encode::deserialize(&bytes).map_err(|_| {
                 StoreError::Serialization("Failed to deserialize input".to_string())
-            })?);
+            })?;
+            decoded.push(stored.tx_in);
         }
 
         // group the offset based inputs for each txid

--- a/p2poolv2_lib/src/test_utils.rs
+++ b/p2poolv2_lib/src/test_utils.rs
@@ -109,7 +109,7 @@ pub fn make_test_address(index: usize) -> Address {
 #[cfg(any(test, feature = "test-utils"))]
 pub fn test_coinbase_transaction(index: usize) -> bitcoin::Transaction {
     let address = make_test_address(index);
-    create_coinbase_transaction(&address)
+    create_coinbase_transaction(&address, &[])
 }
 
 /// Setup returns both chain handle and tempdir (tempdir must stay alive)
@@ -551,10 +551,16 @@ impl TestShareBlockBuilder {
         let pubkey = CompressedPublicKey::from_str(pubkey_hex).unwrap();
         let btcaddress = Address::p2wpkh(&pubkey, bitcoin::Network::Signet);
 
-        let coinbase = create_coinbase_transaction(&btcaddress);
+        let other_share_transactions: Vec<ShareTransaction> = self
+            .transactions
+            .into_iter()
+            .map(ShareTransaction)
+            .collect();
+        let coinbase = create_coinbase_transaction(&btcaddress, &other_share_transactions);
         let all_transactions: Vec<ShareTransaction> = {
-            let mut txs = vec![ShareTransaction(coinbase)];
-            txs.extend(self.transactions.into_iter().map(ShareTransaction));
+            let mut txs = Vec::with_capacity(1 + other_share_transactions.len());
+            txs.push(ShareTransaction(coinbase));
+            txs.extend(other_share_transactions);
             txs
         };
         test_share_block(

--- a/p2poolv2_node/Cargo.toml
+++ b/p2poolv2_node/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
+default-run = "p2poolv2"
 
 [dependencies]
 tokio = { workspace = true }

--- a/p2poolv2_tests/test_data/share_sync/share_blocks.json
+++ b/p2poolv2_tests/test_data/share_sync/share_blocks.json
@@ -18,7 +18,7 @@
     "extranonce": "000000000000000000000000",
     "fee": null,
     "fee_address": null,
-    "merkle_root": "1e20665fc5924aec5b8fdbb8264f1ff7a4395546b42167e2590fcf78e1ca5d9d",
+    "merkle_root": "9d1b8c3e0239911d7d11ee00bb839b28ec014f6c26bd7049f045a7e1ec3b5891",
     "miner_bitcoin_address": "tb1qx6e0gj7q7xurl08cwnpmeve6w6zf4tw6vfwe3f",
     "prev_share_blockhash": "0000000000000000000000000000000000000000000000000000000000000000",
     "template_merkle_branches": [],
@@ -30,7 +30,9 @@
             "previous_output": "0000000000000000000000000000000000000000000000000000000000000000:4294967295",
             "script_sig": "",
             "sequence": 4294967295,
-            "witness": []
+            "witness": [
+              "0000000000000000000000000000000000000000000000000000000000000000"
+            ]
           }
         ],
         "lock_time": 0,
@@ -38,6 +40,10 @@
           {
             "script_pubkey": "001436b2f44bc0f1b83fbcf874c3bcb33a76849aadda",
             "value": 100000000
+          },
+          {
+            "script_pubkey": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9",
+            "value": 0
           }
         ],
         "version": 2
@@ -48,28 +54,28 @@
   },
   {
     "bitcoin_header": {
-      "bits": 486810785,
-      "merkle_root": "068c50c57b9f7749a0b24106f2c0bb189c5ba29b7bcea9df526d277d19035a79",
-      "nonce": 959774772,
-      "prev_blockhash": "0000000000c6a4d1fe561b5fcb58f8209b37f7833cafa6cfee4773e31056eabf",
-      "time": 1775222507,
-      "version": 608755712
+      "bits": 503543726,
+      "merkle_root": "b77121886726127738ce0e7ed1e743101dae8c56cf912da4fc28dcda99cfa3ed",
+      "nonce": 1725038998,
+      "prev_blockhash": "0000000000bc5c1e7692ccfab6625c7995fd1bf2d5d94be62fd50f9d65ba64cb",
+      "time": 1776335283,
+      "version": 628924416
     },
-    "bitcoin_height": 14098,
+    "bitcoin_height": 175,
     "bits": 456674263,
-    "coinbase_nsecs": 1775222507567386032,
+    "coinbase_nsecs": 1776335283228128327,
     "coinbase_value": 5000000000,
     "coinbaseaux_flags": null,
     "donation": 50,
     "donation_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "extranonce": "c282e9341b000000008fce3f",
+    "extranonce": "7032379305000000008ece3f",
     "fee": 200,
     "fee_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "merkle_root": "14ea54b7d9f8967329f204ce12d74e75f57bc4610fd07af87d4838b35fe1f0a4",
+    "merkle_root": "9fb82bc288e02b55e5d6b5c18ddda4efded51621c9d94c9eba614486b76c5663",
     "miner_bitcoin_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "prev_share_blockhash": "3af35c2c35365bd9fc597127c1dcdf3ebe0842d8c29dbdbb55adce7f133906e0",
+    "prev_share_blockhash": "de5fba917bad44790558e0c375d2543e3113a52654c829c91c117849019262b2",
     "template_merkle_branches": [],
-    "time": 1775222507,
+    "time": 1776335283,
     "transactions": [
       {
         "input": [
@@ -77,7 +83,9 @@
             "previous_output": "0000000000000000000000000000000000000000000000000000000000000000:4294967295",
             "script_sig": "",
             "sequence": 4294967295,
-            "witness": []
+            "witness": [
+              "0000000000000000000000000000000000000000000000000000000000000000"
+            ]
           }
         ],
         "lock_time": 0,
@@ -85,6 +93,10 @@
           {
             "script_pubkey": "0014274466e754a1c12d0a2d2cc34ceb70d8e017053a",
             "value": 100000000
+          },
+          {
+            "script_pubkey": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9",
+            "value": 0
           }
         ],
         "version": 2
@@ -95,28 +107,28 @@
   },
   {
     "bitcoin_header": {
-      "bits": 486810785,
-      "merkle_root": "5e5822ed75120443db5bae03bb49abd6b9cb99a9c2071f8e3b41abedbdff0357",
-      "nonce": 4094624030,
-      "prev_blockhash": "00000000003d1f129dd86a9d3fb2441a257f8b30601c8c0ea6d79c5fa62727b2",
-      "time": 1775222529,
-      "version": 672448512
+      "bits": 503543726,
+      "merkle_root": "d9214518d970c6c3227a3b2652664989ef7a88c014ebfff13b361a991a9a3283",
+      "nonce": 2251293456,
+      "prev_blockhash": "0000000000e6f65c31245598aeca60b1f1ea7a6124be7fd3b8edd56f45d5b78d",
+      "time": 1776335307,
+      "version": 586539008
     },
-    "bitcoin_height": 14100,
+    "bitcoin_height": 177,
     "bits": 456674263,
-    "coinbase_nsecs": 1775222529518529991,
+    "coinbase_nsecs": 1776335307184579700,
     "coinbase_value": 5000000000,
     "coinbaseaux_flags": null,
     "donation": 50,
     "donation_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "extranonce": "c282e9340d000000008fce3f",
+    "extranonce": "da55afa70c000000008ece3f",
     "fee": 200,
     "fee_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "merkle_root": "14ea54b7d9f8967329f204ce12d74e75f57bc4610fd07af87d4838b35fe1f0a4",
+    "merkle_root": "9fb82bc288e02b55e5d6b5c18ddda4efded51621c9d94c9eba614486b76c5663",
     "miner_bitcoin_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "prev_share_blockhash": "5e9b6a45eb6c0e983d8f7247c088c1567de50d46b3da1fe023e9f16a04408dd4",
+    "prev_share_blockhash": "6c0983273e2c66a5dde1ff4d27e6348aa3e3be4ba95a1c3dabd607b17d6a73e0",
     "template_merkle_branches": [],
-    "time": 1775222529,
+    "time": 1776335307,
     "transactions": [
       {
         "input": [
@@ -124,7 +136,9 @@
             "previous_output": "0000000000000000000000000000000000000000000000000000000000000000:4294967295",
             "script_sig": "",
             "sequence": 4294967295,
-            "witness": []
+            "witness": [
+              "0000000000000000000000000000000000000000000000000000000000000000"
+            ]
           }
         ],
         "lock_time": 0,
@@ -132,6 +146,10 @@
           {
             "script_pubkey": "0014274466e754a1c12d0a2d2cc34ceb70d8e017053a",
             "value": 100000000
+          },
+          {
+            "script_pubkey": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9",
+            "value": 0
           }
         ],
         "version": 2
@@ -142,28 +160,28 @@
   },
   {
     "bitcoin_header": {
-      "bits": 486810785,
-      "merkle_root": "89177fec592eb8be480987c256f8f2b5acc4c197f1aee064805cc3db06b0398c",
-      "nonce": 2325283166,
-      "prev_blockhash": "00000000003b0a39afda183d08daf62b108ed6467ef53843bab4a203c53c0b6f",
-      "time": 1775222543,
-      "version": 560693248
+      "bits": 503543726,
+      "merkle_root": "136ba6d092a58af3a5ed835d61e6542c2ddc852515c2db0d06efba9e8b89f743",
+      "nonce": 2509046106,
+      "prev_blockhash": "00000000000dc46fcd97f681b812d53e13d1335e8bc8723e6ad80e7816fce4ef",
+      "time": 1776335313,
+      "version": 545898496
     },
-    "bitcoin_height": 14102,
+    "bitcoin_height": 178,
     "bits": 456674263,
-    "coinbase_nsecs": 1775222543368651940,
+    "coinbase_nsecs": 1776335313640598458,
     "coinbase_value": 5000000000,
     "coinbaseaux_flags": null,
     "donation": 50,
     "donation_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "extranonce": "c282e9340d000000008fce3f",
+    "extranonce": "da55afa701000000008ece3f",
     "fee": 200,
     "fee_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "merkle_root": "14ea54b7d9f8967329f204ce12d74e75f57bc4610fd07af87d4838b35fe1f0a4",
+    "merkle_root": "9fb82bc288e02b55e5d6b5c18ddda4efded51621c9d94c9eba614486b76c5663",
     "miner_bitcoin_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "prev_share_blockhash": "780db4fda132ae9e6f09979ccf3268efaf96d12e12aa12ba678922aa3b377837",
+    "prev_share_blockhash": "001eecac05abc20c383427345afc43fe3ebf059992edabe167a387ea68859397",
     "template_merkle_branches": [],
-    "time": 1775222543,
+    "time": 1776335313,
     "transactions": [
       {
         "input": [
@@ -171,7 +189,9 @@
             "previous_output": "0000000000000000000000000000000000000000000000000000000000000000:4294967295",
             "script_sig": "",
             "sequence": 4294967295,
-            "witness": []
+            "witness": [
+              "0000000000000000000000000000000000000000000000000000000000000000"
+            ]
           }
         ],
         "lock_time": 0,
@@ -179,6 +199,10 @@
           {
             "script_pubkey": "0014274466e754a1c12d0a2d2cc34ceb70d8e017053a",
             "value": 100000000
+          },
+          {
+            "script_pubkey": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9",
+            "value": 0
           }
         ],
         "version": 2
@@ -189,28 +213,28 @@
   },
   {
     "bitcoin_header": {
-      "bits": 486810785,
-      "merkle_root": "661f2094dc77809caedbd5033bc3f2849635bc3a386c14ba5c362910625f2d12",
-      "nonce": 857670438,
-      "prev_blockhash": "000000000026ecdeb0785994b77eddf31f5e91d760cba8a5c75dcbe9b0d5fa01",
-      "time": 1775222550,
-      "version": 580788224
+      "bits": 503543726,
+      "merkle_root": "5ba0027cf5d521855fc7a697f97bb80c24f93b815f8a725dbd849fd505a841ee",
+      "nonce": 2439119706,
+      "prev_blockhash": "000000000020b1ee94cd688f5f33e47af48a0586abdb99e5240fcc61a12d1585",
+      "time": 1776335313,
+      "version": 561332224
     },
-    "bitcoin_height": 14103,
+    "bitcoin_height": 179,
     "bits": 456674263,
-    "coinbase_nsecs": 1775222550309156077,
+    "coinbase_nsecs": 1776335313947176164,
     "coinbase_value": 5000000000,
     "coinbaseaux_flags": null,
     "donation": 50,
     "donation_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "extranonce": "c282e93413000000008fce3f",
+    "extranonce": "da55afa712000000008ece3f",
     "fee": 200,
     "fee_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "merkle_root": "14ea54b7d9f8967329f204ce12d74e75f57bc4610fd07af87d4838b35fe1f0a4",
+    "merkle_root": "9fb82bc288e02b55e5d6b5c18ddda4efded51621c9d94c9eba614486b76c5663",
     "miner_bitcoin_address": "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk",
-    "prev_share_blockhash": "751ebbea1296c4147557b4f652dcab0f7ace19f5e80d138f1cf693cf181eaaac",
+    "prev_share_blockhash": "f1433db9bd4e1db4d37ebff2354388b0cbbb6f13799ef03b4432afc2ee3b9edd",
     "template_merkle_branches": [],
-    "time": 1775222550,
+    "time": 1776335313,
     "transactions": [
       {
         "input": [
@@ -218,7 +242,9 @@
             "previous_output": "0000000000000000000000000000000000000000000000000000000000000000:4294967295",
             "script_sig": "",
             "sequence": 4294967295,
-            "witness": []
+            "witness": [
+              "0000000000000000000000000000000000000000000000000000000000000000"
+            ]
           }
         ],
         "lock_time": 0,
@@ -226,6 +252,10 @@
           {
             "script_pubkey": "0014274466e754a1c12d0a2d2cc34ceb70d8e017053a",
             "value": 100000000
+          },
+          {
+            "script_pubkey": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9",
+            "value": 0
           }
         ],
         "version": 2


### PR DESCRIPTION
Add support for share chain block to support BIP141 segwit commitment.

This sets up everything for when we include share transactions from the share chain transaction pool (not calling it mempool as our pool of txs are in Store).