### PR TITLE
Bump version in cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindrpc"
-version = "0.9.1"
+version = "0.10.1"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3236,7 +3236,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2poolv2_api"
-version = "0.9.1"
+version = "0.10.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_cli"
-version = "0.9.1"
+version = "0.10.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_config"
-version = "0.9.1"
+version = "0.10.1"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_lib"
-version = "0.9.1"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_node"
-version = "0.9.1"
+version = "0.10.1"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_tests"
-version = "0.9.1"
+version = "0.10.1"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.1"
 edition = "2024"
 authors = ["Kulpreet Singh<kp@opdup.com>"]
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
We really should switch to cargo-release. This version/tag/changelog consistency is a drain.