### PR TITLE
Fix sync uncles access and timeout issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.10.5] - 2026-04-20
+
+### Fixed
+
+- Fix shared headers to always include uncles at chain boundary. This
+  bug was causing sync to fail when this corner case was reached.
+
+- Send getheaders in response to Inv blockhash for proper sync. We do
+  not immediately send ShareBlock now, instead we let getheaders and
+  headers sync drive the chain sync.
+
+- Don't emit BlockFetch for ancestors on BlockReceive, reducing
+  redundant fetches. Related to the fix in the previous point.
+
+- Fallback to confirmed tip only on NotFound, propagating real store
+  errors instead of silently masking them.
+
+### Changed
+
+- Check candidate chain (not just confirmed) for is_current
+
+- Send Inv messages with peer block knowledge for protocol correctness
+
+- Remove bitcoin transactions from ShareBlock to reduce message
+  size. We will deal with building bitcoin blocks for submitting from
+  other pool peers in a later version.
+
+- Ignore Request ShareBlock messages during sync. This avoids block
+  fetch storms during initial sync from both sides of the chain,
+  genesis and tip.
+
+- Clean up unused peer id from ShareBlockReceived as we don't respond
+  to share block received to the same peer now.
+
 ## [v0.10.4] - 2026-04-18
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove rate limit window config option. The rate limit config uses
+  per second semantics, so the window option was unnecessary.
+
 - Check candidate chain (not just confirmed) for is_current
 
 - Send Inv messages with peer block knowledge for protocol correctness

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindrpc"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3252,7 +3252,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2poolv2_api"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_cli"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_config"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_lib"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_node"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_tests"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.4"
+version = "0.10.5"
 edition = "2024"
 authors = ["Kulpreet Singh<kp@opdup.com>"]
 license = "AGPL-3.0-or-later"

--- a/config-docker.sample.toml
+++ b/config-docker.sample.toml
@@ -11,7 +11,6 @@ max_userworkbase_per_second = 10
 max_miningshare_per_second = 100
 max_inventory_per_second = 100
 max_transaction_per_second = 100
-rate_limit_window_secs = 1
 max_requests_per_second = 100
 dial_timeout_secs = 30
 

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -11,7 +11,6 @@ max_userworkbase_per_second = 10
 max_miningshare_per_second = 100
 max_inventory_per_second = 100
 max_transaction_per_second = 100
-rate_limit_window_secs = 1
 max_requests_per_second = 100
 dial_timeout_secs = 30
 

--- a/p2poolv2_config/src/lib.rs
+++ b/p2poolv2_config/src/lib.rs
@@ -256,7 +256,6 @@ pub struct NetworkConfig {
     pub max_miningshare_per_second: u32,
     pub max_inventory_per_second: u32,
     pub max_transaction_per_second: u32,
-    pub rate_limit_window_secs: u64,
     pub max_requests_per_second: u64,
     pub dial_timeout_secs: u64,
 }
@@ -276,7 +275,6 @@ impl Default for NetworkConfig {
             max_miningshare_per_second: 100,
             max_inventory_per_second: 100,
             max_transaction_per_second: 100,
-            rate_limit_window_secs: 1,
             max_requests_per_second: 1,
             dial_timeout_secs: 30,
         }

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -347,7 +347,7 @@ impl NodeActor {
     }
 
     async fn run(mut self) {
-        // Spawn emission worker - processes shares in separate task and enqueues SwarmSend::Broadcast
+        // Spawn emission worker - processes shares in separate task and enqueues SwarmSend::Inv
         let emission_worker = EmissionWorker::new(
             self.emissions_rx,
             self.node.swarm_tx.clone(),
@@ -406,16 +406,6 @@ impl NodeActor {
                                 error!("Error disconnecting peer {peer_id}");
                             } else {
                                 debug!("Disconnected peer: {peer_id}");
-                            }
-                        }
-                        Some(SwarmSend::Broadcast(share_block)) => {
-                            // Broadcast share to all peers (from emission worker)
-                            debug!("Broadcasting share to peers");
-                            if let Err(e) = self
-                                .node
-                                .send_to_all_peers(Message::ShareBlock(share_block))
-                            {
-                                error!("Error sending share to all peers {e}");
                             }
                         }
                         None => {

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -367,13 +367,14 @@ impl NodeActor {
                 buf = self.node.swarm_rx.recv() => {
                     match buf {
                         Some(SwarmSend::Request(peer_id, msg)) => {
+                            let msg_type = msg.message_type();
                             let request_id = self
                                 .node
                                 .swarm
                                 .behaviour_mut()
                                 .request_response
                                 .send_request(&peer_id, msg);
-                            debug!("Sent message to peer: {peer_id}, request_id: {request_id}");
+                            debug!("Sent {msg_type} to peer: {peer_id}, request_id: {request_id}");
                         }
                         Some(SwarmSend::Response(response_channel, msg)) => {
                             let request_id = self

--- a/p2poolv2_lib/src/node/emission_worker.rs
+++ b/p2poolv2_lib/src/node/emission_worker.rs
@@ -29,10 +29,13 @@ use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 #[cfg(not(test))]
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::handle_stratum_share::handle_stratum_share;
-use crate::stratum::emission::EmissionReceiver;
+use crate::stratum::emission::{Emission, EmissionReceiver};
 use libp2p::request_response::ResponseChannel;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
+
+/// Type alias for the swarm sender used by the emission worker.
+type SwarmSender = mpsc::Sender<SwarmSend<ResponseChannel<Message>>>;
 
 /// Worker that processes emissions from the stratum server.
 ///
@@ -40,7 +43,7 @@ use tracing::{debug, error, info};
 /// during CPU-intensive share processing operations.
 pub struct EmissionWorker {
     emissions_rx: EmissionReceiver,
-    swarm_tx: mpsc::Sender<SwarmSend<ResponseChannel<Message>>>,
+    swarm_tx: SwarmSender,
     chain_store_handle: ChainStoreHandle,
     network: bitcoin::Network,
     organise_tx: OrganiseSender,
@@ -50,7 +53,7 @@ impl EmissionWorker {
     /// Creates a new emission worker.
     pub fn new(
         emissions_rx: EmissionReceiver,
-        swarm_tx: mpsc::Sender<SwarmSend<ResponseChannel<Message>>>,
+        swarm_tx: SwarmSender,
         chain_store_handle: ChainStoreHandle,
         network: bitcoin::Network,
         organise_tx: OrganiseSender,
@@ -69,7 +72,7 @@ impl EmissionWorker {
         info!("Emission worker started");
         while let Some(emission) = self.emissions_rx.recv().await {
             debug!("Processing emission");
-            // Pass a references to chain store handle to avoid clones on each loop
+            // Pass a reference to chain store handle to avoid clones on each loop
             match handle_stratum_share(emission, &self.chain_store_handle).await {
                 Ok(Some(share_block)) => {
                     // Send block to organise worker for confirmed promotion.
@@ -80,9 +83,10 @@ impl EmissionWorker {
                     {
                         error!("Failed to send block to organise worker: {e}");
                     }
-                    // Send to swarm_tx for broadcast to peers
-                    if let Err(e) = self.swarm_tx.send(SwarmSend::Broadcast(share_block)).await {
-                        error!("Failed to queue share for broadcast: {e}");
+                    // Announce block to peers via inventory message
+                    let block_hash = share_block.block_hash();
+                    if let Err(e) = self.swarm_tx.send(SwarmSend::Inv(block_hash)).await {
+                        error!("Failed to queue inv for block {block_hash}: {e}");
                     }
                 }
                 Ok(None) => {
@@ -94,5 +98,296 @@ impl EmissionWorker {
             }
         }
         info!("Emission worker stopped - channel closed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::accounting::payout::simple_pplns::SimplePplnsShare;
+    use crate::node::organise_worker::create_organise_channel;
+    use crate::shares::extranonce::Extranonce;
+    use crate::store::writer::StoreError;
+    use crate::stratum::work::block_template::BlockTemplate;
+    use crate::test_utils::{TEST_COINBASE_NSECS, create_test_commitment};
+    use bitcoin::block::Header;
+    use bitcoin::hashes::Hash;
+    use bitcoin::{BlockHash, CompactTarget};
+    use bitcoin::{Transaction, absolute::LockTime, transaction::Version};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn create_test_blocktemplate() -> BlockTemplate {
+        BlockTemplate {
+            version: 0x20000000,
+            rules: vec![],
+            vbavailable: HashMap::with_capacity(0),
+            vbrequired: 0,
+            previousblockhash: "0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+            transactions: vec![],
+            coinbaseaux: HashMap::with_capacity(0),
+            coinbasevalue: 5000000000,
+            longpollid: String::new(),
+            target: "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+            mintime: 0,
+            mutable: vec![],
+            noncerange: "00000000ffffffff".to_string(),
+            sigoplimit: 80000,
+            sizelimit: 4000000,
+            weightlimit: 4000000,
+            curtime: 1700000000,
+            bits: "207fffff".to_string(),
+            height: 1,
+            default_witness_commitment: None,
+        }
+    }
+
+    fn create_test_emission_without_commitment() -> Emission {
+        let pplns = SimplePplnsShare {
+            user_id: 1,
+            difficulty: 1000,
+            btcaddress: Some("tb1qtest".to_string()),
+            workername: Some("worker1".to_string()),
+            n_time: 1700000000,
+            job_id: "test_job_1".to_string(),
+            extranonce2: "00000001".to_string(),
+            nonce: "12345".to_string(),
+        };
+
+        let bitcoin_header = Header {
+            version: bitcoin::block::Version::TWO,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: 1700000000,
+            bits: CompactTarget::from_consensus(0x1b4188f5),
+            nonce: 12345,
+        };
+
+        let coinbase = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        };
+
+        Emission {
+            pplns,
+            header: bitcoin_header,
+            coinbase,
+            blocktemplate: Arc::new(create_test_blocktemplate()),
+            share_commitment: None,
+            coinbase_nsecs: TEST_COINBASE_NSECS,
+            template_merkle_branches: vec![],
+            extranonce: Extranonce::default(),
+        }
+    }
+
+    fn create_test_emission_with_commitment() -> Emission {
+        let pplns = SimplePplnsShare {
+            user_id: 1,
+            difficulty: 1000,
+            btcaddress: Some("tb1qtest".to_string()),
+            workername: Some("worker1".to_string()),
+            n_time: 1700000000,
+            job_id: "test_job_1".to_string(),
+            extranonce2: "00000001".to_string(),
+            nonce: "12345".to_string(),
+        };
+
+        let bitcoin_header = Header {
+            version: bitcoin::block::Version::TWO,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: 1700000000,
+            bits: CompactTarget::from_consensus(0x1b4188f5),
+            nonce: 12345,
+        };
+
+        let coinbase = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        };
+
+        let commitment = create_test_commitment();
+
+        Emission {
+            pplns,
+            header: bitcoin_header,
+            coinbase,
+            blocktemplate: Arc::new(create_test_blocktemplate()),
+            share_commitment: Some(commitment),
+            coinbase_nsecs: TEST_COINBASE_NSECS,
+            template_merkle_branches: vec![],
+            extranonce: Extranonce::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_with_p2p_share_sends_organise_and_inv() {
+        let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<ResponseChannel<Message>>>(10);
+        let (organise_tx, mut organise_rx) = create_organise_channel();
+
+        let mut mock_chain_store = ChainStoreHandle::default();
+        mock_chain_store
+            .expect_add_share_block()
+            .returning(|_| Ok(()));
+
+        let worker = EmissionWorker::new(
+            emissions_rx,
+            swarm_tx,
+            mock_chain_store,
+            bitcoin::Network::Regtest,
+            organise_tx,
+        );
+        let worker_handle = tokio::spawn(worker.run());
+
+        emissions_tx
+            .send(create_test_emission_with_commitment())
+            .await
+            .unwrap();
+        drop(emissions_tx);
+
+        let organise_event = tokio::time::timeout(Duration::from_secs(2), organise_rx.recv()).await;
+        assert!(
+            matches!(organise_event, Ok(Some(OrganiseEvent::Block(_)))),
+            "Expected OrganiseEvent::Block"
+        );
+
+        let swarm_event = tokio::time::timeout(Duration::from_secs(2), swarm_rx.recv()).await;
+        assert!(
+            matches!(swarm_event, Ok(Some(SwarmSend::Inv(_)))),
+            "Expected SwarmSend::Inv"
+        );
+
+        worker_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_run_without_commitment_sends_nothing() {
+        let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<ResponseChannel<Message>>>(10);
+        let (organise_tx, mut organise_rx) = create_organise_channel();
+
+        let mut mock_chain_store = ChainStoreHandle::default();
+        mock_chain_store
+            .expect_add_pplns_share()
+            .returning(|_| Ok(()));
+
+        let worker = EmissionWorker::new(
+            emissions_rx,
+            swarm_tx,
+            mock_chain_store,
+            bitcoin::Network::Regtest,
+            organise_tx,
+        );
+        let worker_handle = tokio::spawn(worker.run());
+
+        emissions_tx
+            .send(create_test_emission_without_commitment())
+            .await
+            .unwrap();
+        drop(emissions_tx);
+
+        worker_handle.await.unwrap();
+
+        assert!(
+            organise_rx.try_recv().is_err(),
+            "No OrganiseEvent expected for PPLNS-only share"
+        );
+        assert!(
+            swarm_rx.try_recv().is_err(),
+            "No SwarmSend expected for PPLNS-only share"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_continues_after_handle_error() {
+        let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<ResponseChannel<Message>>>(10);
+        let (organise_tx, mut organise_rx) = create_organise_channel();
+
+        let mut mock_chain_store = ChainStoreHandle::default();
+        // First call fails, second call succeeds
+        mock_chain_store
+            .expect_add_pplns_share()
+            .times(1)
+            .returning(|_| Err(StoreError::ChannelClosed));
+        mock_chain_store
+            .expect_add_share_block()
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let worker = EmissionWorker::new(
+            emissions_rx,
+            swarm_tx,
+            mock_chain_store,
+            bitcoin::Network::Regtest,
+            organise_tx,
+        );
+        let worker_handle = tokio::spawn(worker.run());
+
+        // First emission: error path (no commitment, store fails)
+        emissions_tx
+            .send(create_test_emission_without_commitment())
+            .await
+            .unwrap();
+        // Second emission: success path (with commitment, store succeeds)
+        emissions_tx
+            .send(create_test_emission_with_commitment())
+            .await
+            .unwrap();
+        drop(emissions_tx);
+
+        worker_handle.await.unwrap();
+
+        // Only the second emission should produce organise + inv events
+        assert!(
+            matches!(organise_rx.try_recv(), Ok(OrganiseEvent::Block(_))),
+            "Expected OrganiseEvent::Block from second emission"
+        );
+        assert!(
+            matches!(swarm_rx.try_recv(), Ok(SwarmSend::Inv(_))),
+            "Expected SwarmSend::Inv from second emission"
+        );
+
+        assert!(
+            organise_rx.try_recv().is_err(),
+            "No more organise events expected"
+        );
+        assert!(
+            swarm_rx.try_recv().is_err(),
+            "No more swarm events expected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_stops_when_channel_closes() {
+        let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
+        let (swarm_tx, _swarm_rx) = mpsc::channel::<SwarmSend<ResponseChannel<Message>>>(10);
+        let (organise_tx, _organise_rx) = create_organise_channel();
+
+        let mock_chain_store = ChainStoreHandle::default();
+
+        let worker = EmissionWorker::new(
+            emissions_rx,
+            swarm_tx,
+            mock_chain_store,
+            bitcoin::Network::Regtest,
+            organise_tx,
+        );
+        let worker_handle = tokio::spawn(worker.run());
+
+        drop(emissions_tx);
+
+        let result = tokio::time::timeout(Duration::from_secs(2), worker_handle).await;
+        assert!(
+            result.is_ok(),
+            "Worker should stop promptly when channel closes"
+        );
     }
 }

--- a/p2poolv2_lib/src/node/emission_worker.rs
+++ b/p2poolv2_lib/src/node/emission_worker.rs
@@ -113,7 +113,6 @@ mod tests {
     use bitcoin::block::Header;
     use bitcoin::hashes::Hash;
     use bitcoin::{BlockHash, CompactTarget};
-    use bitcoin::{Transaction, absolute::LockTime, transaction::Version};
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
@@ -165,17 +164,9 @@ mod tests {
             nonce: 12345,
         };
 
-        let coinbase = Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: vec![],
-            output: vec![],
-        };
-
         Emission {
             pplns,
             header: bitcoin_header,
-            coinbase,
             blocktemplate: Arc::new(create_test_blocktemplate()),
             share_commitment: None,
             coinbase_nsecs: TEST_COINBASE_NSECS,
@@ -205,19 +196,11 @@ mod tests {
             nonce: 12345,
         };
 
-        let coinbase = Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: vec![],
-            output: vec![],
-        };
-
         let commitment = create_test_commitment();
 
         Emission {
             pplns,
             header: bitcoin_header,
-            coinbase,
             blocktemplate: Arc::new(create_test_blocktemplate()),
             share_commitment: Some(commitment),
             coinbase_nsecs: TEST_COINBASE_NSECS,

--- a/p2poolv2_lib/src/node/messages.rs
+++ b/p2poolv2_lib/src/node/messages.rs
@@ -131,18 +131,28 @@ impl Display for RawMessage {
     }
 }
 
+impl Message {
+    /// Returns the variant name as a static string slice.
+    ///
+    /// We need to avoid allocation for debug logging, when we don't
+    /// want to clone message.
+    pub fn message_type(&self) -> &'static str {
+        match self {
+            Message::Inventory(_) => "Inventory",
+            Message::NotFound(_) => "NotFound",
+            Message::GetShareHeaders(_, _) => "GetShareHeaders",
+            Message::GetShareBlocks(_, _) => "GetShareBlocks",
+            Message::ShareHeaders(_) => "ShareHeaders",
+            Message::ShareBlock(_) => "ShareBlock",
+            Message::GetData(_) => "GetData",
+            Message::Transaction(_) => "Transaction",
+        }
+    }
+}
+
 impl Display for Message {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Message::Inventory(_) => write!(f, "Inventory"),
-            Message::NotFound(_) => write!(f, "NotFound"),
-            Message::GetShareHeaders(_, _) => write!(f, "GetShareHeaders"),
-            Message::GetShareBlocks(_, _) => write!(f, "GetShareBlocks"),
-            Message::ShareHeaders(_) => write!(f, "ShareHeaders"),
-            Message::ShareBlock(_) => write!(f, "ShareBlock"),
-            Message::GetData(_) => write!(f, "GetData"),
-            Message::Transaction(_) => write!(f, "Transaction"),
-        }
+        f.write_str(self.message_type())
     }
 }
 

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -523,7 +523,6 @@ mod tests {
             max_miningshare_per_second: 10,
             max_inventory_per_second: 10,
             max_transaction_per_second: 10,
-            rate_limit_window_secs: 1,
             max_requests_per_second: 1,
             dial_timeout_secs: 2,
         };

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -38,7 +38,6 @@ use crate::node::validation_worker::ValidationSender;
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 #[cfg(not(test))]
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
-use crate::shares::share_block::ShareBlock;
 use crate::shares::validation::ShareValidator;
 use behaviour::{P2PoolBehaviour, P2PoolBehaviourEvent};
 use bitcoin::BlockHash;
@@ -89,8 +88,6 @@ pub enum SwarmSend<C> {
     /// that other peers learn about the block and can request it via GetData.
     Inv(BlockHash),
     Disconnect(PeerId),
-    /// Broadcast a share block to all connected peers (from emission worker)
-    Broadcast(ShareBlock),
 }
 
 /// Node is the main struct that represents the node

--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -332,9 +332,13 @@ mod tests {
         let block_hashes = vec![block_hash1, block_hash2];
         let missing = vec![block_hash1];
 
+        chain_store_handle.expect_is_current().returning(|| true);
         chain_store_handle
             .expect_get_missing_blockhashes()
             .returning(move |_| missing.clone());
+        chain_store_handle
+            .expect_build_locator()
+            .return_once(|| Ok(vec![BlockHash::all_zeros()]));
 
         let inventory = InventoryMessage::BlockHashes(block_hashes);
 
@@ -354,13 +358,12 @@ mod tests {
         let result = handle_request(ctx).await;
         assert!(result.is_ok());
 
-        if let Some(SwarmSend::Request(sent_peer, Message::GetData(GetData::Block(hash)))) =
+        if let Some(SwarmSend::Request(sent_peer, Message::GetShareHeaders(_, _))) =
             swarm_rx.recv().await
         {
             assert_eq!(sent_peer, peer_id);
-            assert_eq!(hash, block_hash1);
         } else {
-            panic!("Expected SwarmSend::Request with GetData::Block message");
+            panic!("Expected SwarmSend::Request with GetShareHeaders message");
         }
 
         assert!(

--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -39,7 +39,7 @@ use receivers::share_headers::handle_share_headers;
 use std::error::Error;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 const MAX_HEADERS_IN_RESPONSE: usize = 2000;
 
@@ -98,18 +98,13 @@ pub async fn handle_request<C: Send + Sync, T: TimeProvider + Send + Sync>(
             info!("Received transaction: {:?}", transaction);
             Ok(())
         }
-        Message::ShareBlock(share_block) => handle_share_block(
-            share_block,
-            &ctx.chain_store_handle,
-            ctx.validation_tx,
-            &ctx.block_receiver_handle,
-            ctx.share_validator.as_ref(),
-        )
-        .await
-        .map_err(|e| {
-            error!("Failed to add share from request: {}", e);
-            format!("Failed to add share from request: {e}").into()
-        }),
+        Message::ShareBlock(_) => {
+            warn!(
+                "Ignoring unsolicited ShareBlock from peer {}; blocks should be announced via inv",
+                ctx.peer
+            );
+            Ok(())
+        }
         other => {
             info!("Unexpected request type {other}");
             Ok(())
@@ -180,7 +175,6 @@ mod tests {
     use super::*;
     use crate::node::SwarmSend;
     use crate::node::messages::InventoryMessage;
-    use crate::node::p2p_message_handlers::receivers::block_receiver::BlockReceiverEvent::ShareBlockReceived;
     use crate::node::p2p_message_handlers::receivers::block_receiver::create_block_receiver_channel;
     use crate::node::request_response_handler::block_fetcher::BlockFetcherHandle;
     use crate::node::request_response_handler::block_fetcher::create_block_fetcher_channel;
@@ -628,82 +622,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_request_share_block() {
+    async fn test_handle_request_share_block_ignored() {
         let peer_id = libp2p::PeerId::random();
         let (swarm_tx, _swarm_rx) = mpsc::channel(32);
         let response_channel = 1u32;
-        let mut chain_store_handle = ChainStoreHandle::default();
+        let chain_store_handle = ChainStoreHandle::default();
         let time_provider = TestTimeProvider::new(SystemTime::now());
-        let (block_fetcher_tx, _) = create_block_fetcher_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
-        let (block_receiver_handle, mut block_receiver_rx) = create_block_receiver_channel();
+        let (block_fetcher_handle, validation_tx, block_receiver_handle) = test_handles();
 
         let share_block = valid_share_block_from_fixture();
-
-        // Block not yet in store
-        chain_store_handle
-            .expect_share_block_exists()
-            .returning(|_| false);
-
-        // Mock share validator to accept the share header
-        let mut mock_validator = MockDefaultShareValidator::default();
-        mock_validator
-            .expect_validate_share_header()
-            .returning(|_| Ok(()));
-
-        // Spawn a task to handle the BlockReceiver event and respond Ok
-        tokio::spawn(async move {
-            if let Some(ShareBlockReceived { result_tx, .. }) = block_receiver_rx.recv().await {
-                let _ = result_tx.send(Ok(()));
-            }
-        });
-
-        let ctx = RequestContext {
-            peer: peer_id,
-            request: Message::ShareBlock(share_block),
-            chain_store_handle,
-            response_channel,
-            swarm_tx,
-            time_provider,
-            block_fetcher_handle: block_fetcher_tx,
-            validation_tx,
-            block_receiver_handle,
-            share_validator: Arc::new(mock_validator),
-        };
-
-        let result = handle_request(ctx).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_handle_request_share_block_store_error() {
-        let peer_id = libp2p::PeerId::random();
-        let (swarm_tx, _swarm_rx) = mpsc::channel(32);
-        let response_channel = 1u32;
-        let mut chain_store_handle = ChainStoreHandle::default();
-        let time_provider = TestTimeProvider::new(SystemTime::now());
-        let (block_fetcher_handle, validation_tx, _) = test_handles();
-        let (block_receiver_handle, mut block_receiver_rx) = create_block_receiver_channel();
-
-        let share_block = valid_share_block_from_fixture();
-
-        // Block not yet in store
-        chain_store_handle
-            .expect_share_block_exists()
-            .returning(|_| false);
-
-        // Mock share validator to accept the share header
-        let mut mock_validator = MockDefaultShareValidator::default();
-        mock_validator
-            .expect_validate_share_header()
-            .returning(|_| Ok(()));
-
-        // Spawn a task to handle the BlockReceiver event and respond with error
-        tokio::spawn(async move {
-            if let Some(ShareBlockReceived { result_tx, .. }) = block_receiver_rx.recv().await {
-                let _ = result_tx.send(Err("test store error".into()));
-            }
-        });
 
         let ctx = RequestContext {
             peer: peer_id,
@@ -715,11 +642,14 @@ mod tests {
             block_fetcher_handle,
             validation_tx,
             block_receiver_handle,
-            share_validator: Arc::new(mock_validator),
+            share_validator: Arc::new(MockDefaultShareValidator::default()),
         };
 
         let result = handle_request(ctx).await;
-        assert!(result.is_err());
+        assert!(
+            result.is_ok(),
+            "Unsolicited ShareBlock should be ignored, not error"
+        );
     }
 
     #[tokio::test]

--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -99,7 +99,6 @@ pub async fn handle_request<C: Send + Sync, T: TimeProvider + Send + Sync>(
             Ok(())
         }
         Message::ShareBlock(share_block) => handle_share_block(
-            ctx.peer,
             share_block,
             &ctx.chain_store_handle,
             ctx.validation_tx,
@@ -154,7 +153,6 @@ pub async fn handle_response<C: Send + Sync>(
             e
         }),
         Message::ShareBlock(share_block) => handle_share_block(
-            peer,
             share_block,
             &chain_store_handle,
             validation_tx,

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
@@ -323,11 +323,11 @@ impl BlockReceiver {
     /// Otherwise, if the block's direct parent and all uncles are at
     /// HeaderValid+, validate ASERT, persist, then drive any
     /// descendants buffered in pending. If the parent or uncles are
-    /// not yet ready, buffer in pending and request the missing
-    /// hashes from the block fetcher.
+    /// not yet ready, buffer in pending. The headers-first pipeline
+    /// will supply ancestors via header sync and block fetch.
     async fn process_share_block(
         &mut self,
-        peer_id: libp2p::PeerId,
+        _peer_id: libp2p::PeerId,
         share_block: ShareBlock,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
         let block_hash = share_block.block_hash();
@@ -370,13 +370,6 @@ impl BlockReceiver {
                 ancestors_not_ready.len()
             );
             self.add_to_pending(block_hash, share_block);
-            let _ = self
-                .block_fetcher_handle
-                .send(BlockFetcherEvent::FetchBlocks {
-                    blockhashes: ancestors_not_ready,
-                    peer_id,
-                })
-                .await;
             return Ok(());
         }
 
@@ -841,7 +834,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_process_share_block_missing_parent_buffers_and_fetches() {
+    async fn test_process_share_block_missing_parent_buffers_without_fetching() {
         let missing_parent_hash = BlockHash::from_byte_array([0x99; 32]);
 
         let mut mock_store = ChainStoreHandle::default();
@@ -880,17 +873,10 @@ mod tests {
             other => panic!("Expected BlockReceived, got: {other}"),
         }
 
-        let fetch_event = block_fetcher_rx.try_recv().unwrap();
-        match fetch_event {
-            BlockFetcherEvent::FetchBlocks {
-                blockhashes,
-                peer_id: event_peer_id,
-            } => {
-                assert_eq!(blockhashes, vec![missing_parent_hash]);
-                assert_eq!(event_peer_id, peer_id);
-            }
-            other => panic!("Expected FetchBlocks, got: {other}"),
-        }
+        assert!(
+            block_fetcher_rx.try_recv().is_err(),
+            "No FetchBlocks should be sent; headers-first pipeline supplies ancestors"
+        );
     }
 
     #[tokio::test]

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
@@ -50,7 +50,6 @@ pub enum BlockReceiverEvent {
     /// A new share block arrived from a peer, after passing DoS
     /// validation (validate_share_header) in handle_share_block.
     ShareBlockReceived {
-        peer_id: libp2p::PeerId,
         share_block: ShareBlock,
         result_tx: oneshot::Sender<Result<(), Box<dyn Error + Send + Sync>>>,
     },
@@ -327,7 +326,6 @@ impl BlockReceiver {
     /// will supply ancestors via header sync and block fetch.
     async fn process_share_block(
         &mut self,
-        _peer_id: libp2p::PeerId,
         share_block: ShareBlock,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
         let block_hash = share_block.block_hash();
@@ -444,11 +442,10 @@ impl BlockReceiver {
                 event = self.event_rx.recv() => {
                     match event {
                         Some(BlockReceiverEvent::ShareBlockReceived {
-                            peer_id,
                             share_block,
                             result_tx,
                         }) => {
-                            let result = self.process_share_block(peer_id, share_block).await;
+                            let result = self.process_share_block(share_block).await;
                             let _ = result_tx.send(result);
                         }
                         None => {
@@ -815,8 +812,7 @@ mod tests {
             CompactTarget::from_consensus(crate::shares::share_block::MAX_POOL_TARGET);
         let child_hash = child_block.block_hash();
 
-        let peer_id = libp2p::PeerId::random();
-        let result = receiver.process_share_block(peer_id, child_block).await;
+        let result = receiver.process_share_block(child_block).await;
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
 
         assert_eq!(receiver.pending_count(), 0);
@@ -860,8 +856,7 @@ mod tests {
             .build();
         let child_hash = child_block.block_hash();
 
-        let peer_id = libp2p::PeerId::random();
-        let result = receiver.process_share_block(peer_id, child_block).await;
+        let result = receiver.process_share_block(child_block).await;
         assert!(result.is_ok());
 
         assert_eq!(receiver.pending_count(), 1);
@@ -903,9 +898,7 @@ mod tests {
         );
 
         let block = TestShareBlockBuilder::new().nonce(0xe9695791).build();
-        let result = receiver
-            .process_share_block(libp2p::PeerId::random(), block)
-            .await;
+        let result = receiver.process_share_block(block).await;
         assert!(result.is_ok());
 
         assert!(block_fetcher_rx.try_recv().is_err());
@@ -977,9 +970,7 @@ mod tests {
             CompactTarget::from_consensus(crate::shares::share_block::MAX_POOL_TARGET);
         let child_hash = child_block.block_hash();
 
-        let result = receiver
-            .process_share_block(libp2p::PeerId::random(), child_block)
-            .await;
+        let result = receiver.process_share_block(child_block).await;
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
 
         let event = validation_rx.try_recv().unwrap();
@@ -1043,9 +1034,7 @@ mod tests {
         child_block.header.bits =
             CompactTarget::from_consensus(crate::shares::share_block::MAX_POOL_TARGET);
 
-        let result = receiver
-            .process_share_block(libp2p::PeerId::random(), child_block)
-            .await;
+        let result = receiver.process_share_block(child_block).await;
         assert!(result.is_ok());
 
         // Block must NOT enter the store and validation must NOT be emitted.
@@ -1147,17 +1136,15 @@ mod tests {
             validation_tx,
         );
 
-        let peer_id = libp2p::PeerId::random();
-
         // Child arrives first -- parent is missing in store, so child
         // is buffered.
-        let result = receiver.process_share_block(peer_id, child_block).await;
+        let result = receiver.process_share_block(child_block).await;
         assert!(result.is_ok());
         assert_eq!(receiver.pending_count(), 1);
 
         // Parent arrives -- commits itself, then cascade commits the
         // buffered child.
-        let result = receiver.process_share_block(peer_id, parent_block).await;
+        let result = receiver.process_share_block(parent_block).await;
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
 
         assert_eq!(receiver.pending_count(), 0);
@@ -1202,11 +1189,9 @@ mod tests {
             .nonce(0xe9695791)
             .build();
 
-        let peer_id = libp2p::PeerId::random();
         let (result_tx, result_rx) = oneshot::channel();
         event_tx
             .send(BlockReceiverEvent::ShareBlockReceived {
-                peer_id,
                 share_block: child_block,
                 result_tx,
             })

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/inventory.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/inventory.rs
@@ -15,7 +15,8 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::node::SwarmSend;
-use crate::node::messages::{GetData, InventoryMessage, Message};
+use crate::node::messages::InventoryMessage;
+use crate::node::p2p_message_handlers::senders::send_getheaders;
 #[cfg(test)]
 #[mockall_double::double]
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
@@ -27,13 +28,14 @@ use tracing::debug;
 
 /// Handle an Inventory message received from a peer.
 ///
-/// Inventory is sent unsolicited when a node becomes aware of a
-/// block, or in response to a getblocks message.  For BlockHashes, we
-/// check which blocks we are missing and send GetData requests back
-/// to the originating peer for each missing block.
+/// When the candidate chain is current, responds to block
+/// announcements by sending a getheaders request to sync any missing
+/// headers from the announcing peer. The headers-first pipeline then
+/// fetches the actual block data.
 ///
-/// The inventory supports list of blockhashes and transactions. Even
-/// though for now we only ever send a vector with a single blockhash.
+/// When the candidate chain is not current (initial sync in
+/// progress), inv messages are ignored because header sync will
+/// catch up independently.
 pub async fn handle_inventory<C: Send + Sync>(
     inventory: InventoryMessage,
     peer: libp2p::PeerId,
@@ -46,25 +48,20 @@ pub async fn handle_inventory<C: Send + Sync>(
         InventoryMessage::BlockHashes(blockhashes) => {
             debug!("Received block hashes locator: {:?}", blockhashes);
 
+            if !chain_store_handle.is_current() {
+                debug!("Chain not current, ignoring inv from peer {peer}");
+                return Ok(());
+            }
+
             let missing_blocks = chain_store_handle.get_missing_blockhashes(&blockhashes);
 
             if !missing_blocks.is_empty() {
                 debug!(
-                    "Requesting {} missing blocks from peer {}",
+                    "Have {} missing blocks from peer {}, sending getheaders",
                     missing_blocks.len(),
                     peer
                 );
-                for block_hash in missing_blocks {
-                    let get_block_request = Message::GetData(GetData::Block(block_hash));
-                    swarm_tx
-                        .send(SwarmSend::Request(peer, get_block_request))
-                        .await
-                        .map_err(|send_error| {
-                            format!(
-                                "Failed to send GetData request for block {block_hash}: {send_error}"
-                            )
-                        })?;
-                }
+                send_getheaders(peer, chain_store_handle, swarm_tx).await?;
             }
         }
         InventoryMessage::TransactionHashes(transaction_hashes) => {
@@ -81,34 +78,34 @@ pub async fn handle_inventory<C: Send + Sync>(
 #[cfg(test)]
 mod tests {
     use super::ChainStoreHandle;
-    use crate::node::messages::{GetData, InventoryMessage};
+    use crate::node::messages::InventoryMessage;
     use crate::node::p2p_message_handlers::receivers::inventory::handle_inventory;
     use crate::node::{Message, SwarmSend};
     use crate::test_utils::TestShareBlockBuilder;
     use bitcoin::BlockHash;
+    use bitcoin::hashes::Hash;
     use mockall::predicate::*;
     use tokio::sync::mpsc;
 
     #[tokio::test]
-    async fn test_handle_inventory_block_hashes() {
+    async fn test_handle_inventory_sends_getheaders_when_current() {
         let mut chain_store_handle = ChainStoreHandle::default();
         let peer_id = libp2p::PeerId::random();
 
         let block1 = TestShareBlockBuilder::new().build();
-        let block2 = TestShareBlockBuilder::new().build();
-        let block3 = TestShareBlockBuilder::new().build();
-
         let block_hash1: BlockHash = block1.block_hash();
-        let block_hash2: BlockHash = block2.block_hash();
-        let block_hash3: BlockHash = block3.block_hash();
 
-        let blockhashes = vec![block_hash1, block_hash2, block_hash3];
-        let missing_blocks = vec![block_hash1, block_hash3];
+        let blockhashes = vec![block_hash1];
+        let missing_blocks = vec![block_hash1];
 
+        chain_store_handle.expect_is_current().returning(|| true);
         chain_store_handle
             .expect_get_missing_blockhashes()
             .with(eq(blockhashes.clone()))
             .returning(move |_| missing_blocks.clone());
+        chain_store_handle
+            .expect_build_locator()
+            .return_once(|| Ok(vec![BlockHash::all_zeros()]));
 
         let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
 
@@ -117,27 +114,41 @@ mod tests {
 
         assert!(result.is_ok(), "handle_inventory should return Ok");
 
-        let message1 = swarm_rx.recv().await.unwrap();
-        match message1 {
-            SwarmSend::Request(sent_peer, Message::GetData(GetData::Block(hash))) => {
+        let message = swarm_rx.recv().await.unwrap();
+        match message {
+            SwarmSend::Request(sent_peer, Message::GetShareHeaders(locator, stop_hash)) => {
                 assert_eq!(sent_peer, peer_id);
-                assert_eq!(hash, block_hash1);
+                assert_eq!(locator, vec![BlockHash::all_zeros()]);
+                assert_eq!(stop_hash, BlockHash::all_zeros());
             }
-            _ => panic!("Expected SwarmSend::Request with GetData::Block for block_hash1"),
-        }
-
-        let message2 = swarm_rx.recv().await.unwrap();
-        match message2 {
-            SwarmSend::Request(sent_peer, Message::GetData(GetData::Block(hash))) => {
-                assert_eq!(sent_peer, peer_id);
-                assert_eq!(hash, block_hash3);
-            }
-            _ => panic!("Expected SwarmSend::Request with GetData::Block for block_hash3"),
+            _ => panic!("Expected SwarmSend::Request with GetShareHeaders"),
         }
 
         assert!(
             swarm_rx.try_recv().is_err(),
             "No more messages should have been sent"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_inventory_ignored_when_not_current() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        let peer_id = libp2p::PeerId::random();
+
+        let block1 = TestShareBlockBuilder::new().build();
+        let block_hash1: BlockHash = block1.block_hash();
+
+        chain_store_handle.expect_is_current().returning(|| false);
+
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+
+        let inventory = InventoryMessage::BlockHashes(vec![block_hash1]);
+        let result = handle_inventory(inventory, peer_id, chain_store_handle, swarm_tx).await;
+
+        assert!(result.is_ok());
+        assert!(
+            swarm_rx.try_recv().is_err(),
+            "No messages should be sent when chain is not current"
         );
     }
 
@@ -149,6 +160,7 @@ mod tests {
         let block1 = TestShareBlockBuilder::new().build();
         let block_hash1: BlockHash = block1.block_hash();
 
+        chain_store_handle.expect_is_current().returning(|| true);
         chain_store_handle
             .expect_get_missing_blockhashes()
             .returning(|_| Vec::with_capacity(0));

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_blocks.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_blocks.rs
@@ -42,7 +42,6 @@ use tracing::{debug, error, warn};
 /// complete, validates ASERT difficulty, stores them, and sends them to
 /// the validation worker.
 pub async fn handle_share_block(
-    peer_id: libp2p::PeerId,
     share_block: ShareBlock,
     chain_store_handle: &ChainStoreHandle,
     validation_tx: ValidationSender,
@@ -83,7 +82,6 @@ pub async fn handle_share_block(
     let (result_tx, result_rx) = oneshot::channel();
     if let Err(send_error) = block_receiver_handle
         .send(BlockReceiverEvent::ShareBlockReceived {
-            peer_id,
             share_block,
             result_tx,
         })
@@ -122,7 +120,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_share_block_success() {
-        let peer_id = libp2p::PeerId::random();
         let mut chain_store_handle = ChainStoreHandle::default();
         let test_data = load_share_headers_test_data();
         let header: ShareHeader =
@@ -154,7 +151,6 @@ mod tests {
         });
 
         let result = handle_share_block(
-            peer_id,
             share_block,
             &chain_store_handle,
             validation_tx,
@@ -167,7 +163,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_share_block_confirmed_duplicate_skips() {
-        let peer_id = libp2p::PeerId::random();
         let mut chain_store_handle = ChainStoreHandle::default();
         let test_data = load_share_headers_test_data();
         let header: ShareHeader =
@@ -188,7 +183,6 @@ mod tests {
 
         let (validation_tx, mut validation_rx, block_receiver_handle) = test_handles();
         let result = handle_share_block(
-            peer_id,
             share_block,
             &chain_store_handle,
             validation_tx,
@@ -206,7 +200,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_share_block_unconfirmed_duplicate_triggers_validation() {
-        let peer_id = libp2p::PeerId::random();
         let mut chain_store_handle = ChainStoreHandle::default();
         let test_data = load_share_headers_test_data();
         let header: ShareHeader =
@@ -227,7 +220,6 @@ mod tests {
 
         let (validation_tx, mut validation_rx, block_receiver_handle) = test_handles();
         let result = handle_share_block(
-            peer_id,
             share_block,
             &chain_store_handle,
             validation_tx,
@@ -247,7 +239,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_share_block_invalid_header_rejected() {
-        let peer_id = libp2p::PeerId::random();
         let mut chain_store_handle = ChainStoreHandle::default();
         let test_data = load_share_headers_test_data();
         let header: ShareHeader =
@@ -272,7 +263,6 @@ mod tests {
 
         let (validation_tx, mut validation_rx, block_receiver_handle) = test_handles();
         let result = handle_share_block(
-            peer_id,
             share_block,
             &chain_store_handle,
             validation_tx,

--- a/p2poolv2_lib/src/node/p2p_message_handlers/senders/getheaders.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/senders/getheaders.rs
@@ -29,7 +29,7 @@ use tracing::{debug, error};
 
 /// Handle outbound connection established events
 /// Send a getheaders request to the peer
-pub async fn send_getheaders<C: 'static>(
+pub async fn send_getheaders<C>(
     peer_id: libp2p::PeerId,
     chain_store_handle: ChainStoreHandle,
     swarm_tx: mpsc::Sender<SwarmSend<C>>,

--- a/p2poolv2_lib/src/node/request_response_handler/block_fetcher/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/block_fetcher/mod.rs
@@ -42,7 +42,8 @@ const MAX_IN_FLIGHT_PER_PEER: usize = 16;
 const INITIAL_IN_FLIGHT_CAPACITY: usize = 64;
 
 /// Default timeout for a single block request before retrying.
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Should remain same as libp2p request timeout.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// How often the fetcher checks for timed-out requests.
 const TICK_INTERVAL: Duration = Duration::from_secs(5);

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -580,6 +580,7 @@ mod tests {
         let mut chain_store_handle = ChainStoreHandle::default();
         chain_store_handle.expect_clone().returning(|| {
             let mut cloned = ChainStoreHandle::default();
+            cloned.expect_is_current().returning(|| true);
             cloned
                 .expect_get_missing_blockhashes()
                 .returning(|_| Vec::with_capacity(0));
@@ -682,6 +683,7 @@ mod tests {
         let mut chain_store_handle = ChainStoreHandle::default();
         chain_store_handle.expect_clone().returning(|| {
             let mut cloned = ChainStoreHandle::default();
+            cloned.expect_is_current().returning(|| true);
             cloned
                 .expect_get_missing_blockhashes()
                 .returning(|_| Vec::with_capacity(0));

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tower::util::BoxService;
 use tower::{Service, ServiceExt};
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 /// Handles request-response events from the libp2p network.
 ///
@@ -129,8 +129,8 @@ impl RequestResponseHandler<ResponseChannel<Message>> {
                     },
             } => {
                 debug!(
-                    "Received response for request {} from peer {}",
-                    request_id, peer
+                    "Received response {} for request {} from peer {}",
+                    response, request_id, peer
                 );
                 self.dispatch_response(peer, response).await
             }
@@ -231,6 +231,7 @@ impl<C: Send + Sync> RequestResponseHandler<C> {
             }
             Ok(Err(err)) => {
                 error!("Service not ready for peer {}: {}", peer, err);
+                info!("Disconnecting peer {} due to service not ready", peer);
                 if let Err(send_err) = self.swarm_tx.send(SwarmSend::Disconnect(peer)).await {
                     error!(
                         "Failed to send disconnect command for peer {}: {:?}",
@@ -240,6 +241,10 @@ impl<C: Send + Sync> RequestResponseHandler<C> {
             }
             Err(_) => {
                 error!("Service readiness timed out for peer {}", peer);
+                info!(
+                    "Disconnecting peer {} due to rate limiter timeout on request {}",
+                    peer, request
+                );
                 if let Err(send_err) = self.swarm_tx.send(SwarmSend::Disconnect(peer)).await {
                     error!(
                         "Failed to send disconnect command for peer {}: {:?}",

--- a/p2poolv2_lib/src/service/mod.rs
+++ b/p2poolv2_lib/src/service/mod.rs
@@ -35,7 +35,7 @@ where
 
     let builder = ServiceBuilder::new().layer(RateLimitLayer::new(
         config.max_requests_per_second,
-        Duration::from_secs(1),
+        Duration::from_secs(1), // We have rate limit per second, so duration hardcoded to 1s
     ));
 
     let service = builder.service(base_service);

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -27,6 +27,7 @@ use crate::store::dag_store::{ShareDag, UncleInfo};
 use crate::store::writer::{StoreError, StoreHandle};
 use bitcoin::{BlockHash, Work};
 use std::collections::{HashMap, HashSet};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, info};
 
 /// A confirmed header with its height, blockhash, and share header.
@@ -43,6 +44,10 @@ pub(crate) const COMMON_ANCESTOR_DEPTH: usize = 2160; // 6 shares per minute * 6
 
 /// PPLNS window in shares
 const PPLNS_WINDOW: usize = 2160; // 6 shares per minute * 60 * 6 hours.
+
+/// Maximum age in seconds for the confirmed chain tip to be considered
+/// current. Used to suppress block fetching during initial header sync.
+const MAX_TIP_AGE_SECS: u64 = 60;
 
 /// Handle for chain-level store operations.
 ///
@@ -268,6 +273,25 @@ impl ChainStoreHandle {
             .next()
             .map(|(_, header)| header)
             .ok_or_else(|| StoreError::NotFound("No header found for chain tip".into()))
+    }
+
+    /// Check whether the top confirmed header is current.
+    ///
+    /// Returns true when the confirmed chain tip timestamp is within
+    /// 60 seconds of the current system time. Returns false when the
+    /// tip is stale or when any store lookup fails (e.g. no confirmed
+    /// chain yet).
+    pub fn is_current(&self) -> bool {
+        let tip_header = match self.get_chain_tip_header() {
+            Ok(header) => header,
+            Err(_) => return false,
+        };
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let tip_time = tip_header.time as u64;
+        now_secs.saturating_sub(tip_time) <= MAX_TIP_AGE_SECS
     }
 
     /// Get the confirmed tip height and parent time for ASERT target
@@ -728,6 +752,7 @@ mockall::mock! {
         pub fn build_locator(&self) -> Result<Vec<BlockHash>, StoreError>;
         pub fn get_chain_tip(&self) -> Result<BlockHash, StoreError>;
         pub fn get_chain_tip_header(&self) -> Result<ShareHeader, StoreError>;
+        pub fn is_current(&self) -> bool;
         pub fn get_chain_tip_and_uncles(&self) -> Result<(BlockHash, HashSet<BlockHash>), StoreError>;
         pub fn get_tip_height_and_time(&self) -> Result<(u32, u32), StoreError>;
         pub fn get_genesis_blockhash(&self) -> Option<BlockHash>;
@@ -1033,5 +1058,64 @@ mod tests {
         // No genesis, no confirmed shares -- range query returns empty
         let headers = chain_handle.get_confirmed_headers_in_range(0, 10).unwrap();
         assert!(headers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_is_current_returns_false_when_no_chain_tip() {
+        let (chain_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+        // No genesis initialised, so get_chain_tip_header will fail
+        assert!(!chain_handle.is_current());
+    }
+
+    #[tokio::test]
+    async fn test_is_current_returns_true_when_tip_is_recent() {
+        let (chain_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as u32;
+
+        let genesis = TestShareBlockBuilder::new().time(now_secs).build();
+
+        chain_handle.init_or_setup_genesis(genesis).await.unwrap();
+
+        assert!(chain_handle.is_current());
+    }
+
+    #[tokio::test]
+    async fn test_is_current_returns_false_when_tip_is_stale() {
+        let (chain_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as u32;
+        // Set the tip timestamp 120 seconds in the past, well beyond the 60s threshold
+        let stale_time = now_secs.saturating_sub(120);
+
+        let genesis = TestShareBlockBuilder::new().time(stale_time).build();
+
+        chain_handle.init_or_setup_genesis(genesis).await.unwrap();
+
+        assert!(!chain_handle.is_current());
+    }
+
+    #[tokio::test]
+    async fn test_is_current_returns_true_at_boundary() {
+        let (chain_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as u32;
+        // Set the tip timestamp exactly at the MAX_TIP_AGE_SECS boundary
+        let boundary_time = now_secs.saturating_sub(super::MAX_TIP_AGE_SECS as u32);
+
+        let genesis = TestShareBlockBuilder::new().time(boundary_time).build();
+
+        chain_handle.init_or_setup_genesis(genesis).await.unwrap();
+
+        assert!(chain_handle.is_current());
     }
 }

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -278,13 +278,13 @@ impl ChainStoreHandle {
     /// Get the ShareHeader at the candidate chain tip.
     ///
     /// Returns the header of the highest-work block on the candidate
-    /// chain. Falls back to the confirmed tip if no candidate exists
-    /// (e.g. fresh node before first header sync).
+    /// chain. Falls back to the confirmed tip if no candidate is found.
     pub fn get_candidate_tip_header(&self) -> Result<ShareHeader, StoreError> {
         let top_candidate = self.store_handle.store().get_top_candidate();
         match top_candidate {
             Ok(top) => self.get_share_header(&top.hash),
-            Err(_) => self.get_chain_tip_header(),
+            Err(StoreError::NotFound(_)) => self.get_chain_tip_header(),
+            Err(error) => Err(error),
         }
     }
 

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -275,14 +275,28 @@ impl ChainStoreHandle {
             .ok_or_else(|| StoreError::NotFound("No header found for chain tip".into()))
     }
 
-    /// Check whether the top confirmed header is current.
+    /// Get the ShareHeader at the candidate chain tip.
     ///
-    /// Returns true when the confirmed chain tip timestamp is within
-    /// 60 seconds of the current system time. Returns false when the
-    /// tip is stale or when any store lookup fails (e.g. no confirmed
-    /// chain yet).
+    /// Returns the header of the highest-work block on the candidate
+    /// chain. Falls back to the confirmed tip if no candidate exists
+    /// (e.g. fresh node before first header sync).
+    pub fn get_candidate_tip_header(&self) -> Result<ShareHeader, StoreError> {
+        let top_candidate = self.store_handle.store().get_top_candidate();
+        match top_candidate {
+            Ok(top) => self.get_share_header(&top.hash),
+            Err(_) => self.get_chain_tip_header(),
+        }
+    }
+
+    /// Check whether the candidate chain tip is current.
+    ///
+    /// Returns true when the candidate chain tip timestamp is within
+    /// MAX_TIP_AGE_SECS seconds of the current system time. Returns
+    /// false when the tip is stale or when any store lookup fails
+    /// (e.g. no chain yet). Falls back to the confirmed tip if no
+    /// candidate exists.
     pub fn is_current(&self) -> bool {
-        let tip_header = match self.get_chain_tip_header() {
+        let tip_header = match self.get_candidate_tip_header() {
             Ok(header) => header,
             Err(_) => return false,
         };
@@ -752,6 +766,7 @@ mockall::mock! {
         pub fn build_locator(&self) -> Result<Vec<BlockHash>, StoreError>;
         pub fn get_chain_tip(&self) -> Result<BlockHash, StoreError>;
         pub fn get_chain_tip_header(&self) -> Result<ShareHeader, StoreError>;
+        pub fn get_candidate_tip_header(&self) -> Result<ShareHeader, StoreError>;
         pub fn is_current(&self) -> bool;
         pub fn get_chain_tip_and_uncles(&self) -> Result<(BlockHash, HashSet<BlockHash>), StoreError>;
         pub fn get_tip_height_and_time(&self) -> Result<(u32, u32), StoreError>;

--- a/p2poolv2_lib/src/shares/handle_stratum_share.rs
+++ b/p2poolv2_lib/src/shares/handle_stratum_share.rs
@@ -39,7 +39,6 @@ pub async fn handle_stratum_share(
     let Emission {
         pplns,
         header,
-        coinbase,
         blocktemplate,
         share_commitment,
         coinbase_nsecs,
@@ -89,14 +88,9 @@ pub async fn handle_stratum_share(
             extranonce,
         );
 
-        let mut bitcoin_transactions = Vec::with_capacity(blocktemplate.transactions.len() + 1);
-        bitcoin_transactions.push(coinbase);
-        bitcoin_transactions.extend(blocktemplate.decode_transactions());
-
         let share_block = ShareBlock {
             header: share_header,
             transactions: share_transactions,
-            bitcoin_transactions,
             template_merkle_branches,
         };
 
@@ -188,18 +182,9 @@ mod tests {
             nonce: 12345,
         };
 
-        // Create a minimal coinbase transaction
-        let coinbase = Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: vec![],
-            output: vec![],
-        };
-
         Emission {
             pplns,
             header: bitcoin_header,
-            coinbase,
             blocktemplate: Arc::new(create_test_blocktemplate()),
             share_commitment: None,
             coinbase_nsecs: TEST_COINBASE_NSECS,
@@ -230,20 +215,11 @@ mod tests {
             nonce: 12345,
         };
 
-        // Create a minimal coinbase transaction
-        let coinbase = Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: vec![],
-            output: vec![],
-        };
-
         let commitment = create_test_commitment();
 
         Emission {
             pplns,
             header: bitcoin_header,
-            coinbase,
             blocktemplate: Arc::new(create_test_blocktemplate()),
             share_commitment: Some(commitment),
             coinbase_nsecs: TEST_COINBASE_NSECS,
@@ -289,8 +265,6 @@ mod tests {
         let share_block = share_block.unwrap();
         // Verify the share block has the expected structure
         assert_eq!(share_block.transactions.len(), 1); // One share coinbase
-        // bitcoin_transactions includes the emission coinbase (1) + decoded template txs (0)
-        assert_eq!(share_block.bitcoin_transactions.len(), 1);
     }
 
     #[tokio::test]
@@ -379,14 +353,6 @@ mod tests {
             nonce: 12345,
         };
 
-        // Create a coinbase transaction
-        let coinbase = Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: vec![],
-            output: vec![],
-        };
-
         // Create a valid template transaction by serializing a real Transaction
         let template_source_tx = Transaction {
             version: Version::TWO,
@@ -416,7 +382,6 @@ mod tests {
         let emission = Emission {
             pplns,
             header: bitcoin_header,
-            coinbase,
             blocktemplate: Arc::new(blocktemplate),
             share_commitment: Some(commitment),
             coinbase_nsecs: TEST_COINBASE_NSECS,
@@ -431,9 +396,6 @@ mod tests {
 
         assert!(result.is_ok());
         let share_block = result.unwrap().unwrap();
-
-        // Verify bitcoin transactions are included (1 coinbase + 2 from template)
-        assert_eq!(share_block.bitcoin_transactions.len(), 3);
 
         // Verify merkle branches are passed through from Emission to ShareBlock
         assert_eq!(share_block.template_merkle_branches.len(), 2);

--- a/p2poolv2_lib/src/shares/share_block/mod.rs
+++ b/p2poolv2_lib/src/shares/share_block/mod.rs
@@ -26,8 +26,7 @@ use crate::shares::witness_commitment::WitnessCommitment;
 use crate::stratum::work::coinbase::extract_height_from_coinbase;
 use bitcoin::consensus::encode::Error::ParseFailed;
 use bitcoin::{
-    Address, BlockHash, CompactTarget, CompressedPublicKey, Target, Transaction, TxMerkleNode,
-    Txid, VarInt,
+    Address, BlockHash, CompactTarget, CompressedPublicKey, Target, TxMerkleNode, Txid, VarInt,
     block::Header,
     consensus::{Decodable, Encodable},
     hashes::Hash,
@@ -306,11 +305,6 @@ pub struct ShareBlock {
     pub header: ShareHeader,
     /// Share chain transactions - including the coinbase for the share.
     pub transactions: Vec<ShareTransaction>,
-    /// Bitcoin transactions, making for a full share block. These are
-    /// only useful when building a block to submitting to
-    /// bitcoin. These are not stored, or used in share validation.
-    #[serde(skip)]
-    pub bitcoin_transactions: Vec<Transaction>,
     /// Merkle path (branches) from coinbase position to the bitcoin
     /// merkle root. Used by validators to verify the bitcoin header's
     /// merkle_root matches the reconstructed coinbase.
@@ -404,7 +398,6 @@ impl ShareBlock {
         Ok(Self {
             header,
             transactions,
-            bitcoin_transactions: vec![],
             template_merkle_branches: vec![],
         })
     }
@@ -413,9 +406,7 @@ impl ShareBlock {
 /// Encode ShareBlock using rust-bitcoin Encodable support
 ///
 /// We have a new type ShareTransaction and have to encode a vector of
-/// `transactions` manually. The `bitcoin_transactions` is a vector of
-/// Transaction and rust-bitcoin provides encoding for vec of their
-/// types out of the box.
+/// `transactions` manually.
 impl Encodable for ShareBlock {
     fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
         &self,
@@ -428,7 +419,6 @@ impl Encodable for ShareBlock {
         for tx in &self.transactions {
             len += tx.consensus_encode(w)?;
         }
-        len += self.bitcoin_transactions.consensus_encode(w)?;
         // Encode template merkle path
         len += VarInt(self.template_merkle_branches.len() as u64).consensus_encode(w)?;
         for node in &self.template_merkle_branches {
@@ -440,7 +430,7 @@ impl Encodable for ShareBlock {
 
 /// Decode ShareBlock using rust-bitcoin.
 ///
-/// See comment on Encodable for handling `transactions` vs `bitcoin_transactions`
+/// See comment on Encodable for handling `transactions`.
 impl Decodable for ShareBlock {
     fn consensus_decode<R: bitcoin::io::Read + ?Sized>(
         r: &mut R,
@@ -454,7 +444,6 @@ impl Decodable for ShareBlock {
         for _ in 0..tx_count {
             transactions.push(ShareTransaction::consensus_decode(r)?);
         }
-        let bitcoin_transactions = Vec::<Transaction>::consensus_decode(r)?;
         // Decode template merkle path
         let path_count = VarInt::consensus_decode(r)?.0 as usize;
         let max_path_capacity = 32; // merkle path depth is at most ~30 for any realistic block
@@ -468,7 +457,6 @@ impl Decodable for ShareBlock {
         Ok(ShareBlock {
             header,
             transactions,
-            bitcoin_transactions,
             template_merkle_branches,
         })
     }

--- a/p2poolv2_lib/src/shares/share_commitment.rs
+++ b/p2poolv2_lib/src/shares/share_commitment.rs
@@ -534,11 +534,8 @@ mod tests {
         assert!(result.unwrap().is_none());
     }
 
-    /// Build a ShareHeader from a commitment and a realistic bitcoin coinbase,
-    /// returning both the header and the bitcoin transactions list.
-    fn header_and_bitcoin_transactions_from_commitment(
-        commitment: ShareCommitment,
-    ) -> (ShareHeader, Vec<bitcoin::Transaction>) {
+    /// Build a ShareHeader from a commitment and a realistic bitcoin coinbase.
+    fn header_from_commitment(commitment: ShareCommitment) -> ShareHeader {
         let coinbase = test_coinbase_transaction(1);
 
         let share_merkle_root: TxMerkleNode = bitcoin::merkle_tree::calculate_root(
@@ -574,7 +571,7 @@ mod tests {
             nonce: 0,
         };
 
-        let header = ShareHeader::from_commitment_and_header(
+        ShareHeader::from_commitment_and_header(
             commitment,
             bitcoin_header,
             share_merkle_root,
@@ -590,9 +587,7 @@ mod tests {
             template.height as u64,
             0,
             Extranonce::default(),
-        );
-
-        (header, bitcoin_transactions)
+        )
     }
 
     #[test]
@@ -604,8 +599,7 @@ mod tests {
         let expected_bits = commitment.bits;
         let expected_time = commitment.time;
 
-        let (header, _bitcoin_transactions) =
-            header_and_bitcoin_transactions_from_commitment(commitment);
+        let header = header_from_commitment(commitment);
 
         let reconstructed = ShareCommitment::from_share_header(&header);
 
@@ -628,8 +622,7 @@ mod tests {
         let commitment = create_test_commitment();
         let expected_hash = commitment.hash();
 
-        let (header, _bitcoin_transactions) =
-            header_and_bitcoin_transactions_from_commitment(commitment);
+        let header = header_from_commitment(commitment);
 
         let reconstructed = ShareCommitment::from_share_header(&header);
 
@@ -707,8 +700,7 @@ mod tests {
 
         let expected_hash = commitment.hash();
 
-        let (header, _bitcoin_transactions) =
-            header_and_bitcoin_transactions_from_commitment(commitment);
+        let header = header_from_commitment(commitment);
 
         assert_eq!(header.donation_address, Some(donation_address));
         assert_eq!(header.donation, Some(150));

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -2628,7 +2628,6 @@ mod tests {
         .unwrap();
 
         share_block.header.bitcoin_header.merkle_root = coinbase_tx.compute_txid().into();
-        share_block.bitcoin_transactions = vec![coinbase_tx];
 
         // Mock PplnsWindow returning matching 60/40 distribution
         let mut mock_window = PplnsWindow::default();
@@ -2699,7 +2698,6 @@ mod tests {
         .unwrap();
 
         share_block.header.bitcoin_header.merkle_root = coinbase_tx.compute_txid().into();
-        share_block.bitcoin_transactions = vec![coinbase_tx];
 
         // Mock PplnsWindow returning 60/40 distribution
         let mut mock_window = PplnsWindow::default();
@@ -2783,7 +2781,6 @@ mod tests {
         let mut share_block = TestShareBlockBuilder::new()
             .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
             .build();
-        share_block.bitcoin_transactions = vec![coinbase_tx];
 
         let mut mock_window = PplnsWindow::default();
         mock_window
@@ -2838,7 +2835,6 @@ mod tests {
         .unwrap();
 
         share_block.header.bitcoin_header.merkle_root = coinbase_tx.compute_txid().into();
-        share_block.bitcoin_transactions = vec![coinbase_tx];
 
         let mut mock_window = PplnsWindow::default();
         mock_window
@@ -2952,7 +2948,6 @@ mod tests {
         .unwrap();
 
         share_block.header.bitcoin_header.merkle_root = coinbase_tx.compute_txid().into();
-        share_block.bitcoin_transactions = vec![coinbase_tx];
 
         // Mock PplnsWindow returning 3 miners with difficulties 500, 300, 200
         let mut mock_window = PplnsWindow::default();
@@ -3063,11 +3058,6 @@ mod tests {
             .map(TxMerkleNode::from_raw_hash)
             .collect();
 
-        let mut bitcoin_transactions = Vec::with_capacity(template_transactions.len() + 1);
-        bitcoin_transactions.push(coinbase_tx);
-        bitcoin_transactions.extend(template_transactions);
-        share_block.bitcoin_transactions = bitcoin_transactions;
-
         // Mock PplnsWindow returning 100% to address_a
         let mut mock_window = PplnsWindow::default();
         mock_window
@@ -3093,27 +3083,6 @@ mod tests {
             share_block.template_merkle_branches.len(),
             3,
             "Expected 3 merkle branches for 4 template transactions"
-        );
-
-        // Validation should still pass with empty bitcoin_transactions,
-        // proving the validator uses merkle branches, not the raw transactions.
-        share_block.bitcoin_transactions = vec![];
-
-        let mut mock_window = PplnsWindow::default();
-        mock_window
-            .expect_network()
-            .return_const(bitcoin::Network::Signet);
-        let addr_a_clone = address_a.clone();
-        mock_window
-            .expect_get_distribution_from_start_hash()
-            .returning(move |_, _| Some(HashMap::from([(addr_a_clone.clone(), 1000u128)])));
-        let pplns_window = Arc::new(RwLock::new(mock_window));
-
-        let result = validator.validate_bitcoin_payout(&share_block, pplns_window);
-        assert!(
-            result.is_ok(),
-            "Validation should pass without bitcoin_transactions, got: {}",
-            result.unwrap_err()
         );
     }
 

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -972,13 +972,15 @@ mod tests {
         assert_eq!(descendants[0], uncle1.block_hash());
         assert_eq!(descendants[1], share_b.block_hash());
 
-        // Test with limit
+        // Test with limit: limit=2 stops after height 1 (share_a) but height 2
+        // adds uncle1 + share_b atomically so the batch contains all 3
         let descendants = store
             .get_descendant_blockhashes(&genesis.block_hash(), &BlockHash::all_zeros(), 2)
             .unwrap();
-        assert_eq!(descendants.len(), 2);
+        assert_eq!(descendants.len(), 3);
         assert_eq!(descendants[0], share_a.block_hash());
         assert_eq!(descendants[1], uncle1.block_hash());
+        assert_eq!(descendants[2], share_b.block_hash());
 
         // Test with stop_blockhash - stop at share_a includes share_a
         let descendants = store

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -227,19 +227,18 @@ impl Store {
         while height <= top_confirmed_height && blockhashes.len() < limit {
             let confirmed_hash = self.get_confirmed_at_height(height)?;
 
-            // Insert uncle blockhashes before the confirmed block
+            // Insert uncle blockhashes before the confirmed block.
+            // We only check the limit at the top of the loop so that a
+            // confirmed block and its uncles are never split across batches.
             if let Ok(Some(header)) = self.get_share_header(&confirmed_hash) {
                 for uncle_blockhash in &header.uncles {
-                    if blockhashes.len() >= limit {
-                        return Ok(blockhashes);
-                    }
                     if seen.insert(*uncle_blockhash) {
                         blockhashes.push(*uncle_blockhash);
                     }
                 }
             }
 
-            if blockhashes.len() < limit && seen.insert(confirmed_hash) {
+            if seen.insert(confirmed_hash) {
                 blockhashes.push(confirmed_hash);
             }
 

--- a/p2poolv2_lib/src/store/share_store.rs
+++ b/p2poolv2_lib/src/store/share_store.rs
@@ -199,7 +199,6 @@ impl Store {
         Some(ShareBlock {
             header,
             transactions,
-            bitcoin_transactions: vec![],
             template_merkle_branches,
         })
     }

--- a/p2poolv2_lib/src/stratum/emission.rs
+++ b/p2poolv2_lib/src/stratum/emission.rs
@@ -27,7 +27,6 @@ use tokio::sync::mpsc;
 pub struct Emission {
     pub pplns: SimplePplnsShare,
     pub header: Header,
-    pub coinbase: bitcoin::Transaction,
     pub blocktemplate: Arc<BlockTemplate>,
     pub share_commitment: Option<ShareCommitment>,
     /// Nanosecond timestamp embedded in the coinbase scriptSig.

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -160,7 +160,6 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
         .send(Emission {
             pplns: stratum_share.clone(),
             header: validation_result.header,
-            coinbase: validation_result.coinbase,
             blocktemplate: job.blocktemplate.clone(),
             share_commitment: job.share_commitment.clone(),
             coinbase_nsecs: job.coinbase_nsecs,

--- a/p2poolv2_lib/src/test_utils.rs
+++ b/p2poolv2_lib/src/test_utils.rs
@@ -469,7 +469,6 @@ pub fn build_block_from_work_components(path: &str, nsecs: u64) -> ShareBlock {
     ShareBlock {
         header: share_header,
         transactions: vec![ShareTransaction(share_coinbase)],
-        bitcoin_transactions,
         template_merkle_branches,
     }
 }
@@ -594,7 +593,6 @@ pub fn empty_share_block_from_header(header: ShareHeader) -> ShareBlock {
     ShareBlock {
         header,
         transactions: Vec::new(),
-        bitcoin_transactions: Vec::new(),
         template_merkle_branches: vec![],
     }
 }
@@ -607,7 +605,6 @@ pub fn valid_share_block_from_fixture() -> ShareBlock {
     ShareBlock {
         header,
         transactions: Vec::new(),
-        bitcoin_transactions: Vec::new(),
         template_merkle_branches: vec![],
     }
 }
@@ -640,7 +637,7 @@ fn test_share_block(
     let share_time = time.unwrap_or(1700000000u32);
     let prev_blockhash = BlockHash::from_str(prev_share_blockhash).unwrap();
 
-    let (bitcoin_header, bitcoin_transactions) = match bitcoin_block {
+    let (bitcoin_header, _bitcoin_transactions) = match bitcoin_block {
         Some(block) => (block.header, block.txdata),
         None => {
             // Build a commitment matching the share header fields
@@ -718,7 +715,6 @@ fn test_share_block(
     ShareBlock {
         header,
         transactions,
-        bitcoin_transactions,
         template_merkle_branches: vec![],
     }
 }

--- a/p2poolv2_tests/src/common/mod.rs
+++ b/p2poolv2_tests/src/common/mod.rs
@@ -38,7 +38,6 @@ pub fn default_test_config() -> Config {
             max_miningshare_per_second: 100,
             max_inventory_per_second: 100,
             max_transaction_per_second: 100,
-            rate_limit_window_secs: 1,
             max_requests_per_second: 1,
             dial_timeout_secs: 30,
         },


### PR DESCRIPTION
- Switch to pre BIP130 sync with inv, getheaders, getdata flow.
- Fix error when sending headers. Uncles at 2000 limit edge should let the nephew be sent as part of the package, even if we go up to 2001 headers.
- Remove bitcoin transactions from share block. We need a scalable approach like compact blocks with prefilled transactions or p2pool's transaction dissemination protocol.