### PR TITLE
Switch to per peer task and tower service

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,2 @@
 [profile.default]
-slow-timeout = { period = "5s", terminate-after = 1 }
+slow-timeout = { period = "30s", terminate-after = 1 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,2 @@
 [profile.default]
-slow-timeout = { period = "30s", terminate-after = 1 }
+slow-timeout = { period = "5s", terminate-after = 1 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Per-peer rate limiting with dedicated service tasks. Each connected
+  peer now gets its own spawned task with an independent rate limiter,
+  so one flooding peer cannot block requests from others. Requests are
+  forwarded via bounded channels with two-tier overload protection:
+  channel full (instant disconnect) and rate limit timeout (sustained
+  flood disconnect). Peer service tasks are spawned on connection and
+  cleaned up on disconnect.
+
+- Raise default max_requests_per_second from 1 to 100 to match sample
+  config and support legitimate sync traffic.
+
 - Remove rate limit window config option. The rate limit config uses
   per second semantics, so the window option was unnecessary.
 

--- a/p2poolv2_config/src/lib.rs
+++ b/p2poolv2_config/src/lib.rs
@@ -275,7 +275,7 @@ impl Default for NetworkConfig {
             max_miningshare_per_second: 100,
             max_inventory_per_second: 100,
             max_transaction_per_second: 100,
-            max_requests_per_second: 1,
+            max_requests_per_second: 100,
             dial_timeout_secs: 30,
         }
     }

--- a/p2poolv2_lib/src/lib.rs
+++ b/p2poolv2_lib/src/lib.rs
@@ -32,4 +32,4 @@ pub mod utils;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
-pub use service::build_service;
+pub use service::spawn_peer_service;

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -329,6 +329,7 @@ impl Node {
                         info!("Inbound connection established from peer: {peer_id}");
                     }
                 }
+                self.request_response_handler.add_peer(peer_id);
                 let _ = self
                     .monitoring_event_sender
                     .send(MonitoringEvent::Peer(PeerResponse {
@@ -345,8 +346,7 @@ impl Node {
                     self.connected_dial_addresses.retain(|addr| addr != address);
                 }
                 self.swarm.behaviour_mut().remove_peer(&peer_id);
-                self.request_response_handler
-                    .remove_peer_knowledge(&peer_id);
+                self.request_response_handler.remove_peer(&peer_id);
                 let _ = self
                     .monitoring_event_sender
                     .send(MonitoringEvent::Peer(PeerResponse {

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -42,7 +42,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 /// Handles request-response events from the libp2p network.
 ///
@@ -215,9 +215,12 @@ impl<C: Send + Sync + 'static> RequestResponseHandler<C> {
     /// Dispatch an inbound request to the peer's service task.
     ///
     /// Records peer block knowledge, then forwards the request
-    /// context to the peer's channel via try_send. If the channel
-    /// is full (peer is overwhelming us) or the peer has no handle,
-    /// the peer is disconnected.
+    /// context to the peer's channel via try_send.
+    ///
+    /// - Full: peer is overwhelming us, disconnect.
+    /// - Closed: task exited (rate limit or error), remove the stale
+    ///   handle so the next request spawns a fresh one.
+    /// - No handle: create one on the fly (defensive fallback).
     async fn dispatch_request(
         &mut self,
         peer: PeerId,
@@ -251,13 +254,16 @@ impl<C: Send + Sync + 'static> RequestResponseHandler<C> {
             }
         };
 
-        if let Err(send_error) = peer_handle.try_send(ctx) {
-            error!(
-                "Failed to forward request to peer {} service: {}",
-                peer, send_error
-            );
-            info!("Disconnecting peer {} due to channel overflow", peer);
-            let _ = self.swarm_tx.send(SwarmSend::Disconnect(peer)).await;
+        match peer_handle.try_send(ctx) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                error!("Peer {} service channel full, disconnecting", peer);
+                let _ = self.swarm_tx.send(SwarmSend::Disconnect(peer)).await;
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                warn!("Peer {} service task exited, removing stale handle", peer);
+                self.peer_handles.remove(&peer);
+            }
         }
 
         Ok(())
@@ -302,6 +308,7 @@ mod tests {
     use crate::node::p2p_message_handlers::receivers::block_receiver::create_block_receiver_channel;
     #[mockall_double::double]
     use crate::pool_difficulty::PoolDifficulty;
+    use crate::service::PeerHandle;
     #[mockall_double::double]
     use crate::shares::chain::chain_store_handle::ChainStoreHandle;
     use crate::shares::validation::MockDefaultShareValidator;
@@ -543,6 +550,39 @@ mod tests {
 
         // Verify the handle was created
         assert!(handler.peer_handles.contains_key(&peer_id));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_request_removes_stale_handle_on_closed() {
+        let (swarm_tx, _swarm_rx) = mpsc::channel(32);
+        let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_clone()
+            .returning(ChainStoreHandle::default);
+
+        let mut handler = build_test_handler(chain_store_handle, swarm_tx);
+
+        let peer_id = PeerId::random();
+
+        // Create a channel where the receiver is immediately dropped,
+        // simulating a task that has exited.
+        let (sender, receiver) = mpsc::channel(16);
+        drop(receiver);
+        handler
+            .peer_handles
+            .insert(peer_id, PeerHandle::new_for_test(sender));
+
+        let (channel_tx, _channel_rx) = oneshot::channel::<Message>();
+        let result = handler
+            .dispatch_request(peer_id, Message::NotFound(()), channel_tx)
+            .await;
+        assert!(result.is_ok());
+
+        // Stale handle should have been removed on Closed
+        assert!(
+            !handler.peer_handles.contains_key(&peer_id),
+            "Stale handle should be removed after Closed error"
+        );
     }
 
     #[tokio::test]

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -26,8 +26,9 @@ use crate::node::messages::{InventoryMessage, Message};
 use crate::node::p2p_message_handlers::handle_response;
 use crate::node::p2p_message_handlers::receivers::block_receiver::BlockReceiverHandle;
 use crate::node::validation_worker::ValidationSender;
-use crate::service::build_service;
+use crate::service::PeerHandle;
 use crate::service::p2p_service::RequestContext;
+use crate::service::spawn_peer_service;
 #[cfg(test)]
 #[mockall_double::double]
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
@@ -35,14 +36,13 @@ use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::validation::ShareValidator;
 use crate::utils::time_provider::SystemTimeProvider;
+use libp2p::PeerId;
 use libp2p::request_response::ResponseChannel;
+use std::collections::HashMap;
 use std::error::Error;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc;
-use tower::util::BoxService;
-use tower::{Service, ServiceExt};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Handles request-response events from the libp2p network.
 ///
@@ -54,14 +54,14 @@ use tracing::{debug, error, info};
 /// We need to do this as ResponseChannel is an opaque type and we
 /// can't write tests for modules that directly use these types.
 ///
-/// Service: The struct owns a tower service stack (rate limiting,
-/// inactivity tracking) and dispatches inbound requests through
-/// it. Responses are handled directly without the service layers
-/// since they are solicited by us and do not need peer-protection
-/// middleware.
+/// Each connected peer gets a dedicated service task with its own
+/// rate limiter. Inbound requests are forwarded to the peer's task
+/// via a bounded channel. Responses are handled directly without
+/// the service layers since they are solicited by us and do not
+/// need peer-protection middleware.
 pub struct RequestResponseHandler<C: Send + Sync> {
-    request_service:
-        BoxService<RequestContext<C, SystemTimeProvider>, (), Box<dyn Error + Send + Sync>>,
+    peer_handles: HashMap<PeerId, PeerHandle<C, SystemTimeProvider>>,
+    max_requests_per_second: u64,
     chain_store_handle: ChainStoreHandle,
     swarm_tx: mpsc::Sender<SwarmSend<C>>,
     block_fetcher_handle: BlockFetcherHandle,
@@ -75,7 +75,7 @@ pub struct RequestResponseHandler<C: Send + Sync> {
 /// The only part left out of tests is the type based dispatching. The
 /// dispatch.* functions are tested for the generic implementation.
 impl RequestResponseHandler<ResponseChannel<Message>> {
-    /// Create a new RequestResponseHandler with the Tower service stack.
+    /// Create a new RequestResponseHandler with per-peer service support.
     pub fn new(
         network_config: NetworkConfig,
         chain_store_handle: ChainStoreHandle,
@@ -85,9 +85,9 @@ impl RequestResponseHandler<ResponseChannel<Message>> {
         block_receiver_handle: BlockReceiverHandle,
         share_validator: Arc<dyn ShareValidator + Send + Sync>,
     ) -> Self {
-        let service = build_service::<ResponseChannel<Message>, _>(network_config);
         Self {
-            request_service: service,
+            peer_handles: HashMap::new(),
+            max_requests_per_second: network_config.max_requests_per_second,
             chain_store_handle,
             swarm_tx,
             block_fetcher_handle,
@@ -166,14 +166,30 @@ impl RequestResponseHandler<ResponseChannel<Message>> {
 
 /// Generic implementation. The dispatch.* functions can be tested as
 /// here we don't depend on the the tokio opaque types.
-impl<C: Send + Sync> RequestResponseHandler<C> {
+impl<C: Send + Sync + 'static> RequestResponseHandler<C> {
     /// Returns a reference to the peer block knowledge tracker.
     pub fn peer_block_knowledge(&self) -> &PeerBlockKnowledge {
         &self.peer_block_knowledge
     }
 
-    /// Removes all tracked block knowledge for a disconnected peer.
-    pub fn remove_peer_knowledge(&mut self, peer_id: &libp2p::PeerId) {
+    /// Spawn a per-peer service task for a newly connected peer.
+    ///
+    /// If a handle already exists for this peer (e.g. duplicate
+    /// ConnectionEstablished), the old one is replaced and its task
+    /// will exit when the dropped sender closes the channel.
+    pub fn add_peer(&mut self, peer_id: PeerId) {
+        let handle =
+            spawn_peer_service(peer_id, self.max_requests_per_second, self.swarm_tx.clone());
+        self.peer_handles.insert(peer_id, handle);
+    }
+
+    /// Remove all state for a disconnected peer.
+    ///
+    /// Drops the peer handle, which closes the channel and causes
+    /// the peer's service task to exit. Also removes peer block
+    /// knowledge.
+    pub fn remove_peer(&mut self, peer_id: &PeerId) {
+        self.peer_handles.remove(peer_id);
         self.peer_block_knowledge.remove_peer(peer_id);
     }
 
@@ -181,7 +197,7 @@ impl<C: Send + Sync> RequestResponseHandler<C> {
     ///
     /// Called before dispatching both requests and responses so that
     /// subsequent inv sends can avoid redundant announcements.
-    fn record_peer_knowledge(&mut self, peer: &libp2p::PeerId, message: &Message) {
+    fn record_peer_knowledge(&mut self, peer: &PeerId, message: &Message) {
         match message {
             Message::Inventory(InventoryMessage::BlockHashes(hashes)) => {
                 for hash in hashes {
@@ -196,15 +212,15 @@ impl<C: Send + Sync> RequestResponseHandler<C> {
         }
     }
 
-    /// Dispatch an inbound request through the Tower service stack.
+    /// Dispatch an inbound request to the peer's service task.
     ///
-    /// Records peer block knowledge before processing, then creates a
-    /// `RequestContext` and attempts to call the service within a
-    /// 1-second timeout. If the service is not ready in time or returns an
-    /// error, the peer is disconnected.
+    /// Records peer block knowledge, then forwards the request
+    /// context to the peer's channel via try_send. If the channel
+    /// is full (peer is overwhelming us) or the peer has no handle,
+    /// the peer is disconnected.
     async fn dispatch_request(
         &mut self,
-        peer: libp2p::PeerId,
+        peer: PeerId,
         request: Message,
         channel: C,
     ) -> Result<(), Box<dyn Error>> {
@@ -212,7 +228,7 @@ impl<C: Send + Sync> RequestResponseHandler<C> {
 
         let ctx = RequestContext::<C, _> {
             peer,
-            request: request.clone(),
+            request,
             chain_store_handle: self.chain_store_handle.clone(),
             response_channel: channel,
             swarm_tx: self.swarm_tx.clone(),
@@ -223,36 +239,27 @@ impl<C: Send + Sync> RequestResponseHandler<C> {
             share_validator: self.share_validator.clone(),
         };
 
-        match tokio::time::timeout(Duration::from_secs(1), self.request_service.ready()).await {
-            Ok(Ok(_)) => {
-                if let Err(err) = self.request_service.call(ctx).await {
-                    error!("Service call failed for peer {}: {}", peer, err);
-                }
-            }
-            Ok(Err(err)) => {
-                error!("Service not ready for peer {}: {}", peer, err);
-                info!("Disconnecting peer {} due to service not ready", peer);
-                if let Err(send_err) = self.swarm_tx.send(SwarmSend::Disconnect(peer)).await {
-                    error!(
-                        "Failed to send disconnect command for peer {}: {:?}",
-                        peer, send_err
-                    );
-                }
-            }
-            Err(_) => {
-                error!("Service readiness timed out for peer {}", peer);
-                info!(
-                    "Disconnecting peer {} due to rate limiter timeout on request {}",
-                    peer, request
+        let peer_handle = match self.peer_handles.get(&peer) {
+            Some(handle) => handle,
+            None => {
+                warn!(
+                    "No service handle for peer {}, creating one on the fly",
+                    peer
                 );
-                if let Err(send_err) = self.swarm_tx.send(SwarmSend::Disconnect(peer)).await {
-                    error!(
-                        "Failed to send disconnect command for peer {}: {:?}",
-                        peer, send_err
-                    );
-                }
+                self.add_peer(peer);
+                self.peer_handles.get(&peer).unwrap()
             }
+        };
+
+        if let Err(send_error) = peer_handle.try_send(ctx) {
+            error!(
+                "Failed to forward request to peer {} service: {}",
+                peer, send_error
+            );
+            info!("Disconnecting peer {} due to channel overflow", peer);
+            let _ = self.swarm_tx.send(SwarmSend::Disconnect(peer)).await;
         }
+
         Ok(())
     }
 
@@ -264,7 +271,7 @@ impl<C: Send + Sync> RequestResponseHandler<C> {
     /// for matching outstanding requests.
     async fn dispatch_response(
         &mut self,
-        peer: libp2p::PeerId,
+        peer: PeerId,
         response: Message,
     ) -> Result<(), Box<dyn Error>> {
         self.record_peer_knowledge(&peer, &response);
@@ -290,7 +297,6 @@ impl<C: Send + Sync> RequestResponseHandler<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::NetworkConfig;
     use crate::node::SwarmSend;
     use crate::node::messages::{InventoryMessage, Message};
     use crate::node::p2p_message_handlers::receivers::block_receiver::create_block_receiver_channel;
@@ -302,20 +308,12 @@ mod tests {
     use crate::test_utils::{TestShareBlockBuilder, valid_share_block_from_fixture};
     use bitcoin::hashes::Hash as _;
     use bitcoin::{BlockHash, CompactTarget};
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
     use tokio::sync::mpsc;
     use tokio::sync::oneshot;
 
     type TestChannel = oneshot::Sender<Message>;
 
-    fn test_network_config() -> NetworkConfig {
-        NetworkConfig {
-            max_requests_per_second: 10,
-            ..NetworkConfig::default()
-        }
-    }
+    const TEST_RATE_LIMIT: u64 = 10;
 
     fn build_test_handler(
         chain_store_handle: ChainStoreHandle,
@@ -333,13 +331,13 @@ mod tests {
         swarm_tx: mpsc::Sender<SwarmSend<TestChannel>>,
         share_validator: Arc<dyn ShareValidator + Send + Sync>,
     ) -> RequestResponseHandler<TestChannel> {
-        let service = build_service::<TestChannel, _>(test_network_config());
         let (block_fetcher_tx, _block_fetcher_rx) = block_fetcher::create_block_fetcher_channel();
         let (validation_tx, _validation_rx) =
             crate::node::validation_worker::create_validation_channel();
         let (block_receiver_handle, _block_receiver_rx) = create_block_receiver_channel();
         RequestResponseHandler {
-            request_service: service,
+            peer_handles: HashMap::new(),
+            max_requests_per_second: TEST_RATE_LIMIT,
             chain_store_handle,
             swarm_tx,
             block_fetcher_handle: block_fetcher_tx,
@@ -347,24 +345,6 @@ mod tests {
             block_receiver_handle,
             peer_block_knowledge: PeerBlockKnowledge::default(),
             share_validator,
-        }
-    }
-
-    /// A service that never becomes ready, causing poll_ready to return
-    /// Pending indefinitely. Used to test the timeout path in dispatch_request.
-    struct NeverReadyService;
-
-    impl<C, T> tower::Service<RequestContext<C, T>> for NeverReadyService {
-        type Response = ();
-        type Error = Box<dyn std::error::Error + Send + Sync>;
-        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
-
-        fn poll_ready(&mut self, _context: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-            Poll::Pending
-        }
-
-        fn call(&mut self, _request: RequestContext<C, T>) -> Self::Future {
-            Box::pin(async { Ok(()) })
         }
     }
 
@@ -510,7 +490,8 @@ mod tests {
 
         let mut handler = build_test_handler(chain_store_handle, swarm_tx);
 
-        let peer_id = libp2p::PeerId::random();
+        let peer_id = PeerId::random();
+        handler.add_peer(peer_id);
         let (response_tx, _response_rx) = oneshot::channel::<Message>();
 
         let result = handler
@@ -523,7 +504,7 @@ mod tests {
 
         assert!(result.is_ok());
 
-        // Verify the service produced a response on swarm_tx
+        // The per-peer task processes asynchronously, wait for response
         if let Some(SwarmSend::Response(_, Message::ShareHeaders(headers))) = swarm_rx.recv().await
         {
             assert_eq!(headers.len(), 2);
@@ -533,50 +514,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_request_service_timeout_disconnects_peer() {
-        let (swarm_tx, mut swarm_rx) = mpsc::channel(32);
+    async fn test_dispatch_request_creates_handle_on_the_fly() {
+        let (swarm_tx, _swarm_rx) = mpsc::channel(32);
         let mut chain_store_handle = ChainStoreHandle::default();
-        chain_store_handle
-            .expect_clone()
-            .returning(ChainStoreHandle::default);
+        chain_store_handle.expect_clone().returning(|| {
+            let mut cloned = ChainStoreHandle::default();
+            cloned.expect_is_current().returning(|| true);
+            cloned
+                .expect_get_missing_blockhashes()
+                .returning(|_| Vec::with_capacity(0));
+            cloned
+        });
 
-        // Use a service that never becomes ready, guaranteeing the 1-second
-        // timeout in dispatch_request fires and triggers a disconnect.
-        let (block_fetcher_tx, _block_fetcher_rx) = block_fetcher::create_block_fetcher_channel();
-        let (validation_tx, _validation_rx) =
-            crate::node::validation_worker::create_validation_channel();
-        let (block_receiver_handle, _block_receiver_rx) = create_block_receiver_channel();
-        let mut handler = RequestResponseHandler {
-            request_service: BoxService::new(NeverReadyService),
-            chain_store_handle,
-            swarm_tx,
-            block_fetcher_handle: block_fetcher_tx,
-            validation_tx,
-            block_receiver_handle,
-            peer_block_knowledge: PeerBlockKnowledge::default(),
-            share_validator: Arc::new(MockDefaultShareValidator::default()),
-        };
+        let mut handler = build_test_handler(chain_store_handle, swarm_tx);
 
-        let peer_id = libp2p::PeerId::random();
+        // Do NOT call add_peer -- dispatch_request should create the handle
+        let peer_id = PeerId::random();
         let (channel_tx, _channel_rx) = oneshot::channel::<Message>();
 
         let result = handler
-            .dispatch_request(peer_id, Message::NotFound(()), channel_tx)
+            .dispatch_request(
+                peer_id,
+                Message::Inventory(InventoryMessage::BlockHashes(vec![BlockHash::all_zeros()])),
+                channel_tx,
+            )
             .await;
         assert!(result.is_ok());
 
-        // Verify that a Disconnect was sent for the peer
-        let received = swarm_rx
-            .try_recv()
-            .expect("Expected a SwarmSend message after timeout");
-        if let SwarmSend::Disconnect(disconnected_peer) = received {
-            assert_eq!(
-                disconnected_peer, peer_id,
-                "Expected Disconnect for the correct peer"
-            );
-        } else {
-            panic!("Expected SwarmSend::Disconnect, got {received:?}");
-        }
+        // Verify the handle was created
+        assert!(handler.peer_handles.contains_key(&peer_id));
     }
 
     #[tokio::test]
@@ -593,7 +559,8 @@ mod tests {
         });
         let mut handler = build_test_handler(chain_store_handle, swarm_tx);
 
-        let peer_id = libp2p::PeerId::random();
+        let peer_id = PeerId::random();
+        handler.add_peer(peer_id);
         let block_hash = BlockHash::all_zeros();
         let inventory = InventoryMessage::BlockHashes(vec![block_hash]);
         let (channel_tx, _channel_rx) = oneshot::channel::<Message>();
@@ -683,7 +650,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_remove_peer_knowledge() {
+    async fn test_remove_peer() {
         let (swarm_tx, _swarm_rx) = mpsc::channel(32);
         let mut chain_store_handle = ChainStoreHandle::default();
         chain_store_handle.expect_clone().returning(|| {
@@ -696,7 +663,8 @@ mod tests {
         });
         let mut handler = build_test_handler(chain_store_handle, swarm_tx);
 
-        let peer_id = libp2p::PeerId::random();
+        let peer_id = PeerId::random();
+        handler.add_peer(peer_id);
         let block_hash = BlockHash::all_zeros();
         let inventory = InventoryMessage::BlockHashes(vec![block_hash]);
         let (channel_tx, _channel_rx) = oneshot::channel::<Message>();
@@ -709,12 +677,14 @@ mod tests {
                 .peer_block_knowledge()
                 .peer_knows_block(&peer_id, &block_hash)
         );
+        assert!(handler.peer_handles.contains_key(&peer_id));
 
-        handler.remove_peer_knowledge(&peer_id);
+        handler.remove_peer(&peer_id);
         assert!(
             !handler
                 .peer_block_knowledge()
                 .peer_knows_block(&peer_id, &block_hash)
         );
+        assert!(!handler.peer_handles.contains_key(&peer_id));
     }
 }

--- a/p2poolv2_lib/src/service/mod.rs
+++ b/p2poolv2_lib/src/service/mod.rs
@@ -20,7 +20,6 @@ use crate::node::SwarmSend;
 use crate::service::p2p_service::{P2PService, RequestContext};
 use crate::utils::time_provider::TimeProvider;
 use libp2p::PeerId;
-use std::error::Error;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tower::limit::RateLimit;
@@ -56,6 +55,13 @@ impl<C, T> PeerHandle<C, T> {
         request: RequestContext<C, T>,
     ) -> Result<(), mpsc::error::TrySendError<RequestContext<C, T>>> {
         self.sender.try_send(request)
+    }
+
+    /// Create a PeerHandle from a raw sender. Used in tests to
+    /// simulate a handle whose task has already exited.
+    #[cfg(test)]
+    pub fn new_for_test(sender: mpsc::Sender<RequestContext<C, T>>) -> Self {
+        Self { sender }
     }
 }
 

--- a/p2poolv2_lib/src/service/mod.rs
+++ b/p2poolv2_lib/src/service/mod.rs
@@ -32,6 +32,12 @@ use tracing::{debug, error, info};
 /// always fits without dropping.
 const MIN_PEER_CHANNEL_CAPACITY: u64 = 16;
 
+/// How long to wait for a peer's service to become ready before
+/// declaring the peer is flooding and disconnecting it. Must be
+/// longer than the rate limit refill interval to avoid false
+/// positives from legitimate rate limit backpressure.
+const READY_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// Handle to a per-peer service task.
 ///
 /// Wraps the sender half of the channel used to forward inbound
@@ -91,7 +97,13 @@ where
     let service = build_rate_limited_service(max_requests_per_second);
     let (sender, receiver) = mpsc::channel(capacity);
 
-    tokio::spawn(run_peer_service(service, receiver, peer_id, swarm_tx));
+    tokio::spawn(run_peer_service(
+        service,
+        receiver,
+        peer_id,
+        swarm_tx,
+        READY_TIMEOUT,
+    ));
 
     PeerHandle { sender }
 }
@@ -99,12 +111,12 @@ where
 /// Run the per-peer service loop.
 ///
 /// Receives requests from the channel and processes each through the
-/// rate-limited service. Applies a 1-second timeout on service
+/// rate-limited service. Applies a configurable timeout on service
 /// readiness to detect sustained overload.
 ///
 /// Exits when:
 /// - The channel closes (sender dropped, peer disconnected)
-/// - The rate limiter is not ready within 1 second (sustained flood)
+/// - The rate limiter is not ready within `ready_timeout` (sustained flood)
 /// - The service returns an error on call
 ///
 /// On service failure, sends a disconnect command before exiting.
@@ -113,13 +125,14 @@ async fn run_peer_service<C, T>(
     mut receiver: mpsc::Receiver<RequestContext<C, T>>,
     peer_id: PeerId,
     swarm_tx: mpsc::Sender<SwarmSend<C>>,
+    ready_timeout: Duration,
 ) where
     C: Send + Sync + 'static,
     T: TimeProvider + Send + Sync + 'static,
 {
     while let Some(request) = receiver.recv().await {
         let ready_future = ServiceExt::<RequestContext<C, T>>::ready(&mut service);
-        match tokio::time::timeout(Duration::from_secs(1), ready_future).await {
+        match tokio::time::timeout(ready_timeout, ready_future).await {
             Ok(Ok(_)) => {
                 if let Err(err) = service.call(request).await {
                     error!("Service call failed for peer {}: {}", peer_id, err);
@@ -150,455 +163,221 @@ async fn run_peer_service<C, T>(
     );
 }
 
-/// Build a boxed service stack with rate limiting.
-///
-/// Used by RequestResponseHandler until per-peer services are wired in.
-pub fn build_service<C, T>(
-    config: crate::config::NetworkConfig,
-) -> tower::util::BoxService<RequestContext<C, T>, (), Box<dyn Error + Send + Sync>>
-where
-    C: Send + Sync + 'static,
-    T: TimeProvider + Send + Sync + 'static,
-{
-    let service = build_rate_limited_service(config.max_requests_per_second);
-    tower::util::BoxService::new(service)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::NetworkConfig;
     use crate::node::SwarmSend;
     use crate::node::messages::Message;
-    use crate::node::p2p_message_handlers::receivers::block_receiver::BlockReceiverHandle;
     use crate::node::p2p_message_handlers::receivers::block_receiver::create_block_receiver_channel;
     use crate::node::request_response_handler::block_fetcher;
     use crate::node::validation_worker;
-    use crate::service::p2p_service::{P2PService, RequestContext};
     #[mockall_double::double]
     use crate::shares::chain::chain_store_handle::ChainStoreHandle;
     use crate::shares::validation::MockDefaultShareValidator;
     use crate::utils::time_provider::TestTimeProvider;
     use libp2p::PeerId;
-    use std::future::Future;
-    use std::pin::Pin;
     use std::sync::Arc;
-    use std::task::{Context, Poll};
-    use std::time::Instant;
     use std::time::SystemTime;
     use tokio::sync::mpsc;
-    use tokio::sync::mpsc::Sender;
     use tokio::sync::oneshot;
-    use tokio::time::{Duration, advance, timeout};
-    use tower::limit::RateLimit;
-    use tower::{Service, ServiceBuilder, ServiceExt, limit::RateLimitLayer};
+    use tokio::time::Duration;
 
-    fn fetcher_validation_handles_for_tests() -> (
-        block_fetcher::BlockFetcherHandle,
-        validation_worker::ValidationSender,
-        BlockReceiverHandle,
-    ) {
+    /// Build a RequestContext for testing with a oneshot response channel.
+    fn make_test_context(
+        peer_id: PeerId,
+        swarm_tx: mpsc::Sender<SwarmSend<oneshot::Sender<Message>>>,
+        response_channel: oneshot::Sender<Message>,
+    ) -> RequestContext<oneshot::Sender<Message>, TestTimeProvider> {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_clone()
+            .returning(ChainStoreHandle::default);
         let (block_fetcher_tx, _) = block_fetcher::create_block_fetcher_channel();
         let (validation_tx, _) = validation_worker::create_validation_channel();
         let (block_receiver_handle, _) = create_block_receiver_channel();
-        (block_fetcher_tx, validation_tx, block_receiver_handle)
-    }
 
-    // This struct simulates a service that always fails on poll_ready()
-    struct AlwaysFailReadyService;
-
-    impl<C, T> tower::Service<RequestContext<C, T>> for AlwaysFailReadyService {
-        type Response = ();
-        type Error = Box<dyn std::error::Error + Send + Sync>;
-        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
-
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-            Poll::Ready(Err("simulated readiness failure".into()))
-        }
-
-        fn call(&mut self, _req: RequestContext<C, T>) -> Self::Future {
-            Box::pin(async { Ok(()) }) // Won't be called in this test
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn test_rate_limit_blocks_excess_requests() {
-        //! Verifies that Tower's RateLimitLayer enforces backpressure by making the service
-        //! not ready after the allowed rate is exceeded, and that readiness resumes after the interval.
-
-        const RATE: u64 = 1;
-        const INTERVAL: Duration = Duration::from_secs(1);
-        const TIMEOUT_MS: u64 = 100;
-
-        let svc = tower::service_fn(|_req| async {
-            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
-        });
-
-        let mut service = ServiceBuilder::new()
-            .layer(RateLimitLayer::new(RATE, INTERVAL))
-            .service(svc);
-
-        // First request should succeed
-        let result1 = service.ready().await.unwrap().call(()).await;
-        assert!(result1.is_ok(), "First request should succeed");
-
-        // All further requests within the interval should be rate limited (not ready)
-        for i in 1..=3 {
-            let not_ready = timeout(Duration::from_millis(TIMEOUT_MS), service.ready()).await;
-            assert!(
-                not_ready.is_err(),
-                "Request {i} should be rate limited (not ready yet), got: {not_ready:?}"
-            );
-        }
-
-        // Advance time and verify service becomes ready again
-        for i in 1..=3 {
-            advance(INTERVAL).await;
-            let ready = timeout(Duration::from_millis(TIMEOUT_MS), service.ready()).await;
-            assert!(ready.is_ok(), "Service should be ready after interval {i}");
-            let result = service.call(()).await;
-            assert!(result.is_ok(), "Request {i} after interval should succeed");
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn test_tower_rate_limiter_with_inline_request_context() {
-        // Setup a channel for the swarm sender
-        let (swarm_tx, _rx) = mpsc::channel(8);
-
-        // Create a response channel for the request context
-        let (response_channel_tx, _response_channel_rx) = oneshot::channel::<Message>();
-
-        let (response_channel_tx1, _response_channel_rx1) = oneshot::channel::<Message>();
-
-        let (response_channel_tx2, _response_channel_rx2) = oneshot::channel::<Message>();
-
-        // Create a dummy ChainHandle and TimeProvider
-        let mut chain_store_handle = ChainStoreHandle::default();
-        chain_store_handle
-            .expect_clone()
-            .returning(ChainStoreHandle::default);
-
-        // Create a TestTimeProvider with the current system time
-        let time_provider = TestTimeProvider::new(SystemTime::now());
-
-        // Configure Tower RateLimitLayer: 2 requests per second
-        let mut service = ServiceBuilder::new()
-            .layer(RateLimitLayer::new(2, Duration::from_secs(1)))
-            .service(P2PService::new());
-
-        // Inline RequestContext construction
-        let (block_fetcher_handle, validation_tx, block_receiver_handle) =
-            fetcher_validation_handles_for_tests();
-        let ctx1 = RequestContext {
-            peer: PeerId::random(),
-            request: Message::NotFound(()),
-            chain_store_handle: chain_store_handle.clone(),
-            response_channel: response_channel_tx,
-            swarm_tx: swarm_tx.clone(),
-            time_provider: time_provider.clone(),
-            block_fetcher_handle: block_fetcher_handle.clone(),
-            validation_tx: validation_tx.clone(),
-            block_receiver_handle: block_receiver_handle.clone(),
-            share_validator: Arc::new(MockDefaultShareValidator::default()),
-        };
-
-        let ctx2 = RequestContext {
-            peer: PeerId::random(),
-            request: Message::NotFound(()),
-            chain_store_handle: chain_store_handle.clone(),
-            response_channel: response_channel_tx1,
-            swarm_tx: swarm_tx.clone(),
-            time_provider: time_provider.clone(),
-            block_fetcher_handle: block_fetcher_handle.clone(),
-            validation_tx: validation_tx.clone(),
-            block_receiver_handle: block_receiver_handle.clone(),
-            share_validator: Arc::new(MockDefaultShareValidator::default()),
-        };
-
-        let ctx3 = RequestContext {
-            peer: PeerId::random(),
-            request: Message::NotFound(()),
-            chain_store_handle: chain_store_handle.clone(),
-            response_channel: response_channel_tx2,
-            swarm_tx: swarm_tx.clone(),
-            time_provider: time_provider.clone(),
-            block_fetcher_handle,
-            validation_tx,
-            block_receiver_handle: block_receiver_handle.clone(),
-            share_validator: Arc::new(MockDefaultShareValidator::default()),
-        };
-
-        // First request should succeed
-        assert!(
-            <RateLimit<P2PService> as tower::ServiceExt<
-                p2p_service::RequestContext<
-                    tokio::sync::oneshot::Sender<Message>,
-                    TestTimeProvider,
-                >,
-            >>::ready(&mut service)
-            .await
-            .is_ok()
-        );
-
-        assert!(service.call(ctx1).await.is_ok());
-
-        // Second request should succeed
-        assert!(
-            <RateLimit<P2PService> as tower::ServiceExt<
-                p2p_service::RequestContext<
-                    tokio::sync::oneshot::Sender<Message>,
-                    TestTimeProvider,
-                >,
-            >>::ready(&mut service)
-            .await
-            .is_ok()
-        );
-
-        assert!(service.call(ctx2).await.is_ok());
-
-        // Third request should be rate limited (not ready)
-        assert!(
-            <RateLimit<P2PService> as tower::ServiceExt<
-                p2p_service::RequestContext<
-                    tokio::sync::oneshot::Sender<Message>,
-                    TestTimeProvider,
-                >,
-            >>::ready(&mut service)
-            .await
-            .is_ok()
-        );
-
-        // Advance time window
-        tokio::time::advance(Duration::from_secs(1)).await;
-
-        // Should be ready again
-        assert!(
-            <RateLimit<P2PService> as tower::ServiceExt<
-                p2p_service::RequestContext<
-                    tokio::sync::oneshot::Sender<Message>,
-                    TestTimeProvider,
-                >,
-            >>::ready(&mut service)
-            .await
-            .is_ok()
-        );
-        assert!(service.call(ctx3).await.is_ok());
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn test_service_disconnects_peer_on_ready_failure() {
-        // Setup a channel to observe swarm events
-        let (swarm_tx, mut swarm_rx) = mpsc::channel(8);
-        let (response_channel_tx, _response_channel_rx) = oneshot::channel::<Message>();
-
-        // Dummy chain handle
-        let mut chain_store_handle = ChainStoreHandle::default();
-        chain_store_handle
-            .expect_clone()
-            .returning(ChainStoreHandle::default);
-
-        let time_provider = TestTimeProvider::new(SystemTime::now());
-
-        // Wrap with rate limit (though here rate limit is not really triggered)
-        let mut service = ServiceBuilder::new()
-            .layer(RateLimitLayer::new(1, Duration::from_secs(1)))
-            .service(AlwaysFailReadyService);
-
-        // Build a request context
-        let peer_id = PeerId::random();
-        let (block_fetcher_handle, validation_tx, block_receiver_handle) =
-            fetcher_validation_handles_for_tests();
-        let ctx = RequestContext {
+        RequestContext {
             peer: peer_id,
             request: Message::NotFound(()),
-            chain_store_handle: chain_store_handle.clone(),
-            response_channel: response_channel_tx,
-            swarm_tx: swarm_tx.clone(),
-            time_provider: time_provider.clone(),
-            block_fetcher_handle,
+            chain_store_handle,
+            response_channel,
+            swarm_tx,
+            time_provider: TestTimeProvider::new(SystemTime::now()),
+            block_fetcher_handle: block_fetcher_tx,
             validation_tx,
-            block_receiver_handle: block_receiver_handle.clone(),
+            block_receiver_handle,
             share_validator: Arc::new(MockDefaultShareValidator::default()),
-        };
-
-        // Try service.ready(), and on failure, trigger disconnect manually
-
-        if <RateLimit<AlwaysFailReadyService> as ServiceExt<
-            RequestContext<tokio::sync::oneshot::Sender<Message>, TestTimeProvider>,
-        >>::ready(&mut service)
-        .await
-        .is_err()
-        {
-            let _ = swarm_tx.send(SwarmSend::Disconnect(ctx.peer)).await;
         }
+    }
 
-        // Verify that a Disconnect command was sent
-        let received = swarm_rx.try_recv().expect("Expected a SwarmSend message");
-        if let SwarmSend::Disconnect(received_peer) = received {
-            assert_eq!(
-                received_peer, peer_id,
-                "Expected Disconnect for the correct peer"
-            );
+    #[tokio::test]
+    async fn test_rate_limit_timeout_disconnects_peer() {
+        //! Uses run_peer_service directly with rate=1/s and a 500ms
+        //! ready timeout. The rate refills at 1s but the timeout fires
+        //! at 500ms, guaranteeing the Disconnect path is taken.
+        let (swarm_tx, mut swarm_rx) = mpsc::channel(8);
+        let peer_id = PeerId::random();
+
+        let service = build_rate_limited_service(1);
+        let (sender, receiver) = mpsc::channel(16);
+        let ready_timeout = Duration::from_millis(500);
+        tokio::spawn(run_peer_service(
+            service,
+            receiver,
+            peer_id,
+            swarm_tx.clone(),
+            ready_timeout,
+        ));
+
+        // First request -- consumes the rate limit bucket
+        let (response_tx, _response_rx) = oneshot::channel::<Message>();
+        let ctx = make_test_context(peer_id, swarm_tx.clone(), response_tx);
+        sender.send(ctx).await.unwrap();
+
+        // Give the task time to process the first request
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Second request -- rate limiter is exhausted
+        let (response_tx2, _response_rx2) = oneshot::channel::<Message>();
+        let ctx2 = make_test_context(peer_id, swarm_tx.clone(), response_tx2);
+        sender.send(ctx2).await.unwrap();
+
+        // Wait for the 500ms timeout to fire (well before 1s refill)
+        let received = tokio::time::timeout(Duration::from_secs(2), swarm_rx.recv())
+            .await
+            .expect("Timed out waiting for Disconnect")
+            .expect("Channel closed unexpectedly");
+
+        if let SwarmSend::Disconnect(disconnected_peer) = received {
+            assert_eq!(disconnected_peer, peer_id);
         } else {
             panic!("Expected SwarmSend::Disconnect, got {:?}", received);
         }
+    }
 
-        // Ensure no additional messages were sent
+    #[tokio::test]
+    async fn test_dropped_handle_stops_peer_task() {
+        //! Verifies that dropping the PeerHandle closes the channel,
+        //! causing the peer's service task to exit cleanly without
+        //! sending a Disconnect.
+        let (swarm_tx, mut swarm_rx) = mpsc::channel(8);
+        let peer_id = PeerId::random();
+
+        let handle: PeerHandle<oneshot::Sender<Message>, TestTimeProvider> =
+            spawn_peer_service(peer_id, 10, swarm_tx.clone());
+
+        // Drop the handle -- channel closes, task should exit
+        drop(handle);
+
+        // Give the task a moment to notice the closed channel
+        tokio::task::yield_now().await;
+
+        // No Disconnect should be sent -- this is a clean shutdown
         assert!(
             swarm_rx.try_recv().is_err(),
-            "No additional SwarmSend messages expected"
+            "No Disconnect expected on clean handle drop"
         );
     }
 
     #[tokio::test]
-    async fn test_rate_limiter_limits_requests() {
-        // Setup a channel to observe swarm events
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<mpsc::Sender<Message>>>(10);
-        let (response_channel_tx, _response_channel_rx) = mpsc::channel::<Message>(10);
+    async fn test_per_peer_rate_limit_independence() {
+        //! Two peers each get their own rate limiter (rate=1/s) with
+        //! a 500ms ready timeout. Peer A exhausts its rate limit and
+        //! gets disconnected, but Peer B processes its request fine.
+        let (swarm_tx, mut swarm_rx) = mpsc::channel(16);
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+        let ready_timeout = Duration::from_millis(500);
 
-        // Dummy chain handle
-        let mut chain_store_handle = ChainStoreHandle::default();
-        chain_store_handle
-            .expect_clone()
-            .returning(|| ChainStoreHandle::default());
+        let service_a = build_rate_limited_service(1);
+        let (sender_a, receiver_a) = mpsc::channel(16);
+        tokio::spawn(run_peer_service(
+            service_a,
+            receiver_a,
+            peer_a,
+            swarm_tx.clone(),
+            ready_timeout,
+        ));
 
-        let time_provider = TestTimeProvider::new(SystemTime::now());
+        let service_b = build_rate_limited_service(1);
+        let (sender_b, receiver_b) = mpsc::channel(16);
+        tokio::spawn(run_peer_service(
+            service_b,
+            receiver_b,
+            peer_b,
+            swarm_tx.clone(),
+            ready_timeout,
+        ));
 
-        // Create a config with a low rate limit
-        let network_config = NetworkConfig {
-            max_requests_per_second: 1,
-            ..NetworkConfig::default()
-        };
+        // Peer A -- first request consumes its rate bucket
+        let (response_tx_a, _) = oneshot::channel::<Message>();
+        let ctx_a = make_test_context(peer_a, swarm_tx.clone(), response_tx_a);
+        sender_a.send(ctx_a).await.unwrap();
 
-        let peer_id = PeerId::random();
-        let (block_fetcher_handle, validation_tx, block_receiver_handle) =
-            fetcher_validation_handles_for_tests();
-        let ctx = RequestContext {
-            peer: peer_id,
-            request: Message::NotFound(()),
-            chain_store_handle: chain_store_handle.clone(),
-            response_channel: response_channel_tx.clone(),
-            swarm_tx: swarm_tx.clone(),
-            time_provider: time_provider.clone(),
-            block_fetcher_handle: block_fetcher_handle.clone(),
-            validation_tx: validation_tx.clone(),
-            block_receiver_handle: block_receiver_handle.clone(),
-            share_validator: Arc::new(MockDefaultShareValidator::default()),
-        };
+        // Give task A time to process
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let ctx1 = RequestContext {
-            peer: peer_id,
-            request: Message::NotFound(()),
-            chain_store_handle: chain_store_handle.clone(),
-            response_channel: response_channel_tx.clone(),
-            swarm_tx: swarm_tx.clone(),
-            time_provider: time_provider.clone(),
-            block_fetcher_handle,
-            validation_tx,
-            block_receiver_handle: block_receiver_handle.clone(),
-            share_validator: Arc::new(MockDefaultShareValidator::default()),
-        };
+        // Peer A -- second request, will be rate limited
+        let (response_tx_a2, _) = oneshot::channel::<Message>();
+        let ctx_a2 = make_test_context(peer_a, swarm_tx.clone(), response_tx_a2);
+        sender_a.send(ctx_a2).await.unwrap();
 
-        let mut service = build_service::<Sender<Message>, _>(network_config.clone());
+        // Peer B -- should process immediately despite A being rate limited
+        let (response_tx_b, _) = oneshot::channel::<Message>();
+        let ctx_b = make_test_context(peer_b, swarm_tx.clone(), response_tx_b);
+        sender_b.send(ctx_b).await.unwrap();
 
-        // First request should succeed immediately
+        // Wait for A's timeout to fire (500ms) plus some margin
+        tokio::time::sleep(Duration::from_millis(700)).await;
+
+        // Collect all messages -- expect a Disconnect for peer A only
+        let mut disconnect_peers = Vec::new();
+        while let Ok(message) = swarm_rx.try_recv() {
+            if let SwarmSend::Disconnect(peer) = message {
+                disconnect_peers.push(peer);
+            }
+        }
+
         assert!(
-            service.ready().await.is_ok(),
-            "First request should be ready"
-        );
-        assert!(service.call(ctx).await.is_ok(), "First call should succeed");
-
-        // Second request should wait due to rate limit (1 req/sec)
-        let start = Instant::now();
-        assert!(
-            tokio::time::timeout(Duration::from_secs(2), service.ready())
-                .await
-                .is_ok(),
-            "Second request should be ready within 2 seconds"
-        );
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed >= Duration::from_millis(900) && elapsed <= Duration::from_millis(1100),
-            "Expected wait of ~1 second due to rate limit, got {:?}",
-            elapsed
+            disconnect_peers.contains(&peer_a),
+            "Peer A should be disconnected due to rate limit timeout"
         );
         assert!(
-            service.call(ctx1).await.is_ok(),
-            "Second call should succeed"
+            !disconnect_peers.contains(&peer_b),
+            "Peer B should NOT be disconnected"
         );
 
-        // No disconnect should occur
-        assert!(swarm_rx.try_recv().is_err(), "No disconnect expected");
+        drop(sender_a);
+        drop(sender_b);
     }
 
     #[tokio::test]
-    async fn test_rate_limiter_disconnects_on_timeout() {
-        // Setup a channel to observe swarm events
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<mpsc::Sender<Message>>>(10);
-
-        let (response_channel_tx, _response_channel_rx) = mpsc::channel::<Message>(10);
-
-        // Dummy chain handle
-        let mut chain_store_handle = ChainStoreHandle::default();
-        chain_store_handle
-            .expect_clone()
-            .returning(ChainStoreHandle::default);
-
-        let time_provider = TestTimeProvider::new(SystemTime::now());
-
-        // Create a network_config with a low rate limit
-        let network_config = NetworkConfig {
-            max_requests_per_second: 1,
-            ..NetworkConfig::default()
-        };
-
+    async fn test_spawn_peer_service_processes_single_request() {
+        //! Minimal test: spawn a peer service, send one request, verify
+        //! the task processes it without panicking.
+        let (swarm_tx, _swarm_rx) = mpsc::channel(8);
         let peer_id = PeerId::random();
-        let (block_fetcher_handle, validation_tx, block_receiver_handle) =
-            fetcher_validation_handles_for_tests();
-        let ctx = RequestContext {
-            peer: peer_id,
-            request: Message::NotFound(()),
-            chain_store_handle: chain_store_handle.clone(),
-            response_channel: response_channel_tx,
-            swarm_tx: swarm_tx.clone(),
-            time_provider: time_provider.clone(),
-            block_fetcher_handle,
-            validation_tx,
-            block_receiver_handle: block_receiver_handle.clone(),
-            share_validator: Arc::new(MockDefaultShareValidator::default()),
-        };
 
-        let mut service = build_service::<Sender<Message>, _>(network_config.clone());
+        let handle: PeerHandle<oneshot::Sender<Message>, TestTimeProvider> =
+            spawn_peer_service(peer_id, 10, swarm_tx.clone());
 
-        // First request succeeds
-        assert!(
-            service.ready().await.is_ok(),
-            "First request should be ready"
-        );
-        assert!(service.call(ctx).await.is_ok(), "First call should succeed");
+        let (response_tx, _response_rx) = oneshot::channel::<Message>();
+        let ctx = make_test_context(peer_id, swarm_tx.clone(), response_tx);
+        handle.try_send(ctx).unwrap();
 
-        // Second request should timeout due to rate limit
-        let result = tokio::time::timeout(Duration::from_millis(500), service.ready()).await;
-        assert!(
-            result.is_err(),
-            "Second request should timeout due to rate limit"
-        );
+        // Drop the handle to close the channel, causing the task to exit
+        drop(handle);
 
-        if result.is_err() {
-            // Simulate a disconnect due to timeout
-            let _ = swarm_tx.send(SwarmSend::Disconnect(peer_id)).await;
-        }
+        // Give the task time to process and exit
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 
-        // Check that a disconnect was sent
-        let received = swarm_rx.try_recv().expect("Expected a SwarmSend message");
-        if let SwarmSend::Disconnect(received_peer) = received {
-            assert_eq!(
-                received_peer, peer_id,
-                "Expected Disconnect for the correct peer"
-            );
-        } else {
-            panic!("Expected SwarmSend::Disconnect, got {:?}", received);
-        }
+    #[tokio::test]
+    async fn test_peer_channel_capacity_calculation() {
+        //! Verifies channel capacity is max(rate, MIN_PEER_CHANNEL_CAPACITY).
+        assert_eq!(peer_channel_capacity(1), 16);
+        assert_eq!(peer_channel_capacity(16), 16);
+        assert_eq!(peer_channel_capacity(50), 50);
+        assert_eq!(peer_channel_capacity(100), 100);
     }
 }

--- a/p2poolv2_lib/src/service/mod.rs
+++ b/p2poolv2_lib/src/service/mod.rs
@@ -16,31 +16,152 @@
 
 pub mod p2p_service;
 
-use crate::config::NetworkConfig;
+use crate::node::SwarmSend;
 use crate::service::p2p_service::{P2PService, RequestContext};
 use crate::utils::time_provider::TimeProvider;
+use libp2p::PeerId;
 use std::error::Error;
 use std::time::Duration;
-use tower::{ServiceBuilder, limit::RateLimitLayer, util::BoxService};
+use tokio::sync::mpsc;
+use tower::limit::RateLimit;
+use tower::{Service, ServiceBuilder, ServiceExt, limit::RateLimitLayer};
+use tracing::{debug, error, info};
 
-/// Build the full service stack with rate limiting.
-pub fn build_service<C, T>(
-    config: NetworkConfig,
-) -> BoxService<RequestContext<C, T>, (), Box<dyn Error + Send + Sync>>
+/// Minimum per-peer channel capacity, matching the block fetcher's
+/// maximum in-flight requests per peer so a legitimate sync burst
+/// always fits without dropping.
+const MIN_PEER_CHANNEL_CAPACITY: u64 = 16;
+
+/// Handle to a per-peer service task.
+///
+/// Wraps the sender half of the channel used to forward inbound
+/// requests to the peer's dedicated processing task.
+pub struct PeerHandle<C, T> {
+    sender: mpsc::Sender<RequestContext<C, T>>,
+}
+
+impl<C, T> PeerHandle<C, T> {
+    /// Try to forward a request to the peer's task without blocking.
+    ///
+    /// Returns an error if the channel is full, meaning the peer's
+    /// task cannot keep up with the inbound request rate.
+    pub fn try_send(
+        &self,
+        request: RequestContext<C, T>,
+    ) -> Result<(), mpsc::error::TrySendError<RequestContext<C, T>>> {
+        self.sender.try_send(request)
+    }
+}
+
+/// Calculate the per-peer channel capacity.
+///
+/// Uses the larger of the configured rate limit and the minimum
+/// capacity needed for block sync bursts.
+fn peer_channel_capacity(max_requests_per_second: u64) -> usize {
+    std::cmp::max(max_requests_per_second, MIN_PEER_CHANNEL_CAPACITY) as usize
+}
+
+/// Build a rate-limited service for a single peer.
+fn build_rate_limited_service(max_requests_per_second: u64) -> RateLimit<P2PService> {
+    ServiceBuilder::new()
+        .layer(RateLimitLayer::new(
+            max_requests_per_second,
+            Duration::from_secs(1),
+        ))
+        .service(P2PService::new())
+}
+
+/// Spawn a per-peer service task and return a handle to send requests.
+///
+/// Creates a bounded channel and a rate-limited service, then spawns
+/// a tokio task that processes requests from the channel. The task
+/// exits when the channel closes (peer disconnected) or when the
+/// service fails (rate limit timeout or processing error), sending a
+/// disconnect command in the latter case.
+pub fn spawn_peer_service<C, T>(
+    peer_id: PeerId,
+    max_requests_per_second: u64,
+    swarm_tx: mpsc::Sender<SwarmSend<C>>,
+) -> PeerHandle<C, T>
 where
     C: Send + Sync + 'static,
     T: TimeProvider + Send + Sync + 'static,
 {
-    let base_service = P2PService::new();
+    let capacity = peer_channel_capacity(max_requests_per_second);
+    let service = build_rate_limited_service(max_requests_per_second);
+    let (sender, receiver) = mpsc::channel(capacity);
 
-    let builder = ServiceBuilder::new().layer(RateLimitLayer::new(
-        config.max_requests_per_second,
-        Duration::from_secs(1), // We have rate limit per second, so duration hardcoded to 1s
-    ));
+    tokio::spawn(run_peer_service(service, receiver, peer_id, swarm_tx));
 
-    let service = builder.service(base_service);
+    PeerHandle { sender }
+}
 
-    BoxService::new(service)
+/// Run the per-peer service loop.
+///
+/// Receives requests from the channel and processes each through the
+/// rate-limited service. Applies a 1-second timeout on service
+/// readiness to detect sustained overload.
+///
+/// Exits when:
+/// - The channel closes (sender dropped, peer disconnected)
+/// - The rate limiter is not ready within 1 second (sustained flood)
+/// - The service returns an error on call
+///
+/// On service failure, sends a disconnect command before exiting.
+async fn run_peer_service<C, T>(
+    mut service: RateLimit<P2PService>,
+    mut receiver: mpsc::Receiver<RequestContext<C, T>>,
+    peer_id: PeerId,
+    swarm_tx: mpsc::Sender<SwarmSend<C>>,
+) where
+    C: Send + Sync + 'static,
+    T: TimeProvider + Send + Sync + 'static,
+{
+    while let Some(request) = receiver.recv().await {
+        let ready_future = ServiceExt::<RequestContext<C, T>>::ready(&mut service);
+        match tokio::time::timeout(Duration::from_secs(1), ready_future).await {
+            Ok(Ok(_)) => {
+                if let Err(err) = service.call(request).await {
+                    error!("Service call failed for peer {}: {}", peer_id, err);
+                    let _ = swarm_tx.send(SwarmSend::Disconnect(peer_id)).await;
+                    return;
+                }
+            }
+            Ok(Err(err)) => {
+                error!("Service not ready for peer {}: {}", peer_id, err);
+                info!("Disconnecting peer {} due to service error", peer_id);
+                let _ = swarm_tx.send(SwarmSend::Disconnect(peer_id)).await;
+                return;
+            }
+            Err(_) => {
+                error!("Rate limit timeout for peer {}", peer_id);
+                info!(
+                    "Disconnecting peer {} due to sustained rate limit violation",
+                    peer_id
+                );
+                let _ = swarm_tx.send(SwarmSend::Disconnect(peer_id)).await;
+                return;
+            }
+        }
+    }
+    debug!(
+        "Peer service task exiting for peer {} -- channel closed",
+        peer_id
+    );
+}
+
+/// Build a boxed service stack with rate limiting.
+///
+/// Used by RequestResponseHandler until per-peer services are wired in.
+pub fn build_service<C, T>(
+    config: crate::config::NetworkConfig,
+) -> tower::util::BoxService<RequestContext<C, T>, (), Box<dyn Error + Send + Sync>>
+where
+    C: Send + Sync + 'static,
+    T: TimeProvider + Send + Sync + 'static,
+{
+    let service = build_rate_limited_service(config.max_requests_per_second);
+    tower::util::BoxService::new(service)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Earlier all peers were using the same tower service, which meant a global rate limit.

Now we have a per peer service which is more idiomatic and allows us to rate limit peers independent of each other. We will need a service around Store if we want to further control the global rates. I do think, with controls on number of connections and rate limits on each connections, we should be OK.