### PR TITLE
Change testnet4 genesis timestamp for asert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.10.6] - 2026-04-21
+
+- Change the testnet4 genesis to today. This is our testnet4 daa
+  anchor.
+
 ## [v0.10.5] - 2026-04-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindrpc"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3252,7 +3252,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2poolv2_api"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_cli"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_config"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_lib"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_node"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_tests"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.5"
+version = "0.10.6"
 edition = "2024"
 authors = ["Kulpreet Singh<kp@opdup.com>"]
 license = "AGPL-3.0-or-later"

--- a/p2poolv2_lib/src/shares/share_block/mod.rs
+++ b/p2poolv2_lib/src/shares/share_block/mod.rs
@@ -382,7 +382,7 @@ impl ShareBlock {
             miner_bitcoin_address: btcaddress,
             bitcoin_header: bitcoin_block.header,
             merkle_root,
-            time: 1700000000u32,
+            time: 1776801826u32,
             bits: CompactTarget::from_consensus(0x1b4188f5),
             donation_address: None,
             donation: None,


### PR DESCRIPTION
asert requires the anchor timestamp is not too far behind, as the lag time between current and anchor defines the daa.