### PR TITLE
Restart testnet4

### DIFF
--- a/p2poolv2_api/static/dashboard.html
+++ b/p2poolv2_api/static/dashboard.html
@@ -8,6 +8,52 @@
     <link rel="stylesheet" href="/static/pico.min.css" />
     <script defer src="/static/alpine.min.js"></script>
     <style>
+      .nav-links {
+        display: flex;
+        gap: 0;
+      }
+      .nav-menu-toggle {
+        display: none;
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        cursor: pointer;
+        padding: 0.25rem 0.5rem;
+        color: var(--pico-color);
+      }
+      .nav-dropdown {
+        display: none;
+        position: absolute;
+        right: 0;
+        top: 100%;
+        background: var(--pico-card-background-color);
+        border: 1px solid var(--pico-muted-border-color);
+        border-radius: var(--pico-border-radius);
+        padding: 0.5rem 0;
+        z-index: 10;
+        min-width: 10rem;
+      }
+      .nav-dropdown.open {
+        display: block;
+      }
+      .nav-dropdown a {
+        display: block;
+        padding: 0.5rem 1rem;
+      }
+      .nav-menu-wrapper {
+        display: none;
+      }
+      @media (max-width: 576px) {
+        .nav-links {
+          display: none;
+        }
+        .nav-menu-wrapper {
+          display: flex;
+        }
+        .nav-menu-toggle {
+          display: block;
+        }
+      }
     </style>
   </head>
   <body>
@@ -59,18 +105,48 @@
                   alt="P2Poolv2 Dashboard"
                   style="height: 2.5rem"
                 />
-                <small><em>Replace pool operators with miners</em></small>
               </li>
             </ul>
-            <ul>
+            <ul class="nav-links">
               <li>
-                <a href="https://p2poolv2.org" target="_blank">Mine on P2Poolv2</a>
+                <a href="https://p2poolv2.org" target="_blank"
+                  >Mine on P2Poolv2</a
+                >
               </li>
               <li>
-                <a href="#" @click.prevent="logout" x-show="credentials !== ''">Logout</a>
+                <a href="#" @click.prevent="logout" x-show="credentials !== ''"
+                  >Logout</a
+                >
+              </li>
+            </ul>
+            <ul class="nav-menu-wrapper">
+              <li style="position: relative">
+                <button
+                  class="nav-menu-toggle"
+                  @click="menuOpen = !menuOpen"
+                  @click.outside="menuOpen = false"
+                  aria-label="Menu"
+                >
+                  &#9776;
+                </button>
+                <div class="nav-dropdown" :class="menuOpen ? 'open' : ''">
+                  <a href="https://p2poolv2.org" target="_blank"
+                    >Mine on P2Poolv2</a
+                  >
+                  <a
+                    href="#"
+                    @click.prevent="logout; menuOpen = false"
+                    x-show="credentials !== ''"
+                    >Logout</a
+                  >
+                </div>
               </li>
             </ul>
           </nav>
+          <small
+            style="display: block; margin-top: -1rem; margin-bottom: 1.5rem"
+            ><em>Replace pool operators with miners</em></small
+          >
 
           <article>
             <header>
@@ -144,6 +220,7 @@
                       <th>Height</th>
                       <th>Blockhash</th>
                       <th>Miner</th>
+                      <th>Difficulty</th>
                       <th>Time</th>
                       <th>Uncles</th>
                     </tr>
@@ -169,6 +246,9 @@
                             x-text="formatHash(row.share.miner_address)"
                           ></code>
                         </td>
+                        <td
+                          x-text="row.share.bits ? difficultyFromBits(row.share.bits) : ''"
+                        ></td>
                         <td x-text="formatTimestamp(row.share.timestamp)"></td>
                         <td
                           x-text="row.isUncle ? 'uncle' : row.share.uncles.length"
@@ -271,7 +351,9 @@
               <tr>
                 <th scope="row">Bits</th>
                 <td>
-                  <code x-text="selectedShare ? selectedShare.bits + ' (Difficulty: ' + difficultyFromBits(selectedShare.bits) + ')' : ''"></code>
+                  <code
+                    x-text="selectedShare ? selectedShare.bits + ' (Difficulty: ' + difficultyFromBits(selectedShare.bits) + ')' : ''"
+                  ></code>
                 </td>
               </tr>
               <tr>

--- a/p2poolv2_api/static/dashboard.js
+++ b/p2poolv2_api/static/dashboard.js
@@ -20,13 +20,32 @@ function difficultyFromBits(bits) {
     var target =
         shift >= 0 ? mantissa << BigInt(shift) : mantissa >> BigInt(-shift);
     if (target === 0n) return "0";
-    var diff1Target = 0xFFFFn << 208n;
+    var diff1Target = 0xffffn << 208n;
     var difficulty = diff1Target / target;
-    return difficulty.toLocaleString();
+    return formatDifficulty(Number(difficulty));
+}
+
+function formatDifficulty(value) {
+    var suffixes = ["", "K", "M", "G", "T", "P", "E"];
+    if (value < 10000) return value.toLocaleString();
+    var tier = 0;
+    var scaled = value;
+    while (scaled >= 1000 && tier < suffixes.length - 1) {
+        scaled = scaled / 1000;
+        tier = tier + 1;
+    }
+    var formatted =
+        scaled >= 100
+            ? scaled.toFixed(0)
+            : scaled >= 10
+              ? scaled.toFixed(1)
+              : scaled.toFixed(2);
+    return formatted + suffixes[tier];
 }
 
 function dashboard() {
     return {
+        menuOpen: false,
         username: "",
         password: "",
         error: "",
@@ -241,10 +260,8 @@ function dashboard() {
 
         formatHash(hash) {
             if (!hash) return "N/A";
-            if (hash.length <= 16) return hash;
-            return (
-                hash.substring(0, 8) + "..." + hash.substring(hash.length - 8)
-            );
+            if (hash.length <= 12) return hash;
+            return hash.substring(0, 10);
         },
 
         formatTimestamp(timestamp) {

--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -664,7 +664,7 @@ mod tests {
         let mut pool_difficulty = PoolDifficulty::default();
         pool_difficulty
             .expect_calculate_target_clamped()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 CompactTarget::from_consensus(crate::shares::share_block::MAX_POOL_TARGET)
             });
         mock_validator

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
@@ -264,11 +264,7 @@ impl BlockReceiver {
         let expected_bits = self
             .share_validator
             .pool_difficulty()
-            .calculate_target_clamped(
-                parent_time,
-                parent_height,
-                share_block.header.bitcoin_header.bits,
-            );
+            .calculate_target_clamped(parent_time, parent_height);
         if share_block.header.bits != expected_bits {
             let block_hash = share_block.block_hash();
             return Err(format!(
@@ -785,7 +781,7 @@ mod tests {
         let mut pool_difficulty = PoolDifficulty::default();
         pool_difficulty
             .expect_calculate_target_clamped()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 CompactTarget::from_consensus(crate::shares::share_block::MAX_POOL_TARGET)
             });
         mock_validator
@@ -943,7 +939,7 @@ mod tests {
         let mut pool_difficulty = PoolDifficulty::default();
         pool_difficulty
             .expect_calculate_target_clamped()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 CompactTarget::from_consensus(crate::shares::share_block::MAX_POOL_TARGET)
             });
         mock_validator
@@ -1009,7 +1005,7 @@ mod tests {
         let mut mock_pool_difficulty = PoolDifficulty::default();
         mock_pool_difficulty
             .expect_calculate_target_clamped()
-            .returning(|_, _, _| CompactTarget::from_consensus(0x1d00ffff));
+            .returning(|_, _| CompactTarget::from_consensus(0x1d00ffff));
         let mut mock_validator = MockDefaultShareValidator::default();
         mock_validator
             .expect_pool_difficulty()
@@ -1117,7 +1113,7 @@ mod tests {
         let mut pool_difficulty = PoolDifficulty::default();
         pool_difficulty
             .expect_calculate_target_clamped()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 CompactTarget::from_consensus(crate::shares::share_block::MAX_POOL_TARGET)
             });
         mock_validator

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -234,11 +234,7 @@ fn classify_link_and_validate<'a>(
             }
         };
 
-        let expected_bits = pool_difficulty.calculate_target_clamped(
-            parent_time,
-            parent_height,
-            header.bitcoin_header.bits,
-        );
+        let expected_bits = pool_difficulty.calculate_target_clamped(parent_time, parent_height);
         if header.bits != expected_bits {
             let block_hash = header.block_hash();
             return Err(format!(
@@ -467,7 +463,7 @@ mod tests {
         let mut pool_difficulty = PoolDifficulty::default();
         pool_difficulty
             .expect_calculate_target_clamped()
-            .returning(|_, _, _| CompactTarget::from_consensus(MAX_POOL_TARGET));
+            .returning(|_, _| CompactTarget::from_consensus(MAX_POOL_TARGET));
         mock_validator
             .expect_pool_difficulty()
             .return_const(pool_difficulty);

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -377,7 +377,7 @@ mod tests {
         let mut pool_difficulty = PoolDifficulty::default();
         pool_difficulty
             .expect_calculate_target_clamped()
-            .returning(|_, _, _| {
+            .returning(|_, _| {
                 CompactTarget::from_consensus(crate::shares::share_block::MAX_POOL_TARGET)
             });
         mock_validator

--- a/p2poolv2_lib/src/pool_difficulty.rs
+++ b/p2poolv2_lib/src/pool_difficulty.rs
@@ -264,39 +264,24 @@ impl PoolDifficulty {
     ///
     /// The returned target is clamped in two directions:
     /// 1. Never harder than bitcoin difficulty (floor) -- ASERT can produce a
-    ///    target smaller than the bitcoin target, which would be impossible to
-    ///    satisfy since no bitcoin block hash can beat bitcoin's own target.
+    ///    target smaller than the bitcoin target.
     /// 2. Never easier than MAX_POOL_TARGET (ceiling) -- ensures shares always
     ///    meet the pool's minimum difficulty requirement.
     pub fn calculate_target_clamped(
         &self,
         block_parent_time: u32,
         block_parent_height: u32,
-        bitcoin_bits: CompactTarget,
     ) -> CompactTarget {
         let asert_target = self.calculate_target(block_parent_time, block_parent_height);
-        let bitcoin_target = Target::from_compact(bitcoin_bits);
-        let pool_target = Target::from_compact(asert_target);
 
         let max_pool_target_compact = CompactTarget::from_consensus(MAX_POOL_TARGET);
         let max_pool_target = Target::from_compact(max_pool_target_compact);
 
-        // A smaller Target value means harder difficulty. If the pool target is
-        // harder than bitcoin, use bitcoin as the floor.
-        let result = if pool_target < bitcoin_target {
-            bitcoin_bits
-        } else {
-            asert_target
-        };
-
-        // Final clamp: never return a target easier than MAX_POOL_TARGET.
-        // This applies regardless of whether bitcoin clamping was used,
-        // ensuring shares always meet the pool's minimum difficulty.
-        let result_target = Target::from_compact(result);
+        let result_target = Target::from_compact(asert_target);
         if result_target > max_pool_target {
             max_pool_target_compact
         } else {
-            result
+            asert_target
         }
     }
 
@@ -321,7 +306,7 @@ mockall::mock! {
         pub fn new(anchor_target: CompactTarget, anchor_parent_time: u32, anchor_height: u32) -> Self;
         pub fn build(chain_store_handle: &ChainStoreHandle) -> Result<Self, PoolDifficultyError>;
         pub fn calculate_target(&self, block_parent_time: u32, block_parent_height: u32) -> CompactTarget;
-        pub fn calculate_target_clamped(&self, block_parent_time: u32, block_parent_height: u32, bitcoin_bits: CompactTarget) -> CompactTarget;
+        pub fn calculate_target_clamped(&self, block_parent_time: u32, block_parent_height: u32) -> CompactTarget;
         pub fn calculate_target_consensus(&self, block_parent_time: u32, block_parent_height: u32) -> u32;
     }
 
@@ -758,52 +743,13 @@ mod tests {
         // return a target easier than MAX_POOL_TARGET, so it gets clamped
         let anchor = CompactTarget::from_consensus(0x1b4188f5);
         let pool_diff = PoolDifficulty::new(anchor, 1700000000, 0);
-        // Bitcoin difficulty is much harder (smaller target)
-        let bitcoin_bits = CompactTarget::from_consensus(0x170f2e48);
 
-        let result = pool_diff.calculate_target_clamped(1700000000, 0, bitcoin_bits);
+        let result = pool_diff.calculate_target_clamped(1700000000, 0);
 
         assert_eq!(
             result.to_consensus(),
             MAX_POOL_TARGET,
             "Should clamp to MAX_POOL_TARGET when ASERT target is easier"
-        );
-    }
-
-    #[test]
-    fn test_calculate_target_clamped_clamps_easy_bitcoin_to_max_pool_target() {
-        // Use a very hard anchor target that is harder than bitcoin
-        let hard_anchor = CompactTarget::from_consensus(0x170f2e48);
-        let pool_diff = PoolDifficulty::new(hard_anchor, 1700000000, 0);
-        // Bitcoin difficulty is easier (signet-like) but still easier than
-        // MAX_POOL_TARGET, so the final clamp kicks in
-        let bitcoin_bits = CompactTarget::from_consensus(0x1b4188f5);
-
-        let result = pool_diff.calculate_target_clamped(1700000000, 0, bitcoin_bits);
-
-        // Bitcoin target (0x1b4188f5) is easier than MAX_POOL_TARGET (0x1b384bd7),
-        // so the final clamp returns MAX_POOL_TARGET
-        assert_eq!(
-            result.to_consensus(),
-            MAX_POOL_TARGET,
-            "Should clamp to MAX_POOL_TARGET when bitcoin target is easier than pool max"
-        );
-    }
-
-    #[test]
-    fn test_calculate_target_clamped_equal_targets() {
-        // When ASERT and bitcoin targets are equal but both easier than
-        // MAX_POOL_TARGET, the result is clamped to MAX_POOL_TARGET
-        let anchor = CompactTarget::from_consensus(0x1b4188f5);
-        let pool_diff = PoolDifficulty::new(anchor, 1700000000, 0);
-        let bitcoin_bits = pool_diff.calculate_target(1700000000, 0);
-
-        let result = pool_diff.calculate_target_clamped(1700000000, 0, bitcoin_bits);
-
-        assert_eq!(
-            result.to_consensus(),
-            MAX_POOL_TARGET,
-            "Should clamp to MAX_POOL_TARGET when both targets are easier"
         );
     }
 
@@ -856,12 +802,8 @@ mod tests {
 
             let parent = &blocks[index - 1];
             let parent_height = (index - 1) as u32;
-            let bitcoin_bits = block.header.bitcoin_header.bits;
-            let expected_target = pool_difficulty.calculate_target_clamped(
-                parent.header.time,
-                parent_height,
-                bitcoin_bits,
-            );
+            let expected_target =
+                pool_difficulty.calculate_target_clamped(parent.header.time, parent_height);
             assert_eq!(
                 block.header.bits,
                 expected_target,

--- a/p2poolv2_lib/src/shares/genesis/mod.rs
+++ b/p2poolv2_lib/src/shares/genesis/mod.rs
@@ -50,7 +50,7 @@ const TESTNET4_GENESIS_DATA: GenesisData = GenesisData {
     // for bitcoin blockhash 00000000000000013c0a1f4152b458118ed666282e6235d744bf2a5d66ecf022
     bitcoin_block_hex: include!("testnet4.rs"),
     bitcoin_height: 130754,
-    timestamp: 1776855600,
+    timestamp: 1776849600,
 };
 
 // Using the following JSON data for the genesis block

--- a/p2poolv2_lib/src/shares/genesis/mod.rs
+++ b/p2poolv2_lib/src/shares/genesis/mod.rs
@@ -32,6 +32,8 @@ pub struct GenesisData {
     pub bitcoin_block_hex: &'static str,
     /// Bitcoin header height
     pub bitcoin_height: u64,
+    /// Unix timestamp for the genesis share block
+    pub timestamp: u32,
 }
 
 const SIGNET_GENESIS_DATA: GenesisData = GenesisData {
@@ -40,6 +42,7 @@ const SIGNET_GENESIS_DATA: GenesisData = GenesisData {
     // bitcoin_header_hex: "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a008f4d5fae77031e8ad22203",
     bitcoin_block_hex: include!("signet.rs"),
     bitcoin_height: 0,
+    timestamp: 1776855600,
 };
 
 const TESTNET4_GENESIS_DATA: GenesisData = GenesisData {
@@ -47,6 +50,7 @@ const TESTNET4_GENESIS_DATA: GenesisData = GenesisData {
     // for bitcoin blockhash 00000000000000013c0a1f4152b458118ed666282e6235d744bf2a5d66ecf022
     bitcoin_block_hex: include!("testnet4.rs"),
     bitcoin_height: 130754,
+    timestamp: 1776855600,
 };
 
 // Using the following JSON data for the genesis block
@@ -56,6 +60,7 @@ const MAINNET_GENESIS_DATA: GenesisData = GenesisData {
     // header in hex "00a06f239cf5fe7a514fd6f9e64d77cd2345cf225ee3fe9b75bf00000000000000000000923435bf0a5f91886f7f94ade677752a526dec905eef07d181893faf15113a75b039fb6821eb01173c0137da"
     bitcoin_block_hex: include!("main.rs"),
     bitcoin_height: 920527,
+    timestamp: 1776855600,
 };
 
 /// Get the genesis data for a given network

--- a/p2poolv2_lib/src/shares/share_block/mod.rs
+++ b/p2poolv2_lib/src/shares/share_block/mod.rs
@@ -382,7 +382,7 @@ impl ShareBlock {
             miner_bitcoin_address: btcaddress,
             bitcoin_header: bitcoin_block.header,
             merkle_root,
-            time: 1776801826u32,
+            time: 1776842294u32,
             bits: CompactTarget::from_consensus(0x1b4188f5),
             donation_address: None,
             donation: None,

--- a/p2poolv2_lib/src/shares/share_block/mod.rs
+++ b/p2poolv2_lib/src/shares/share_block/mod.rs
@@ -382,7 +382,7 @@ impl ShareBlock {
             miner_bitcoin_address: btcaddress,
             bitcoin_header: bitcoin_block.header,
             merkle_root,
-            time: 1776842294u32,
+            time: genesis_data.timestamp,
             bits: CompactTarget::from_consensus(0x1b4188f5),
             donation_address: None,
             donation: None,

--- a/p2poolv2_lib/src/shares/share_commitment.rs
+++ b/p2poolv2_lib/src/shares/share_commitment.rs
@@ -173,9 +173,7 @@ pub(crate) fn build_share_commitment(
 
     let (tip_height, parent_time) = chain_store_handle.get_tip_height_and_time()?;
     // tip_height is the parent height; ASERT internally adds 1 to height_delta
-    let bitcoin_bits = bitcoin::CompactTarget::from_unprefixed_hex(&template.bits)
-        .map_err(|error| format!("Failed to parse bitcoin bits from block template: {error}"))?;
-    let target = pool_difficulty.calculate_target_clamped(parent_time, tip_height, bitcoin_bits);
+    let target = pool_difficulty.calculate_target_clamped(parent_time, tip_height);
 
     let time = SystemTimeProvider.seconds_since_epoch() as u32;
 

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -731,10 +731,9 @@ impl ShareValidator for DefaultShareValidator {
 
         let parent_time = parent_header.time;
 
-        let bitcoin_bits = share_header.bitcoin_header.bits;
-        let calculated_target =
-            self.pool_difficulty
-                .calculate_target_clamped(parent_time, parent_height, bitcoin_bits);
+        let calculated_target = self
+            .pool_difficulty
+            .calculate_target_clamped(parent_time, parent_height);
         let target = Target::from_compact(calculated_target);
         let bitcoin_block_hash = share_header.bitcoin_header.block_hash();
 

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -121,9 +121,9 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
         let pool_target = bitcoin::Target::from_compact(commitment.bits);
         if !pool_target.is_met_by(validation_result.header.block_hash()) {
             debug!(
-                "Share does not meet pool difficulty: hash {} target {}",
+                "Share does not meet pool difficulty: hash {} target {:?}",
                 validation_result.header.block_hash(),
-                pool_target
+                commitment.bits
             );
             return Ok(vec![Message::Response(Response::new_ok(
                 message.id,

--- a/p2poolv2_lib/src/stratum/work/notify.rs
+++ b/p2poolv2_lib/src/stratum/work/notify.rs
@@ -97,14 +97,9 @@ fn build_prepared_notify(
         .map_err(|error| WorkError {
             message: format!("Failed to get tip height: {error}"),
         })?;
-    let bitcoin_bits =
-        bitcoin::CompactTarget::from_unprefixed_hex(&template.bits).map_err(|_| WorkError {
-            message: "Failed to parse bitcoin bits from block template".to_string(),
-        })?;
-    let target =
-        context
-            .pool_difficulty
-            .calculate_target_clamped(parent_time, tip_height, bitcoin_bits);
+    let target = context
+        .pool_difficulty
+        .calculate_target_clamped(parent_time, tip_height);
     let time = SystemTimeProvider.seconds_since_epoch() as u32;
 
     PreparedNotifyParamsBuilder::new(

--- a/p2poolv2_lib/src/test_utils.rs
+++ b/p2poolv2_lib/src/test_utils.rs
@@ -234,7 +234,7 @@ pub fn setup_pool_difficulty_mocks(
 
     pool_difficulty
         .expect_calculate_target_clamped()
-        .returning(move |_, _, _| CompactTarget::from_consensus(target_bits));
+        .returning(move |_, _| CompactTarget::from_consensus(target_bits));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Change genesis timestamp for testnet4
- Stop clamping difficulty to bitcoin diff
- Update dash to show share diff in the table.

**Re difficulty clamping from a commit below:**

"We were doing that for signet, but it was breaking things. We need our
chain to be targetting 10s blocks.

The signet chain will slow down to 10s blocks during initial chain
life. Which is OK.

For testnet4, when bitcoin difficulty is brought down to 1 due to
ongoing timing attack we still don't go faster than 10s block
rate. Which is fine as after the timing attack blocks, the MTP check
will reject our blocks anyway."