### PR TITLE
feat: Add optional CORS support to API server

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -71,3 +71,5 @@ port = 46884
 # auth_token = "your_secret_token"
 # auth_password is the raw password for p2poolv2_cli client auth only. Do not set on server config.
 # auth_password = "your_password"
+# Enable permissive CORS (careful with this; allows any origin)
+# cors_allowed = false

--- a/p2poolv2_api/Cargo.toml
+++ b/p2poolv2_api/Cargo.toml
@@ -27,7 +27,7 @@ serde = { workspace = true }
 serde_json = "1"
 chrono = { workspace = true }
 subtle = "2"
-tower-http = { version = "0.6", features = ["fs"] }
+tower-http = { version = "0.6", features = ["fs", "cors"] }
 
 [dev-dependencies]
 p2poolv2_lib = { workspace = true, features = ["test-utils"] }

--- a/p2poolv2_api/src/api/endpoints/candidates.rs
+++ b/p2poolv2_api/src/api/endpoints/candidates.rs
@@ -111,6 +111,7 @@ mod tests {
             app_config: AppConfig {
                 pool_signature_length: 0,
                 network: bitcoin::Network::Signet,
+                cors_allowed: false,
             },
             chain_store_handle,
             metrics_handle,

--- a/p2poolv2_api/src/api/endpoints/chain_info.rs
+++ b/p2poolv2_api/src/api/endpoints/chain_info.rs
@@ -96,6 +96,7 @@ mod tests {
             app_config: AppConfig {
                 pool_signature_length: 0,
                 network: bitcoin::Network::Signet,
+                cors_allowed: false,
             },
             chain_store_handle,
             metrics_handle,

--- a/p2poolv2_api/src/api/endpoints/share.rs
+++ b/p2poolv2_api/src/api/endpoints/share.rs
@@ -272,6 +272,7 @@ mod tests {
             app_config: AppConfig {
                 pool_signature_length: 0,
                 network: bitcoin::Network::Signet,
+                cors_allowed: false,
             },
             chain_store_handle,
             metrics_handle,

--- a/p2poolv2_api/src/api/endpoints/share_headers.rs
+++ b/p2poolv2_api/src/api/endpoints/share_headers.rs
@@ -179,6 +179,7 @@ mod tests {
             app_config: AppConfig {
                 pool_signature_length: 0,
                 network: bitcoin::Network::Signet,
+                cors_allowed: false,
             },
             chain_store_handle,
             metrics_handle,

--- a/p2poolv2_api/src/api/endpoints/shares.rs
+++ b/p2poolv2_api/src/api/endpoints/shares.rs
@@ -113,6 +113,7 @@ mod tests {
             app_config: AppConfig {
                 pool_signature_length: 0,
                 network: bitcoin::Network::Signet,
+                cors_allowed: false,
             },
             chain_store_handle,
             metrics_handle,

--- a/p2poolv2_api/src/api/server.rs
+++ b/p2poolv2_api/src/api/server.rs
@@ -38,6 +38,7 @@ use serde::Deserialize;
 use std::path::PathBuf;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::oneshot;
+use tower_http::cors::CorsLayer;
 use tower_http::services::{ServeDir, ServeFile};
 use tracing::{info, trace};
 
@@ -59,6 +60,7 @@ pub(crate) struct AppState {
 pub struct AppConfig {
     pub pool_signature_length: usize,
     pub network: bitcoin::Network,
+    pub cors_allowed: bool,
 }
 
 /// Get AppConfig from AppState ref
@@ -133,11 +135,15 @@ fn build_router(app_state: Arc<AppState>, app_config: AppConfig) -> Router {
         )
         .nest_service("/static", ServeDir::new(&static_dir));
 
-    authenticated_routes
+    let mut router = authenticated_routes
         .merge(unauthenticated_routes)
-        .layer(middleware::from_fn(log_req))
-        .layer(Extension(app_config))
-        .with_state(app_state)
+        .layer(middleware::from_fn(log_req));
+
+    if app_config.cors_allowed {
+        router = router.layer(CorsLayer::permissive())
+    }
+
+    router.layer(Extension(app_config)).with_state(app_state)
 }
 
 /// Start the API server and return a shutdown channel and the actual bound port.
@@ -154,6 +160,7 @@ pub async fn start_api_server(
     let app_config = AppConfig {
         pool_signature_length: pool_signature.unwrap_or_default().len(),
         network,
+        cors_allowed: config.cors_allowed,
     };
 
     let app_state = Arc::new(AppState {
@@ -338,6 +345,7 @@ mod tests {
             app_config: AppConfig {
                 pool_signature_length: 0,
                 network: bitcoin::Network::Signet,
+                cors_allowed: false,
             },
             chain_store_handle,
             metrics_handle,
@@ -480,6 +488,7 @@ mod tests {
             app_config: AppConfig {
                 pool_signature_length: 8,
                 network: bitcoin::Network::Signet,
+                cors_allowed: false,
             },
             chain_store_handle,
             metrics_handle,
@@ -587,6 +596,7 @@ mod tests {
             app_config: AppConfig {
                 pool_signature_length: 0,
                 network: bitcoin::Network::Signet,
+                cors_allowed: false,
             },
             chain_store_handle,
             metrics_handle,
@@ -729,6 +739,53 @@ mod tests {
             response.status(),
             101,
             "WebSocket upgrade should not succeed with only an Authorization header"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cors_headers_present_when_enabled() {
+        use tower::ServiceExt;
+
+        let node_handle = NodeHandle::new_for_test();
+        let (chain_store_handle, _temp_dir) =
+            p2poolv2_lib::test_utils::setup_test_chain_store_handle(true).await;
+        let metrics_temp = tempfile::tempdir().unwrap();
+        let metrics_handle =
+            metrics::start_metrics(metrics_temp.path().to_str().unwrap().to_string())
+                .await
+                .unwrap();
+        let tracker_handle = start_tracker_actor();
+
+        let state = Arc::new(AppState {
+            app_config: AppConfig {
+                pool_signature_length: 0,
+                network: bitcoin::Network::Signet,
+                cors_allowed: true,
+            },
+            chain_store_handle,
+            metrics_handle,
+            tracker_handle,
+            node_handle,
+            monitoring_event_sender: create_monitoring_event_channel().0,
+            auth_user: None,
+            auth_token: None,
+        });
+
+        let app = build_router(state.clone(), state.app_config.clone());
+
+        let request = http::Request::builder()
+            .uri("/health")
+            .body(http_body_util::Empty::<bytes::Bytes>::new())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), http::StatusCode::OK);
+
+        let headers = response.headers();
+        assert_eq!(
+            headers.get("access-control-allow-origin"),
+            Some(&"*".parse().unwrap()),
+            "access-control-allow-origin header should be present"
         );
     }
 }

--- a/p2poolv2_cli/src/commands/api_client.rs
+++ b/p2poolv2_cli/src/commands/api_client.rs
@@ -96,6 +96,7 @@ mod tests {
             auth_user: None,
             auth_token: None,
             auth_password: None,
+            cors_allowed: false,
         }
     }
 

--- a/p2poolv2_cli/src/commands/candidates.rs
+++ b/p2poolv2_cli/src/commands/candidates.rs
@@ -49,6 +49,7 @@ mod tests {
             auth_user: None,
             auth_token: None,
             auth_password: None,
+            cors_allowed: false,
         }
     }
 

--- a/p2poolv2_cli/src/commands/chain_info.rs
+++ b/p2poolv2_cli/src/commands/chain_info.rs
@@ -39,6 +39,7 @@ mod tests {
             auth_user: None,
             auth_token: None,
             auth_password: None,
+            cors_allowed: false,
         }
     }
 

--- a/p2poolv2_cli/src/commands/peers_info.rs
+++ b/p2poolv2_cli/src/commands/peers_info.rs
@@ -40,6 +40,7 @@ mod tests {
             auth_user: None,
             auth_token: None,
             auth_password: None,
+            cors_allowed: false,
         }
     }
 

--- a/p2poolv2_cli/src/commands/pplns_shares.rs
+++ b/p2poolv2_cli/src/commands/pplns_shares.rs
@@ -62,6 +62,7 @@ mod tests {
             auth_user: None,
             auth_token: None,
             auth_password: None,
+            cors_allowed: false,
         }
     }
 

--- a/p2poolv2_cli/src/commands/share.rs
+++ b/p2poolv2_cli/src/commands/share.rs
@@ -55,6 +55,7 @@ mod tests {
             auth_user: None,
             auth_token: None,
             auth_password: None,
+            cors_allowed: false,
         }
     }
 

--- a/p2poolv2_cli/src/commands/shares.rs
+++ b/p2poolv2_cli/src/commands/shares.rs
@@ -57,6 +57,7 @@ mod tests {
             auth_user: None,
             auth_token: None,
             auth_password: None,
+            cors_allowed: false,
         }
     }
 

--- a/p2poolv2_config/src/lib.rs
+++ b/p2poolv2_config/src/lib.rs
@@ -339,6 +339,9 @@ pub struct ApiConfig {
     pub auth_token: Option<String>,
     /// Optional raw password for CLI client authentication (not used by server)
     pub auth_password: Option<String>,
+    /// Enable permissive CORS for the API server
+    #[serde(default)]
+    pub cors_allowed: bool,
 }
 
 /// Custom Debug to redact password
@@ -351,6 +354,7 @@ impl std::fmt::Debug for ApiConfig {
             .field("auth_user", &self.auth_user)
             .field("auth_token", &"[redacted]")
             .field("auth_password", &"[redacted]")
+            .field("cors_allowed", &self.cors_allowed)
             .finish()
     }
 }

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -555,6 +555,7 @@ mod tests {
                 auth_user: None,
                 auth_token: None,
                 auth_password: None,
+                cors_allowed: false,
             },
         };
         config.network = network_config;

--- a/p2poolv2_tests/src/common/mod.rs
+++ b/p2poolv2_tests/src/common/mod.rs
@@ -64,6 +64,7 @@ pub fn default_test_config() -> Config {
             auth_user: None,
             auth_token: None,
             auth_password: None,
+            cors_allowed: false,
         },
     }
 }

--- a/p2poolv2_tests/src/test_api_server_health_check.rs
+++ b/p2poolv2_tests/src/test_api_server_health_check.rs
@@ -45,6 +45,7 @@ async fn test_api_server_without_authentication() -> Result<(), ApiError> {
         auth_user: None,
         auth_token: None,
         auth_password: None,
+        cors_allowed: false,
     };
 
     // Start API server with the new signature
@@ -128,6 +129,7 @@ async fn test_api_server_with_authentication() -> Result<(), ApiError> {
         auth_user: Some("testuser".to_string()),
         auth_token: Some(test_token),
         auth_password: None,
+        cors_allowed: false,
     };
 
     // Start API server with authentication
@@ -245,6 +247,7 @@ async fn test_pplns_shares_endpoint_get_all() -> Result<(), ApiError> {
         auth_user: None,
         auth_token: None,
         auth_password: None,
+        cors_allowed: false,
     };
 
     // Start API server
@@ -358,6 +361,7 @@ async fn test_pplns_shares_endpoint_limit() -> Result<(), ApiError> {
         auth_user: None,
         auth_token: None,
         auth_password: None,
+        cors_allowed: false,
     };
 
     // Start API server
@@ -466,6 +470,7 @@ async fn test_pplns_shares_endpoint_time_filter() -> Result<(), ApiError> {
         auth_user: None,
         auth_token: None,
         auth_password: None,
+        cors_allowed: false,
     };
 
     // Start API server


### PR DESCRIPTION
Add `cors_allowed` configuration option to enable permissive CORS headers on the API server. Defaults to false for security. Minimal implementation to avoid focusing on irrelevant features. Setting this on allows any origin (useful for testing/troubleshooting).