### PR TITLE
fix: add the static folder to the final img

### DIFF
--- a/docker/docker-compose.p2poolv2.yml
+++ b/docker/docker-compose.p2poolv2.yml
@@ -21,7 +21,7 @@ services:
       - "${P2POOL_P2P_PORT:-6884}:${P2POOL_P2P_PORT:-6884}"
     volumes:
       - p2poolv2_data:/p2poolv2
-      - ../config.toml:/etc/p2poolv2/config.toml:ro
+      - ../${P2POOL_CONFIG:-config.toml}:/etc/p2poolv2/config.toml:ro
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/docker/p2poolv2/Dockerfile
+++ b/docker/p2poolv2/Dockerfile
@@ -73,6 +73,10 @@ COPY --from=builder /usr/local/cargo/bin/p2poolv2 /usr/local/bin/p2poolv2
 COPY --from=builder /usr/local/cargo/bin/p2poolv2_cli /usr/local/bin/p2poolv2_cli
 COPY config-docker.sample.toml /etc/p2poolv2/config.toml
 
+# Set up dashboard
+COPY p2poolv2_api/static /var/www/dashboard
+ENV P2POOL_STATIC_DIR=/var/www/dashboard
+
 # TODO: add non-root user
 
 HEALTHCHECK --interval=5s --timeout=1s --start-period=1s --retries=3 \

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-set unstable := true
+set unstable
 
 dev_config := "." / "config-dev.toml"
 default_config := "." / "config.toml"
@@ -130,7 +130,7 @@ container-explore: (docker-run "--entrypoint bash")
 [group("docker")]
 [working-directory("docker")]
 compose *services="all":
-    docker compose --env-file .env up -d --build --force-recreate {{ if services == "all" { "" } else { services } }}
+    P2POOL_CONFIG={{ target_config }} docker compose --env-file .env up -d --build --force-recreate {{ if services == "all" { "" } else { services } }}
 
 # Start a shell in a docker compose service
 [group("docker")]


### PR DESCRIPTION
The endpoint /dashboard was not loading when using the docker img, this commit adds the static files to the img so the server can respond with them.