### PR TITLE
chore: sync and prune bitcoind configs

### DIFF
--- a/docker/bitcoind/signet/bitcoin-signet.conf
+++ b/docker/bitcoind/signet/bitcoin-signet.conf
@@ -35,7 +35,7 @@
 # Maintain an index of compact filters by block (default: 0, values:
 # basic). If <type> is not supplied or if <type> = 1, indexes for
 # all known types are enabled.
-blockfilterindex=basic
+#blockfilterindex=<type>
 
 # Execute command when the best block changes (%s in cmd is replaced by
 # block hash)
@@ -61,7 +61,7 @@ blockfilterindex=basic
 #blocksxor=1
 
 # Maintain coinstats index used by the gettxoutsetinfo RPC (default: 0)
-coinstatsindex=1
+#coinstatsindex=1
 
 # Specify path to read-only configuration file. Relative paths will be
 # prefixed by datadir location (only useable from command line, not
@@ -131,7 +131,7 @@ persistmempool=1
 # disable pruning blocks, 1 = allow manual pruning via RPC, >=550 =
 # automatically prune block files to stay under the specified
 # target size in MiB)
-#prune=<n>
+prune=1000
 
 # If enabled, wipe chain state and block index, and rebuild them from
 # blk*.dat files on disk. Also wipe and rebuild other optional
@@ -163,7 +163,7 @@ persistmempool=1
 
 # Maintain a full transaction index, used by the getrawtransaction rpc
 # call (default: 0)
-txindex=1
+#txindex=1
 
 # Print version and exit
 #version=1
@@ -383,7 +383,7 @@ listenonion=0
 # A fee rate (in BTC/kvB) that will be used when fee estimation has
 # insufficient data. 0 to entirely disable the fallbackfee feature.
 # (default: 0.00)
-fallbackfee=0.001
+#fallbackfee=<amt>
 
 # Set key pool size to <n> (default: 1000). Warning: Smaller sizes may
 # increase the risk of losing funds when restoring from an old
@@ -491,35 +491,39 @@ zmqpubhashblock=tcp://*:28332
 # selectcoins, tor, txpackages, txreconciliation, validation,
 # walletdb, zmq. This option can be specified multiple times to
 # output multiple categories.
-debug=all
+debug=cmpctblock
+debug=ipc
+debug=mempool
+debug=rpc
+debug=validation
+debug=zmq
 
 # Exclude debug and trace logging for a category. Can be used in
 # conjunction with -debug=1 to output debug and trace logging for
 # all categories except the specified category. This option can be
 # specified multiple times to exclude multiple categories. This
 # takes priority over "-debug"
-debugexclude=libevent
-debugexclude=rpc
-debugexclude=http
+# debugexclude=libevent
+# debugexclude=net
 
 # Print help message with debugging options and exit
 #help-debug=1
 
 # Include IP addresses in debug output (default: 0)
-#logips=1
+logips=1
 
 # Always prepend a category and level (default: 0)
 #loglevelalways=1
 
 # Prepend debug output with name of the originating source location
 # (source file, line number and function name) (default: 0)
-#logsourcelocations=1
+logsourcelocations=1
 
 # Prepend debug output with name of the originating thread (default: 0)
-#logthreadnames=1
+logthreadnames=1
 
 # Prepend debug output with timestamp (default: 1)
-#logtimestamps=1
+logtimestamps=1
 
 # Maximum total fees (in BTC) to use in a single wallet transaction;
 # setting this too low may abort large transactions (default: 0.10)

--- a/docker/bitcoind/testnet4/bitcoin-testnet4.conf
+++ b/docker/bitcoind/testnet4/bitcoin-testnet4.conf
@@ -81,7 +81,7 @@
 # Maximum database cache size <n> MiB (4 to 16384, default: 450). In
 # addition, unused mempool memory is shared for this cache (see
 # -maxmempool).
-#dbcache=<n>
+dbcache=1024
 
 # Specify location of debug log file (default: debug.log). Relative paths
 # will be prefixed by a net-specific datadir location. Pass
@@ -96,7 +96,7 @@
 #loadblock=<file>
 
 # Keep the transaction memory pool below <n> megabytes (default: 300)
-#maxmempool=<n>
+maxmempool=500
 
 # Keep at most <n> unconnectable transactions in memory (default: 100)
 #maxorphantx=<n>
@@ -110,7 +110,7 @@
 #par=<n>
 
 # Whether to save the mempool on shutdown and load on restart (default: 1)
-#persistmempool=1
+persistmempool=1
 
 # Whether a mempool.dat file created by -persistmempool or the savemempool
 # RPC will be written in the legacy format (version 1) or the
@@ -131,7 +131,7 @@
 # disable pruning blocks, 1 = allow manual pruning via RPC, >=550 =
 # automatically prune block files to stay under the specified
 # target size in MiB)
-#prune=<n>
+prune=1000
 
 # If enabled, wipe chain state and block index, and rebuild them from
 # blk*.dat files on disk. Also wipe and rebuild other optional
@@ -491,7 +491,11 @@ zmqpubhashblock=tcp://*:28332
 # selectcoins, tor, txpackages, txreconciliation, validation,
 # walletdb, zmq. This option can be specified multiple times to
 # output multiple categories.
+debug=cmpctblock
+debug=ipc
+debug=mempool
 debug=rpc
+debug=validation
 debug=zmq
 
 # Exclude debug and trace logging for a category. Can be used in
@@ -506,20 +510,20 @@ debug=zmq
 #help-debug=1
 
 # Include IP addresses in debug output (default: 0)
-#logips=1
+logips=1
 
 # Always prepend a category and level (default: 0)
 #loglevelalways=1
 
 # Prepend debug output with name of the originating source location
 # (source file, line number and function name) (default: 0)
-#logsourcelocations=1
+logsourcelocations=1
 
 # Prepend debug output with name of the originating thread (default: 0)
-#logthreadnames=1
+logthreadnames=1
 
 # Prepend debug output with timestamp (default: 1)
-#logtimestamps=1
+logtimestamps=1
 
 # Maximum total fees (in BTC) to use in a single wallet transaction;
 # setting this too low may abort large transactions (default: 0.10)


### PR DESCRIPTION
- Enable pruning (1000MB) on both configs
- Add mining related debug categories (cmpctblock, ipc, mempool, rpc,
validation, zmq)
- Enable logips, logsourcelocations, logthreadnames, logtimestamps
- Comment out txindex (unused)
- Comment out coinstatsindex and blockfilterindex (unused)
- Leave loglevelalways commented (redundant)
