### PR TITLE
feat: make sure that the connect btc node is synced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3364,6 +3364,7 @@ dependencies = [
 name = "p2poolv2_node"
 version = "0.10.10"
 dependencies = [
+ "base64 0.22.1",
  "bitcoin",
  "bitcoindrpc",
  "clap",
@@ -3374,10 +3375,12 @@ dependencies = [
  "p2poolv2_cli",
  "p2poolv2_lib",
  "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ mockall = "0.13.1"
 mockall_double = "0.3.1"
 tempfile = "3.15.0"
 tokio-test = "0.4.3"
+wiremock = "0.6.2"
 dashmap = "6"
 uint = "0.9"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/bitcoindrpc/src/lib.rs
+++ b/bitcoindrpc/src/lib.rs
@@ -109,6 +109,12 @@ impl fmt::Display for BitcoindRpcError {
     }
 }
 
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub struct GetBlockchainInfo {
+    #[serde(rename = "initialblockdownload")]
+    pub initial_block_download: bool,
+}
+
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct BitcoindRpcClient {
@@ -211,6 +217,10 @@ impl BitcoindRpcClient {
         let params: Vec<serde_json::Value> = vec![];
         let result: serde_json::Value = self.request("getdifficulty", params).await?;
         Ok(result.as_f64().unwrap())
+    }
+
+    pub async fn getblockchaininfo(&self) -> Result<GetBlockchainInfo, BitcoindRpcError> {
+        self.request("getblockchaininfo", vec![]).await
     }
 
     /// Get current bitcoin block count from bitcoind rpc
@@ -420,6 +430,39 @@ mod tests {
         let difficulty = client.get_difficulty().await.unwrap();
 
         assert_eq!(difficulty, 1234.56);
+    }
+
+    #[tokio::test]
+    async fn test_getblockchaininfo() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", "Basic cDJwb29sOnAycG9vbA=="))
+            .and(body_json(serde_json::json!({
+                "method": "getblockchaininfo",
+                "params": [],
+                "id": 0
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": {
+                    "initialblockdownload": true,
+                },
+                "error": null,
+                "id": 0
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = BitcoindRpcClient::new(&mock_server.uri(), "p2pool", "p2pool").unwrap();
+        let info = client.getblockchaininfo().await.unwrap();
+
+        assert_eq!(
+            info,
+            GetBlockchainInfo {
+                initial_block_download: true,
+            }
+        );
     }
 
     #[tokio::test]

--- a/p2poolv2_node/Cargo.toml
+++ b/p2poolv2_node/Cargo.toml
@@ -47,3 +47,7 @@ p2poolv2_lib = { workspace = true, features = ["test-utils"] }
 mockall.workspace = true
 mockall_double.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
+wiremock = { workspace = true }
+base64 = { workspace = true }
+serde_json = { workspace = true }

--- a/p2poolv2_node/src/bitcoin_node.rs
+++ b/p2poolv2_node/src/bitcoin_node.rs
@@ -1,0 +1,91 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+use bitcoindrpc::{BitcoinRpcConfig, BitcoindRpcClient};
+use std::process::exit;
+use tracing::error;
+
+pub async fn ensure_ibd_done(
+    bitcoinrpc_config: &BitcoinRpcConfig,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let bitcoind = BitcoindRpcClient::new(
+        &bitcoinrpc_config.url,
+        &bitcoinrpc_config.username,
+        &bitcoinrpc_config.password,
+    )?;
+
+    let is_in_ibd = bitcoind.getblockchaininfo().await?.initial_block_download;
+
+    if is_in_ibd {
+        error!("Bitcoin node still in initial block download. Shutting down");
+        exit(1);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_partial_json, header, method, path},
+    };
+
+    async fn setup_mock_bitcoin_rpc() -> (MockServer, BitcoinRpcConfig) {
+        let mock_server = MockServer::start().await;
+        let config = BitcoinRpcConfig {
+            url: mock_server.uri(),
+            username: "testuser".to_string(),
+            password: "testpass".to_string(),
+        };
+        (mock_server, config)
+    }
+
+    fn test_auth_header() -> String {
+        format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD
+                .encode(format!("{}:{}", "testuser", "testpass"))
+        )
+    }
+
+    #[tokio::test]
+    async fn ensure_ibd_done_returns_ok_when_not_in_ibd() {
+        let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", test_auth_header().as_str()))
+            .and(body_partial_json(serde_json::json!({
+                "method": "getblockchaininfo",
+                "params": [],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": {
+                    "initialblockdownload": false,
+                },
+                "error": null,
+                "id": 0
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let result = ensure_ibd_done(&bitcoinrpc_config).await;
+        assert!(result.is_ok(), "ensure_ibd_done returned an error");
+    }
+}

--- a/p2poolv2_node/src/main.rs
+++ b/p2poolv2_node/src/main.rs
@@ -41,6 +41,7 @@ use tracing::{error, info, trace};
 use crate::signal::{ShutdownReason, setup_signal_handler};
 
 mod background_tasks;
+mod bitcoin_node;
 mod signal;
 
 /// Interval in seconds to poll for new block templates since the last zmq event signal
@@ -142,6 +143,11 @@ async fn main() -> ExitCode {
         return ExitCode::FAILURE;
     };
     info!("Latest tip {} at height {}", tip, height);
+
+    if let Err(error) = bitcoin_node::ensure_ibd_done(&config.bitcoinrpc).await {
+        error!("Bitcoin node still in IBD: {error}");
+        return ExitCode::FAILURE;
+    }
 
     background_tasks::start_background_tasks(
         store.clone(),

--- a/p2poolv2_node/src/main.rs
+++ b/p2poolv2_node/src/main.rs
@@ -41,7 +41,7 @@ use tracing::{error, info, trace};
 use crate::signal::{ShutdownReason, setup_signal_handler};
 
 mod background_tasks;
-mod bitcoin_node;
+mod preflight;
 mod signal;
 
 /// Interval in seconds to poll for new block templates since the last zmq event signal
@@ -144,7 +144,7 @@ async fn main() -> ExitCode {
     };
     info!("Latest tip {} at height {}", tip, height);
 
-    if let Err(error) = bitcoin_node::ensure_ibd_done(&config.bitcoinrpc).await {
+    if let Err(error) = preflight::ensure_bitcoin_node_synced(&config.bitcoinrpc).await {
         error!("Bitcoin node still in IBD: {error}");
         return ExitCode::FAILURE;
     }

--- a/p2poolv2_node/src/preflight.rs
+++ b/p2poolv2_node/src/preflight.rs
@@ -15,10 +15,8 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use bitcoindrpc::{BitcoinRpcConfig, BitcoindRpcClient};
-use std::process::exit;
-use tracing::error;
 
-pub async fn ensure_ibd_done(
+pub async fn ensure_bitcoin_node_synced(
     bitcoinrpc_config: &BitcoinRpcConfig,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let bitcoind = BitcoindRpcClient::new(
@@ -30,8 +28,7 @@ pub async fn ensure_ibd_done(
     let is_in_ibd = bitcoind.getblockchaininfo().await?.initial_block_download;
 
     if is_in_ibd {
-        error!("Bitcoin node still in initial block download. Shutting down");
-        exit(1);
+        return Err("Bitcoin node still in initial block download".into());
     }
 
     Ok(())
@@ -65,7 +62,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ensure_ibd_done_returns_ok_when_not_in_ibd() {
+    async fn ensure_bitcoin_node_synced_returns_ok_when_not_in_ibd() {
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
 
         Mock::given(method("POST"))
@@ -85,7 +82,38 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let result = ensure_ibd_done(&bitcoinrpc_config).await;
-        assert!(result.is_ok(), "ensure_ibd_done returned an error");
+        let result = ensure_bitcoin_node_synced(&bitcoinrpc_config).await;
+        assert!(
+            result.is_ok(),
+            "ensure_bitcoin_node_synced returned an error"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_bitcoin_node_synced_returns_err_when_in_ibd() {
+        let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", test_auth_header().as_str()))
+            .and(body_partial_json(serde_json::json!({
+                "method": "getblockchaininfo",
+                "params": [],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": {
+                    "initialblockdownload": true,
+                },
+                "error": null,
+                "id": 0
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let result = ensure_bitcoin_node_synced(&bitcoinrpc_config).await;
+        assert!(
+            result.is_err(),
+            "ensure_bitcoin_node_synced should return error when in IBD"
+        );
     }
 }


### PR DESCRIPTION
We didn't check if IBD was done before using the bitcoin node. This would lead to calling RPC multiple times slowing down IBD and being useless for p2poolv2 to be "online" but not ready.

<img width="1112" height="150" alt="image" src="https://github.com/user-attachments/assets/b6a7585f-b515-4b3b-abf9-daec62d1e3b6" />

Fixes #502