### PR TITLE
Sync fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.10.8] - 2026-05-02
+
+### Changed
+
+- Streamline header organisation by simplifying the candidate chain
+  extension path and removing redundant lookups during header sync.
+
+- Block fetcher now fetches missing blocks in batches instead of
+  one at a time, reducing round-trips during sync.
+
+- Buffer out-of-order blocks in the BlockReceiver actor until their
+  parent and uncle dependencies are ready, then validate ASERT
+  difficulty and commit atomically. Cascading descendants are driven
+  iteratively when ancestors arrive.
+
+- Remove `schedule_dependents` from the organise worker.
+  `drain_pending_blocks` and the normal block pipeline already handle
+  chain advancement, so scheduling dependents caused 40% redundant
+  validation work during sync.
+
+- Refactor `get_candidate_blocks_missing_data` into smaller functions
+  for readability: `missing_data_scan_start` and
+  `scan_heights_for_missing_blocks`.
+
 ### Fixed
 
 - Use confirmed tip (not candidate) in `is_current()` to fix slow
@@ -15,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   suppression. Using the confirmed tip correctly identifies the node
   as not-current during initial sync, allowing bulk header-first sync
   to run in batches of 2000 instead of one block per inv message.
+
+- BlockReceiver now checks uncle block bodies via `share_block_exists`
+  and fetches missing uncles, preventing confirmation stalls when uncle
+  bodies were never retrieved.
 
 ## [v0.10.7] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use confirmed tip (not candidate) in `is_current()` to fix slow
+  initial sync. The candidate tip is always recent during sync (each
+  newly-received header has a fresh timestamp), which prevented inv
+  suppression. Using the confirmed tip correctly identifies the node
+  as not-current during initial sync, allowing bulk header-first sync
+  to run in batches of 2000 instead of one block per inv message.
+
 ## [v0.10.7] - 2026-04-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindrpc"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3252,7 +3252,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2poolv2_api"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_cli"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_config"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_lib"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_node"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_tests"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.7"
+version = "0.10.8"
 edition = "2024"
 authors = ["Kulpreet Singh<kp@opdup.com>"]
 license = "AGPL-3.0-or-later"

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -296,7 +296,6 @@ impl NodeActor {
             monitoring_event_sender,
             notify_tx,
             pplns_window.clone(),
-            validation_tx_for_worker.clone(),
             share_validator.clone(),
         );
         let organise_handle = tokio::spawn(organise_worker.run());

--- a/p2poolv2_lib/src/node/organise_worker.rs
+++ b/p2poolv2_lib/src/node/organise_worker.rs
@@ -31,7 +31,6 @@ use crate::accounting::payout::sharechain_pplns::PplnsWindow;
 #[cfg(not(test))]
 use crate::accounting::payout::sharechain_pplns::PplnsWindow;
 use crate::monitoring_events::{MonitoringEvent, MonitoringEventSender};
-use crate::node::validation_worker::{ValidationEvent, ValidationSender};
 #[cfg(test)]
 #[mockall_double::double]
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
@@ -42,7 +41,6 @@ use crate::shares::validation::ShareValidator;
 use crate::store::dag_store::ShareInfo;
 use crate::store::writer::StoreError;
 use crate::stratum::work::notify::{NotifyCmd, NotifySender};
-use bitcoin::BlockHash;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::{Arc, RwLock};
@@ -104,7 +102,6 @@ pub struct OrganiseWorker {
     monitoring_event_sender: MonitoringEventSender,
     notify_tx: NotifySender,
     pplns_window: Arc<RwLock<PplnsWindow>>,
-    validation_tx: ValidationSender,
     share_validator: Arc<dyn ShareValidator + Send + Sync>,
     /// Blocks whose parent height exceeds the confirmed tip, keyed by the
     /// parent's expected height. One block per height since the confirmed
@@ -120,7 +117,6 @@ impl OrganiseWorker {
         monitoring_event_sender: MonitoringEventSender,
         notify_tx: NotifySender,
         pplns_window: Arc<RwLock<PplnsWindow>>,
-        validation_tx: ValidationSender,
         share_validator: Arc<dyn ShareValidator + Send + Sync>,
     ) -> Self {
         Self {
@@ -129,7 +125,6 @@ impl OrganiseWorker {
             monitoring_event_sender,
             notify_tx,
             pplns_window,
-            validation_tx,
             share_validator,
             pending_blocks: BTreeMap::new(),
         }
@@ -237,12 +232,10 @@ impl OrganiseWorker {
         }
     }
 
-    /// Run post-promotion actions: update PPLNS, schedule dependents,
-    /// optionally send new notify, and emit a monitoring event.
+    /// Run post-promotion actions: update PPLNS, optionally send new
+    /// notify, and emit a monitoring event.
     async fn post_promote(&self, share_block: &ShareBlock, height: u32) {
-        let blockhash = share_block.block_hash();
         self.update_pplns_window();
-        self.schedule_dependents(&blockhash);
 
         match self.chain_store_handle.get_candidate_tip_height() {
             Ok(Some(candidate_tip_height)) if height >= candidate_tip_height => {
@@ -360,48 +353,6 @@ impl OrganiseWorker {
         }
     }
 
-    /// Schedule stored children and nephews for validation.
-    ///
-    /// Called after promote_block and PPLNS update so that dependents
-    /// validate against the freshly updated window.
-    fn schedule_dependents(&self, block_hash: &BlockHash) {
-        let mut dependent_hashes = Vec::with_capacity(4);
-
-        if let Ok(Some(children)) = self.chain_store_handle.get_children_blockhashes(block_hash) {
-            for child_hash in children {
-                if self.chain_store_handle.share_block_exists(&child_hash) {
-                    dependent_hashes.push(child_hash);
-                }
-            }
-        }
-
-        if let Some(nephews) = self.chain_store_handle.get_nephews(block_hash) {
-            for nephew_hash in nephews {
-                if self.chain_store_handle.share_block_exists(&nephew_hash) {
-                    dependent_hashes.push(nephew_hash);
-                }
-            }
-        }
-
-        for dependent_hash in dependent_hashes {
-            info!("Scheduling dependent {dependent_hash} for validation after {block_hash}");
-            match self
-                .validation_tx
-                .try_send(ValidationEvent::ValidateBlock(dependent_hash))
-            {
-                Ok(()) => {}
-                Err(mpsc::error::TrySendError::Full(_)) => {
-                    error!(
-                        "Validation channel full, dropping schedule for dependent {dependent_hash}"
-                    );
-                }
-                Err(mpsc::error::TrySendError::Closed(_)) => {
-                    error!("Validation channel closed, cannot schedule dependent {dependent_hash}");
-                }
-            }
-        }
-    }
-
     /// Send new notify message to workers after share chain is
     /// extended. This is important to keep uncles from being generated.
     ///
@@ -445,7 +396,6 @@ impl OrganiseWorker {
 mod tests {
     use super::*;
     use crate::monitoring_events::create_monitoring_event_channel;
-    use crate::node::validation_worker::create_validation_channel;
     use crate::shares::chain::chain_store_handle::MockChainStoreHandle;
     use crate::shares::validation::MockDefaultShareValidator;
     use crate::store::block_tx_metadata::BlockMetadata;
@@ -473,13 +423,6 @@ mod tests {
         Arc::new(mock_validator)
     }
 
-    /// Add mock expectations for schedule_dependents: no children, no nephews.
-    fn setup_no_dependents(mock: &mut MockChainStoreHandle) {
-        mock.expect_get_children_blockhashes()
-            .returning(|_| Ok(None));
-        mock.expect_get_nephews().returning(|_| None);
-    }
-
     #[tokio::test]
     async fn test_organise_worker_stops_on_channel_close() {
         let (_organise_tx, organise_rx) = create_organise_channel();
@@ -489,14 +432,12 @@ mod tests {
             .return_once(MockChainStoreHandle::new);
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, _notify_rx) = create_test_notify_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
         let worker = OrganiseWorker::new(
             organise_rx,
             mock_chain_handle,
             monitoring_tx,
             notify_tx,
             create_test_pplns_window(),
-            validation_tx,
             stub_share_validator_with_success(),
         );
 
@@ -520,14 +461,12 @@ mod tests {
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, _notify_rx) = create_test_notify_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
         let worker = OrganiseWorker::new(
             organise_rx,
             mock_chain_handle,
             monitoring_tx,
             notify_tx,
             create_test_pplns_window(),
-            validation_tx,
             stub_share_validator_with_success(),
         );
 
@@ -560,14 +499,12 @@ mod tests {
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, _notify_rx) = create_test_notify_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
         let worker = OrganiseWorker::new(
             organise_rx,
             mock_chain_handle,
             monitoring_tx,
             notify_tx,
             create_test_pplns_window(),
-            validation_tx,
             stub_share_validator_with_success(),
         );
 
@@ -604,14 +541,12 @@ mod tests {
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, _notify_rx) = create_test_notify_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
         let worker = OrganiseWorker::new(
             organise_rx,
             mock_chain_handle,
             monitoring_tx,
             notify_tx,
             create_test_pplns_window(),
-            validation_tx,
             share_validator,
         );
 
@@ -641,14 +576,12 @@ mod tests {
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, _notify_rx) = create_test_notify_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
         let worker = OrganiseWorker::new(
             organise_rx,
             mock_chain_handle,
             monitoring_tx,
             notify_tx,
             create_test_pplns_window(),
-            validation_tx,
             stub_share_validator_with_success(),
         );
 
@@ -678,14 +611,12 @@ mod tests {
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, _notify_rx) = create_test_notify_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
         let worker = OrganiseWorker::new(
             rx,
             mock_chain_handle,
             monitoring_tx,
             notify_tx,
             create_test_pplns_window(),
-            validation_tx,
             stub_share_validator_with_success(),
         );
 
@@ -722,18 +653,15 @@ mod tests {
         mock_chain_handle
             .expect_get_uncle_infos()
             .returning(|_| Vec::new());
-        setup_no_dependents(&mut mock_chain_handle);
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, mut notify_rx) = create_test_notify_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
         let worker = OrganiseWorker::new(
             organise_rx,
             mock_chain_handle,
             monitoring_tx,
             notify_tx,
             create_test_pplns_window(),
-            validation_tx,
             stub_share_validator_with_success(),
         );
 
@@ -775,18 +703,15 @@ mod tests {
         mock_chain_handle
             .expect_get_uncle_infos()
             .returning(|_| Vec::new());
-        setup_no_dependents(&mut mock_chain_handle);
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, mut notify_rx) = create_test_notify_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
         let worker = OrganiseWorker::new(
             organise_rx,
             mock_chain_handle,
             monitoring_tx,
             notify_tx,
             create_test_pplns_window(),
-            validation_tx,
             stub_share_validator_with_success(),
         );
 
@@ -801,73 +726,6 @@ mod tests {
 
         // No NewNotify should have been sent
         assert!(notify_rx.try_recv().is_err());
-    }
-
-    #[tokio::test]
-    async fn test_organise_worker_updates_pplns_and_schedules_dependents() {
-        let (organise_tx, organise_rx) = create_organise_channel();
-        let mut mock_chain_handle = MockChainStoreHandle::new();
-        mock_chain_handle
-            .expect_clone()
-            .return_once(MockChainStoreHandle::new);
-        mock_chain_handle
-            .expect_get_block_metadata()
-            .returning(|_| Err(StoreError::NotFound("not found".into())));
-        mock_chain_handle
-            .expect_get_tip_height()
-            .returning(|| Ok(None));
-        mock_chain_handle
-            .expect_promote_block()
-            .returning(|_| Ok(Some(5)));
-        mock_chain_handle
-            .expect_get_candidate_tip_height()
-            .returning(|| Ok(Some(5)));
-        mock_chain_handle
-            .expect_get_uncle_infos()
-            .returning(|_| Vec::new());
-
-        let child_hash = "0000000086704a35f17580d06f76d4c02d2b1f68774800675fb45f0411205bb7"
-            .parse::<BlockHash>()
-            .unwrap();
-        mock_chain_handle
-            .expect_get_children_blockhashes()
-            .returning(move |_| Ok(Some(vec![child_hash])));
-        mock_chain_handle
-            .expect_share_block_exists()
-            .returning(|_| true);
-        mock_chain_handle.expect_get_nephews().returning(|_| None);
-
-        let mut mock_window = PplnsWindow::default();
-        mock_window.expect_update().returning(|_| Ok(true));
-        let pplns_window = Arc::new(RwLock::new(mock_window));
-
-        let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
-        let (notify_tx, _notify_rx) = create_test_notify_channel();
-        let (validation_tx, mut validation_rx) = create_validation_channel();
-        let worker = OrganiseWorker::new(
-            organise_rx,
-            mock_chain_handle,
-            monitoring_tx,
-            notify_tx,
-            pplns_window,
-            validation_tx,
-            stub_share_validator_with_success(),
-        );
-
-        let share = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
-        organise_tx.send(OrganiseEvent::Block(share)).await.unwrap();
-        drop(organise_tx);
-
-        let result = worker.run().await;
-        assert!(result.is_ok());
-
-        // Verify the child was scheduled for validation
-        let event = validation_rx.try_recv();
-        assert!(event.is_ok());
-        let ValidationEvent::ValidateBlock(hash) = event.unwrap();
-        assert_eq!(hash, child_hash);
     }
 
     #[tokio::test]
@@ -893,14 +751,12 @@ mod tests {
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, _notify_rx) = create_test_notify_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
         let worker = OrganiseWorker::new(
             organise_rx,
             mock_chain_handle,
             monitoring_tx,
             notify_tx,
             create_test_pplns_window(),
-            validation_tx,
             stub_share_validator_with_success(),
         );
 
@@ -942,18 +798,15 @@ mod tests {
         mock_chain_handle
             .expect_get_uncle_infos()
             .returning(|_| Vec::new());
-        setup_no_dependents(&mut mock_chain_handle);
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, _notify_rx) = create_test_notify_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
         let worker = OrganiseWorker::new(
             organise_rx,
             mock_chain_handle,
             monitoring_tx,
             notify_tx,
             create_test_pplns_window(),
-            validation_tx,
             stub_share_validator_with_success(),
         );
 
@@ -1015,18 +868,15 @@ mod tests {
         mock_chain_handle
             .expect_get_uncle_infos()
             .returning(|_| Vec::new());
-        setup_no_dependents(&mut mock_chain_handle);
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, _notify_rx) = create_test_notify_channel();
-        let (validation_tx, _validation_rx) = create_validation_channel();
         let worker = OrganiseWorker::new(
             organise_rx,
             mock_chain_handle,
             monitoring_tx,
             notify_tx,
             create_test_pplns_window(),
-            validation_tx,
             stub_share_validator_with_success(),
         );
 

--- a/p2poolv2_lib/src/node/organise_worker.rs
+++ b/p2poolv2_lib/src/node/organise_worker.rs
@@ -43,6 +43,7 @@ use crate::store::dag_store::ShareInfo;
 use crate::store::writer::StoreError;
 use crate::stratum::work::notify::{NotifyCmd, NotifySender};
 use bitcoin::BlockHash;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::{Arc, RwLock};
 use tokio::sync::mpsc;
@@ -50,6 +51,10 @@ use tracing::{debug, error, info};
 
 /// Channel capacity for shares pending organisation.
 const ORGANISE_CHANNEL_CAPACITY: usize = 8192;
+
+/// Maximum number of blocks buffered while waiting for ancestor
+/// confirmation during sync.
+const PENDING_BLOCKS_CAPACITY: usize = 16384;
 
 /// Events for the organise worker.
 pub enum OrganiseEvent {
@@ -101,6 +106,10 @@ pub struct OrganiseWorker {
     pplns_window: Arc<RwLock<PplnsWindow>>,
     validation_tx: ValidationSender,
     share_validator: Arc<dyn ShareValidator + Send + Sync>,
+    /// Blocks whose parent height exceeds the confirmed tip, keyed by the
+    /// parent's expected height. One block per height since the confirmed
+    /// chain has exactly one block per height.
+    pending_blocks: BTreeMap<u32, ShareBlock>,
 }
 
 impl OrganiseWorker {
@@ -122,6 +131,7 @@ impl OrganiseWorker {
             pplns_window,
             validation_tx,
             share_validator,
+            pending_blocks: BTreeMap::new(),
         }
     }
 
@@ -172,36 +182,65 @@ impl OrganiseWorker {
         &mut self,
         share_block: ShareBlock,
     ) -> Result<(), OrganiseError> {
+        if let Some(parent_height) = self.should_buffer_block(&share_block) {
+            self.buffer_block(parent_height, share_block);
+            return Ok(());
+        }
+
+        let promoted_height = self.validate_and_promote_block(&share_block).await?;
+
+        if let Some(height) = promoted_height {
+            self.post_promote(&share_block, height).await;
+            self.drain_pending_blocks().await?;
+        }
+
+        Ok(())
+    }
+
+    /// Validate a block with chain context and promote it to confirmed.
+    ///
+    /// Returns the confirmed height on successful promotion, None when
+    /// validation fails or the block is not promoted, or a fatal error
+    /// when the store channel is closed.
+    async fn validate_and_promote_block(
+        &self,
+        share_block: &ShareBlock,
+    ) -> Result<Option<u32>, OrganiseError> {
         let blockhash = share_block.block_hash();
         debug!("Organising block: {blockhash:?}");
 
         if let Err(validation_error) = self
             .share_validator
-            .validate_with_chain_context(&share_block, &self.chain_store_handle)
+            .validate_with_chain_context(share_block, &self.chain_store_handle)
         {
             error!("Chain-context validation failed for {blockhash}: {validation_error}");
-            return Ok(());
+            return Ok(None);
         }
 
-        let height = match self
+        match self
             .chain_store_handle
             .promote_block(share_block.header.clone())
             .await
         {
-            Ok(Some(height)) => height,
-            Ok(None) => return Ok(()),
+            Ok(Some(height)) => Ok(Some(height)),
+            Ok(None) => Ok(None),
             Err(StoreError::ChannelClosed) => {
                 error!("Store writer channel closed during promote block");
-                return Err(OrganiseError {
+                Err(OrganiseError {
                     message: "Store writer channel closed".to_string(),
-                });
+                })
             }
             Err(error) => {
                 error!("Error promoting block {blockhash}: {error}");
-                return Ok(());
+                Ok(None)
             }
-        };
+        }
+    }
 
+    /// Run post-promotion actions: update PPLNS, schedule dependents,
+    /// optionally send new notify, and emit a monitoring event.
+    async fn post_promote(&self, share_block: &ShareBlock, height: u32) {
+        let blockhash = share_block.block_hash();
         self.update_pplns_window();
         self.schedule_dependents(&blockhash);
 
@@ -213,8 +252,97 @@ impl OrganiseWorker {
             _ => debug!("No candidate tip found"),
         }
 
-        self.emit_share_monitoring_event(&share_block, height);
-        Ok(())
+        self.emit_share_monitoring_event(share_block, height);
+    }
+
+    /// Check whether a block's parent height exceeds the confirmed tip.
+    ///
+    /// Returns `Some(parent_height)` when the block should be buffered
+    /// because the confirmed chain has not yet reached the parent's
+    /// height. Returns `None` when the block can proceed to validation
+    /// immediately.
+    fn should_buffer_block(&self, share_block: &ShareBlock) -> Option<u32> {
+        let parent_hash = share_block.header.prev_share_blockhash;
+        let parent_metadata = match self.chain_store_handle.get_block_metadata(&parent_hash) {
+            Ok(metadata) => metadata,
+            Err(_) => return None,
+        };
+        let parent_height = parent_metadata.expected_height?;
+        let confirmed_tip = match self.chain_store_handle.get_tip_height() {
+            Ok(Some(tip)) => tip,
+            Ok(None) => 0,
+            Err(_) => return None,
+        };
+        if parent_height > confirmed_tip {
+            return Some(parent_height);
+        }
+        None
+    }
+
+    /// Insert a block into the pending buffer, keyed by its parent height.
+    ///
+    /// Drops the block with an error log if the buffer is at capacity.
+    fn buffer_block(&mut self, parent_height: u32, share_block: ShareBlock) {
+        if self.pending_blocks.len() >= PENDING_BLOCKS_CAPACITY {
+            error!(
+                "Pending block buffer full ({PENDING_BLOCKS_CAPACITY}), dropping block {}",
+                share_block.block_hash()
+            );
+            return;
+        }
+        info!(
+            "Buffering block {} at parent height {parent_height} (confirmed tip not yet reached)",
+            share_block.block_hash()
+        );
+        self.pending_blocks.insert(parent_height, share_block);
+    }
+
+    /// Process buffered blocks whose parent height is now at or below the
+    /// confirmed tip.
+    ///
+    /// After each successful promotion the confirmed tip advances, so
+    /// additional buffered blocks may become processable. Uses an
+    /// iterative loop that terminates when no more buffered blocks are
+    /// ready or no promotions occurred in the last pass.
+    async fn drain_pending_blocks(&mut self) -> Result<(), OrganiseError> {
+        loop {
+            let confirmed_tip = match self.chain_store_handle.get_tip_height() {
+                Ok(Some(tip)) => tip,
+                Ok(None) => return Ok(()),
+                Err(error) => {
+                    error!("Failed to get confirmed tip during drain: {error}");
+                    return Ok(());
+                }
+            };
+
+            // split_off returns entries with key >= confirmed_tip + 1,
+            // leaving entries with key <= confirmed_tip in self.pending_blocks.
+            let not_ready = self.pending_blocks.split_off(&(confirmed_tip + 1));
+            // Move not_ready into pending_blocks and return the current pending_blocks as processable
+            let processable = std::mem::replace(&mut self.pending_blocks, not_ready);
+
+            if processable.is_empty() {
+                return Ok(());
+            }
+
+            info!(
+                "Draining {} buffered blocks with parent height <= confirmed tip {confirmed_tip}",
+                processable.len()
+            );
+
+            let mut promoted_any = false;
+            for (_parent_height, share_block) in processable {
+                let promoted_height = self.validate_and_promote_block(&share_block).await?;
+                if let Some(height) = promoted_height {
+                    self.post_promote(&share_block, height).await;
+                    promoted_any = true;
+                }
+            }
+
+            if !promoted_any {
+                return Ok(());
+            }
+        }
     }
 
     /// Update the shared PplnsWindow cache after a block is promoted.
@@ -320,6 +448,7 @@ mod tests {
     use crate::node::validation_worker::create_validation_channel;
     use crate::shares::chain::chain_store_handle::MockChainStoreHandle;
     use crate::shares::validation::MockDefaultShareValidator;
+    use crate::store::block_tx_metadata::BlockMetadata;
     use crate::stratum::work::notify::{NotifyCmd, NotifyReceiver};
 
     /// Create a notify channel for tests, returning the sender and receiver.
@@ -423,6 +552,9 @@ mod tests {
             .expect_clone()
             .return_once(MockChainStoreHandle::new);
         mock_chain_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("not found".into())));
+        mock_chain_handle
             .expect_promote_block()
             .returning(|_| Ok(None));
 
@@ -458,6 +590,9 @@ mod tests {
         mock_chain_handle
             .expect_clone()
             .return_once(MockChainStoreHandle::new);
+        mock_chain_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("not found".into())));
         // promote_block must NOT be called when chain-context validation fails.
         mock_chain_handle.expect_promote_block().never();
 
@@ -498,6 +633,9 @@ mod tests {
             .expect_clone()
             .return_once(MockChainStoreHandle::new);
         mock_chain_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("not found".into())));
+        mock_chain_handle
             .expect_promote_block()
             .returning(|_| Err(StoreError::ChannelClosed));
 
@@ -531,6 +669,9 @@ mod tests {
         mock_chain_handle
             .expect_clone()
             .return_once(MockChainStoreHandle::new);
+        mock_chain_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("not found".into())));
         mock_chain_handle
             .expect_promote_block()
             .returning(|_| Err(StoreError::Database("test error".to_string())));
@@ -566,6 +707,12 @@ mod tests {
         mock_chain_handle
             .expect_clone()
             .return_once(MockChainStoreHandle::new);
+        mock_chain_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("not found".into())));
+        mock_chain_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(None));
         mock_chain_handle
             .expect_promote_block()
             .returning(|_| Ok(Some(5)));
@@ -612,6 +759,12 @@ mod tests {
         mock_chain_handle
             .expect_clone()
             .return_once(MockChainStoreHandle::new);
+        mock_chain_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("not found".into())));
+        mock_chain_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(None));
         // Confirmed height 3 is below candidate tip 5
         mock_chain_handle
             .expect_promote_block()
@@ -657,6 +810,12 @@ mod tests {
         mock_chain_handle
             .expect_clone()
             .return_once(MockChainStoreHandle::new);
+        mock_chain_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("not found".into())));
+        mock_chain_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(None));
         mock_chain_handle
             .expect_promote_block()
             .returning(|_| Ok(Some(5)));
@@ -709,5 +868,191 @@ mod tests {
         assert!(event.is_ok());
         let ValidationEvent::ValidateBlock(hash) = event.unwrap();
         assert_eq!(hash, child_hash);
+    }
+
+    #[tokio::test]
+    async fn test_organise_worker_buffers_block_when_parent_above_confirmed_tip() {
+        let (organise_tx, organise_rx) = create_organise_channel();
+        let mut mock_chain_handle = MockChainStoreHandle::new();
+        mock_chain_handle
+            .expect_clone()
+            .return_once(MockChainStoreHandle::new);
+        mock_chain_handle
+            .expect_get_block_metadata()
+            .returning(|_| {
+                Ok(BlockMetadata {
+                    expected_height: Some(10),
+                    chain_work: bitcoin::Work::from_be_bytes([0u8; 32]),
+                    status: crate::store::block_tx_metadata::Status::Candidate,
+                })
+            });
+        mock_chain_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(5)));
+        mock_chain_handle.expect_promote_block().never();
+
+        let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
+        let (notify_tx, _notify_rx) = create_test_notify_channel();
+        let (validation_tx, _validation_rx) = create_validation_channel();
+        let worker = OrganiseWorker::new(
+            organise_rx,
+            mock_chain_handle,
+            monitoring_tx,
+            notify_tx,
+            create_test_pplns_window(),
+            validation_tx,
+            stub_share_validator_with_success(),
+        );
+
+        let share = crate::test_utils::TestShareBlockBuilder::new()
+            .nonce(0xe9695791)
+            .build();
+        organise_tx.send(OrganiseEvent::Block(share)).await.unwrap();
+        drop(organise_tx);
+
+        let result = worker.run().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_organise_worker_does_not_buffer_when_parent_at_confirmed_tip() {
+        let (organise_tx, organise_rx) = create_organise_channel();
+        let mut mock_chain_handle = MockChainStoreHandle::new();
+        mock_chain_handle
+            .expect_clone()
+            .return_once(MockChainStoreHandle::new);
+        mock_chain_handle
+            .expect_get_block_metadata()
+            .returning(|_| {
+                Ok(BlockMetadata {
+                    expected_height: Some(5),
+                    chain_work: bitcoin::Work::from_be_bytes([0u8; 32]),
+                    status: crate::store::block_tx_metadata::Status::Confirmed,
+                })
+            });
+        mock_chain_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(5)));
+        mock_chain_handle
+            .expect_promote_block()
+            .returning(|_| Ok(Some(6)));
+        mock_chain_handle
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(6)));
+        mock_chain_handle
+            .expect_get_uncle_infos()
+            .returning(|_| Vec::new());
+        setup_no_dependents(&mut mock_chain_handle);
+
+        let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
+        let (notify_tx, _notify_rx) = create_test_notify_channel();
+        let (validation_tx, _validation_rx) = create_validation_channel();
+        let worker = OrganiseWorker::new(
+            organise_rx,
+            mock_chain_handle,
+            monitoring_tx,
+            notify_tx,
+            create_test_pplns_window(),
+            validation_tx,
+            stub_share_validator_with_success(),
+        );
+
+        let share = crate::test_utils::TestShareBlockBuilder::new()
+            .nonce(0xe9695791)
+            .build();
+        organise_tx.send(OrganiseEvent::Block(share)).await.unwrap();
+        drop(organise_tx);
+
+        let result = worker.run().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_organise_worker_drains_buffered_block_after_promotion() {
+        let (organise_tx, organise_rx) = create_organise_channel();
+        let mut mock_chain_handle = MockChainStoreHandle::new();
+        mock_chain_handle
+            .expect_clone()
+            .return_once(MockChainStoreHandle::new);
+
+        // First call: block A has parent at height 100, tip is 5 -> buffer.
+        // Second call: block B has parent at height 5, tip is 5 -> proceed.
+        // Third call (during drain): block A re-checked, parent at 100 still.
+        let metadata_call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let metadata_counter = metadata_call_count.clone();
+        mock_chain_handle
+            .expect_get_block_metadata()
+            .returning(move |_| {
+                let count = metadata_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let height = if count == 0 { 100 } else { 5 };
+                Ok(BlockMetadata {
+                    expected_height: Some(height),
+                    chain_work: bitcoin::Work::from_be_bytes([0u8; 32]),
+                    status: crate::store::block_tx_metadata::Status::Confirmed,
+                })
+            });
+
+        // First call (should_buffer for block A): tip is 5 -> buffer.
+        // Second call (should_buffer for block B): tip is 5 -> proceed.
+        // Third call (drain after B promotes): tip is 100 -> drain A.
+        // Fourth call (drain loop re-check): tip is 100 -> empty, stop.
+        let tip_call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let tip_counter = tip_call_count.clone();
+        mock_chain_handle
+            .expect_get_tip_height()
+            .returning(move || {
+                let count = tip_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let tip = if count < 2 { 5 } else { 100 };
+                Ok(Some(tip))
+            });
+
+        mock_chain_handle
+            .expect_promote_block()
+            .returning(|_| Ok(Some(100)));
+        mock_chain_handle
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(100)));
+        mock_chain_handle
+            .expect_get_uncle_infos()
+            .returning(|_| Vec::new());
+        setup_no_dependents(&mut mock_chain_handle);
+
+        let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
+        let (notify_tx, _notify_rx) = create_test_notify_channel();
+        let (validation_tx, _validation_rx) = create_validation_channel();
+        let worker = OrganiseWorker::new(
+            organise_rx,
+            mock_chain_handle,
+            monitoring_tx,
+            notify_tx,
+            create_test_pplns_window(),
+            validation_tx,
+            stub_share_validator_with_success(),
+        );
+
+        // Block A: parent height 100, will be buffered
+        let share_a = crate::test_utils::TestShareBlockBuilder::new()
+            .nonce(0xe9695791)
+            .build();
+        organise_tx
+            .send(OrganiseEvent::Block(share_a))
+            .await
+            .unwrap();
+
+        // Block B: parent height 5, will proceed and promote
+        let share_b = crate::test_utils::TestShareBlockBuilder::new()
+            .nonce(0xe9695792)
+            .build();
+        organise_tx
+            .send(OrganiseEvent::Block(share_b))
+            .await
+            .unwrap();
+        drop(organise_tx);
+
+        let result = worker.run().await;
+        assert!(result.is_ok());
+
+        // promote_block was called at least twice: once for B, once for
+        // drained A. The mock allows unlimited calls.
     }
 }

--- a/p2poolv2_lib/src/node/organise_worker.rs
+++ b/p2poolv2_lib/src/node/organise_worker.rs
@@ -21,9 +21,7 @@
 //! tokio task, decoupled from share producers (emission worker, peer
 //! handler, future validation worker).
 //!
-//! After promoting a block to confirmed, updates the PplnsWindow cache
-//! and schedules stored children and nephews for validation so the
-//! chain advances with a fresh PPLNS state.
+//! After promoting a block to confirmed, updates the PplnsWindow cache.
 
 #[cfg(test)]
 #[mockall_double::double]
@@ -104,9 +102,9 @@ pub struct OrganiseWorker {
     pplns_window: Arc<RwLock<PplnsWindow>>,
     share_validator: Arc<dyn ShareValidator + Send + Sync>,
     /// Blocks whose parent height exceeds the confirmed tip, keyed by the
-    /// parent's expected height. One block per height since the confirmed
-    /// chain has exactly one block per height.
-    pending_blocks: BTreeMap<u32, ShareBlock>,
+    /// parent's expected height. Multiple blocks may share the same parent
+    /// height during forks or rapid sync.
+    pending_blocks: BTreeMap<u32, Vec<ShareBlock>>,
 }
 
 impl OrganiseWorker {
@@ -275,8 +273,10 @@ impl OrganiseWorker {
     /// Insert a block into the pending buffer, keyed by its parent height.
     ///
     /// Drops the block with an error log if the buffer is at capacity.
+    /// The capacity check counts total blocks across all heights.
     fn buffer_block(&mut self, parent_height: u32, share_block: ShareBlock) {
-        if self.pending_blocks.len() >= PENDING_BLOCKS_CAPACITY {
+        let total_blocks: usize = self.pending_blocks.values().map(|v| v.len()).sum();
+        if total_blocks >= PENDING_BLOCKS_CAPACITY {
             error!(
                 "Pending block buffer full ({PENDING_BLOCKS_CAPACITY}), dropping block {}",
                 share_block.block_hash()
@@ -287,7 +287,10 @@ impl OrganiseWorker {
             "Buffering block {} at parent height {parent_height} (confirmed tip not yet reached)",
             share_block.block_hash()
         );
-        self.pending_blocks.insert(parent_height, share_block);
+        self.pending_blocks
+            .entry(parent_height)
+            .or_insert_with(|| Vec::with_capacity(2))
+            .push(share_block);
     }
 
     /// Process buffered blocks whose parent height is now at or below the
@@ -318,17 +321,19 @@ impl OrganiseWorker {
                 return Ok(());
             }
 
+            let total_processable: usize = processable.values().map(|v| v.len()).sum();
             info!(
-                "Draining {} buffered blocks with parent height <= confirmed tip {confirmed_tip}",
-                processable.len()
+                "Draining {total_processable} buffered blocks with parent height <= confirmed tip {confirmed_tip}",
             );
 
             let mut promoted_any = false;
-            for (_parent_height, share_block) in processable {
-                let promoted_height = self.validate_and_promote_block(&share_block).await?;
-                if let Some(height) = promoted_height {
-                    self.post_promote(&share_block, height).await;
-                    promoted_any = true;
+            for (_parent_height, blocks) in processable {
+                for share_block in blocks {
+                    let promoted_height = self.validate_and_promote_block(&share_block).await?;
+                    if let Some(height) = promoted_height {
+                        self.post_promote(&share_block, height).await;
+                        promoted_any = true;
+                    }
                 }
             }
 
@@ -904,5 +909,116 @@ mod tests {
 
         // promote_block was called at least twice: once for B, once for
         // drained A. The mock allows unlimited calls.
+    }
+
+    #[tokio::test]
+    async fn test_buffer_block_overwrites_when_two_blocks_share_parent_height() {
+        let (organise_tx, organise_rx) = create_organise_channel();
+        let mut mock_chain_handle = MockChainStoreHandle::new();
+        mock_chain_handle
+            .expect_clone()
+            .return_once(MockChainStoreHandle::new);
+
+        // Blocks A and B both have parents at height 10; block C has no
+        // metadata so it skips buffering and goes straight to promote.
+        let metadata_call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let metadata_counter = metadata_call_count.clone();
+        mock_chain_handle
+            .expect_get_block_metadata()
+            .returning(move |_| {
+                let count = metadata_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if count < 2 {
+                    Ok(BlockMetadata {
+                        expected_height: Some(10),
+                        chain_work: bitcoin::Work::from_be_bytes([0u8; 32]),
+                        status: crate::store::block_tx_metadata::Status::Candidate,
+                    })
+                } else {
+                    Err(StoreError::NotFound("not found".into()))
+                }
+            });
+
+        // First two calls (should_buffer for A and B): tip is 5 -> buffer.
+        // Remaining calls (drain after C promotes): tip is 10 -> drain.
+        let tip_call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let tip_counter = tip_call_count.clone();
+        mock_chain_handle
+            .expect_get_tip_height()
+            .returning(move || {
+                let count = tip_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let tip = if count < 2 { 5 } else { 10 };
+                Ok(Some(tip))
+            });
+
+        // Count how many times promote_block is called.
+        let promote_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let promote_counter = promote_count.clone();
+        mock_chain_handle
+            .expect_promote_block()
+            .returning(move |_| {
+                promote_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(Some(10))
+            });
+        mock_chain_handle
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(10)));
+        mock_chain_handle
+            .expect_get_uncle_infos()
+            .returning(|_| Vec::new());
+
+        let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
+        let (notify_tx, _notify_rx) = create_test_notify_channel();
+        let worker = OrganiseWorker::new(
+            organise_rx,
+            mock_chain_handle,
+            monitoring_tx,
+            notify_tx,
+            create_test_pplns_window(),
+            stub_share_validator_with_success(),
+        );
+
+        // Block A: parent height 10, tip is 5 -> buffered at key 10
+        let share_a = crate::test_utils::TestShareBlockBuilder::new()
+            .nonce(0xe9695791)
+            .build();
+        organise_tx
+            .send(OrganiseEvent::Block(share_a))
+            .await
+            .unwrap();
+
+        // Block B: different nonce (different hash), same parent height 10
+        // -> should also be buffered, but currently overwrites A
+        let share_b = crate::test_utils::TestShareBlockBuilder::new()
+            .nonce(0xe9695792)
+            .build();
+        organise_tx
+            .send(OrganiseEvent::Block(share_b))
+            .await
+            .unwrap();
+
+        // Block C: metadata returns Err -> skips buffer, goes to promote,
+        // which triggers drain of the buffered blocks
+        let share_c = crate::test_utils::TestShareBlockBuilder::new()
+            .nonce(0xe9695793)
+            .build();
+        organise_tx
+            .send(OrganiseEvent::Block(share_c))
+            .await
+            .unwrap();
+        drop(organise_tx);
+
+        let result = worker.run().await;
+        assert!(result.is_ok());
+
+        // promote_block should be called 3 times: once for C (direct),
+        // once for A (drained), once for B (drained).
+        // With the current BTreeMap<u32, ShareBlock>, block A is silently
+        // overwritten by B, so promote is only called twice.
+        let total_promotes = promote_count.load(std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(
+            total_promotes, 3,
+            "Expected 3 promotions (C + drained A + drained B), got {total_promotes}. \
+             Second block buffered at same parent height likely overwrote the first."
+        );
     }
 }

--- a/p2poolv2_lib/src/node/organise_worker.rs
+++ b/p2poolv2_lib/src/node/organise_worker.rs
@@ -141,7 +141,7 @@ impl OrganiseWorker {
                     let blockhash = header.block_hash();
                     debug!("Organising header: {blockhash:?}");
                     match self.chain_store_handle.organise_header(header).await {
-                        Ok(Some((_height, _valid_blocks))) => {}
+                        Ok(Some(_height)) => {}
                         Ok(None) => {}
                         Err(StoreError::ChannelClosed) => {
                             error!("Store writer channel closed during organise header");

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
@@ -137,10 +137,8 @@ impl BlockReceiver {
                 .push(block_hash);
         }
 
-        self.pending.insert(
-            block_hash,
-            PendingBlock { share_block },
-        );
+        self.pending
+            .insert(block_hash, PendingBlock { share_block });
     }
 
     /// Remove a block from the pending set and clean up its entries

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
@@ -191,10 +191,19 @@ impl BlockReceiver {
         let mut not_ready: Vec<BlockHash> = Vec::with_capacity(1 + header.uncles.len());
         let parent_hash = header.prev_share_blockhash;
         if parent_hash != BlockHash::all_zeros() && !self.ancestor_ready(&parent_hash) {
+            debug!(
+                "Parent {parent_hash} not ready for block {}. Metadata: {:?}",
+                share_block.block_hash(),
+                self.chain_store_handle.get_block_metadata(&parent_hash)
+            );
             not_ready.push(parent_hash);
         }
         for uncle_hash in &header.uncles {
             if !self.chain_store_handle.share_block_exists(uncle_hash) {
+                debug!(
+                    "Uncle {uncle_hash} block body missing for block {}",
+                    share_block.block_hash()
+                );
                 not_ready.push(*uncle_hash);
             }
         }
@@ -522,8 +531,6 @@ mod tests {
         assert!(!receiver.descendants.contains_key(&parent_hash));
         assert_eq!(receiver.pending_count(), 0);
     }
-
-
 
     #[test]
     fn test_genesis_parent_not_tracked_in_descendants_key() {

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
@@ -29,21 +29,11 @@ use bitcoin::hashes::Hash;
 use std::collections::{HashMap, VecDeque};
 use std::error::Error;
 use std::sync::Arc;
-use std::time::Instant;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, info, warn};
 
-/// Maximum number of blocks held in the pending set.
-const PENDING_CAPACITY: usize = 2000;
-
 /// Channel capacity for block receiver events.
 const BLOCK_RECEIVER_CHANNEL_CAPACITY: usize = 8192;
-
-/// Interval for evicting stale pending blocks.
-const EVICTION_TICK_SECONDS: u64 = 60;
-
-/// Maximum age of a pending block before eviction.
-const STALE_THRESHOLD_SECONDS: u64 = 300;
 
 /// Events sent to the BlockReceiver actor.
 pub enum BlockReceiverEvent {
@@ -67,7 +57,6 @@ pub fn create_block_receiver_channel() -> (BlockReceiverHandle, BlockReceiverRec
 /// HeaderValid in the store.
 struct PendingBlock {
     share_block: ShareBlock,
-    received_at: Instant,
 }
 
 /// Buffers incoming ShareBlocks until their direct parent and uncles are
@@ -113,8 +102,8 @@ impl BlockReceiver {
     ) -> Self {
         Self {
             event_rx,
-            pending: HashMap::with_capacity(PENDING_CAPACITY),
-            descendants: HashMap::with_capacity(PENDING_CAPACITY),
+            pending: HashMap::new(),
+            descendants: HashMap::new(),
             share_validator,
             chain_store_handle,
             block_fetcher_handle,
@@ -127,14 +116,11 @@ impl BlockReceiver {
         self.pending.len()
     }
 
-    /// Add a block to the pending set. Evicts the oldest entry if at
-    /// capacity. Updates the descendants index for parent and uncles.
+    /// Add a block to the pending set.
+    /// Updates the descendants index for parent and uncles.
     fn add_to_pending(&mut self, block_hash: BlockHash, share_block: ShareBlock) {
         if self.pending.contains_key(&block_hash) {
             return;
-        }
-        if self.pending.len() >= PENDING_CAPACITY {
-            self.evict_oldest();
         }
 
         let parent_hash = share_block.header.prev_share_blockhash;
@@ -153,10 +139,7 @@ impl BlockReceiver {
 
         self.pending.insert(
             block_hash,
-            PendingBlock {
-                share_block,
-                received_at: Instant::now(),
-            },
+            PendingBlock { share_block },
         );
     }
 
@@ -184,37 +167,6 @@ impl BlockReceiver {
         }
 
         Some(pending_block.share_block)
-    }
-
-    /// Evict the oldest pending block by received_at timestamp.
-    fn evict_oldest(&mut self) {
-        let oldest_hash = self
-            .pending
-            .iter()
-            .min_by_key(|(_, pending_block)| pending_block.received_at)
-            .map(|(hash, _)| *hash);
-
-        if let Some(hash) = oldest_hash {
-            debug!("Evicting oldest pending block {hash} to maintain capacity");
-            self.remove_from_pending(&hash);
-        }
-    }
-
-    /// Evict pending blocks older than the stale threshold.
-    fn evict_stale_pending(&mut self) {
-        let threshold = Instant::now() - std::time::Duration::from_secs(STALE_THRESHOLD_SECONDS);
-
-        let stale_hashes: Vec<BlockHash> = self
-            .pending
-            .iter()
-            .filter(|(_, pending_block)| pending_block.received_at < threshold)
-            .map(|(hash, _)| *hash)
-            .collect();
-
-        for hash in stale_hashes {
-            info!("Evicting stale pending block {hash}");
-            self.remove_from_pending(&hash);
-        }
     }
 
     /// Look up parent (time, expected_height) for ASERT.
@@ -433,28 +385,18 @@ impl BlockReceiver {
     /// Processes incoming share blocks and periodically evicts stale
     /// pending blocks. Runs until the event channel is closed.
     pub async fn run(mut self) {
-        let mut eviction_interval =
-            tokio::time::interval(std::time::Duration::from_secs(EVICTION_TICK_SECONDS));
-
         loop {
-            tokio::select! {
-                event = self.event_rx.recv() => {
-                    match event {
-                        Some(BlockReceiverEvent::ShareBlockReceived {
-                            share_block,
-                            result_tx,
-                        }) => {
-                            let result = self.process_share_block(share_block).await;
-                            let _ = result_tx.send(result);
-                        }
-                        None => {
-                            info!("BlockReceiver channel closed, shutting down");
-                            return;
-                        }
-                    }
+            match self.event_rx.recv().await {
+                Some(BlockReceiverEvent::ShareBlockReceived {
+                    share_block,
+                    result_tx,
+                }) => {
+                    let result = self.process_share_block(share_block).await;
+                    let _ = result_tx.send(result);
                 }
-                _ = eviction_interval.tick() => {
-                    self.evict_stale_pending();
+                None => {
+                    info!("BlockReceiver channel closed, shutting down");
+                    return;
                 }
             }
         }
@@ -583,35 +525,7 @@ mod tests {
         assert_eq!(receiver.pending_count(), 0);
     }
 
-    #[test]
-    fn test_evict_oldest_at_capacity() {
-        let (_, event_rx) = create_block_receiver_channel();
-        let (block_fetcher_handle, _) = block_fetcher::create_block_fetcher_channel();
-        let (validation_tx, _) = validation_worker::create_validation_channel();
-        let mut receiver = BlockReceiver::new(
-            event_rx,
-            Arc::new(MockDefaultShareValidator::default()),
-            ChainStoreHandle::default(),
-            block_fetcher_handle,
-            validation_tx,
-        );
 
-        for nonce in 0..PENDING_CAPACITY {
-            let share_block = TestShareBlockBuilder::new().nonce(nonce as u32).build();
-            let block_hash = share_block.block_hash();
-            receiver.add_to_pending(block_hash, share_block);
-        }
-        assert_eq!(receiver.pending_count(), PENDING_CAPACITY);
-
-        let extra_block = TestShareBlockBuilder::new()
-            .nonce(PENDING_CAPACITY as u32)
-            .build();
-        let extra_hash = extra_block.block_hash();
-        receiver.add_to_pending(extra_hash, extra_block);
-
-        assert_eq!(receiver.pending_count(), PENDING_CAPACITY);
-        assert!(receiver.pending.contains_key(&extra_hash));
-    }
 
     #[test]
     fn test_genesis_parent_not_tracked_in_descendants_key() {

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
@@ -389,8 +389,8 @@ impl BlockReceiver {
 
     /// Run the BlockReceiver event loop.
     ///
-    /// Processes incoming share blocks and periodically evicts stale
-    /// pending blocks. Runs until the event channel is closed.
+    /// Processes incoming share blocks. Runs until the event channel
+    /// is closed.
     pub async fn run(mut self) {
         loop {
             match self.event_rx.recv().await {

--- a/p2poolv2_lib/src/node/request_response_handler/block_fetcher/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/block_fetcher/mod.rs
@@ -51,6 +51,12 @@ const TICK_INTERVAL: Duration = Duration::from_secs(5);
 /// Channel capacity for block fetcher events.
 const BLOCK_FETCHER_CHANNEL_CAPACITY: usize = 8192;
 
+/// Number of blockhashes moved from the backlog into the pending
+/// queue at a time. The next batch is loaded only after the current
+/// batch is fully dispatched and all responses have been received,
+/// bounding memory in the downstream block receiver.
+const FETCH_BATCH_SIZE: usize = 1000;
+
 /// Events sent to the block fetcher from p2p message handlers.
 pub enum BlockFetcherEvent {
     /// Blocks identified by handle_share_headers
@@ -130,7 +136,12 @@ pub struct BlockFetcher {
     /// Blockhashes that have been requested -- inflight
     in_flight: HashMap<BlockHash, InFlightRequest>,
     /// Blockhashes waiting to be requested (not yet in-flight).
+    /// Holds at most one batch of FETCH_BATCH_SIZE entries.
     pending: VecDeque<BlockHash>,
+    /// Blockhashes that have not yet been moved into `pending`.
+    /// Batches of FETCH_BATCH_SIZE are promoted when the current
+    /// batch is fully processed (pending and in_flight both empty).
+    backlog: VecDeque<BlockHash>,
     /// Peer selection with round-robin distribution and capacity tracking.
     peer_selector: PeerSelector,
 }
@@ -146,6 +157,7 @@ impl BlockFetcher {
             swarm_tx,
             in_flight: HashMap::with_capacity(INITIAL_IN_FLIGHT_CAPACITY),
             pending: VecDeque::new(),
+            backlog: VecDeque::new(),
             peer_selector: PeerSelector::new(),
         }
     }
@@ -165,6 +177,7 @@ impl BlockFetcher {
                         Some(BlockFetcherEvent::BlockRequestCompleted(blockhash)) => {
                             self.handle_block_request_completed(blockhash);
                             self.dispatch_pending_requests().await;
+                            self.refill_pending_from_backlog().await;
                         }
                         Some(BlockFetcherEvent::PeersUpdated(peers)) => {
                             debug!("Peers list updated in block fetcher");
@@ -179,13 +192,21 @@ impl BlockFetcher {
                 _ = tick_interval.tick() => {
                     self.retry_timed_out_requests().await;
                     self.dispatch_pending_requests().await;
+                    self.refill_pending_from_backlog().await;
                 }
             }
         }
     }
 
-    /// Handle a FetchBlocks event by adding blockhashes to the pending queue
-    /// and immediately dispatching requests to peers to trigget getblock.
+    /// Check whether a blockhash is already tracked in any queue.
+    fn is_known(&self, blockhash: &BlockHash) -> bool {
+        self.in_flight.contains_key(blockhash)
+            || self.pending.contains(blockhash)
+            || self.backlog.contains(blockhash)
+    }
+
+    /// Handle a FetchBlocks event by adding new blockhashes to the
+    /// backlog and refilling pending if the current batch is done.
     async fn handle_fetch_blocks(&mut self, blockhashes: Vec<BlockHash>, peer_id: PeerId) {
         info!(
             "Block fetcher received {} blockhashes to fetch from peer {}",
@@ -195,27 +216,46 @@ impl BlockFetcher {
 
         self.peer_selector.add_peer(peer_id);
 
-        // Add blockhashes that are not already in-flight or pending
         for blockhash in blockhashes {
-            if !self.in_flight.contains_key(&blockhash) && !self.pending.contains(&blockhash) {
-                self.pending.push_back(blockhash);
+            if !self.is_known(&blockhash) {
+                self.backlog.push_back(blockhash);
             }
         }
 
-        self.dispatch_pending_requests().await;
+        self.refill_pending_from_backlog().await;
     }
 
     /// Remove a blockhash from in-flight tracking when a block request completes.
-    /// Called both when the block is received and when the peer responds NotFound.
-    /// The caller should dispatch pending requests afterwards since capacity
-    /// may have been freed.
+    /// Also removes from pending and backlog so the block is not re-requested.
     fn handle_block_request_completed(&mut self, blockhash: BlockHash) {
         if let Some(request) = self.in_flight.remove(&blockhash) {
             debug!("Block request completed, removed from in-flight: {blockhash}");
             self.peer_selector.record_completion(request.peer_id);
         }
-        // Also remove from pending in case it was queued but not yet sent
         self.pending.retain(|hash| *hash != blockhash);
+        self.backlog.retain(|hash| *hash != blockhash);
+    }
+
+    /// Move the next batch of blockhashes from the backlog into
+    /// pending when the current batch is fully processed.
+    async fn refill_pending_from_backlog(&mut self) {
+        if !self.pending.is_empty() || !self.in_flight.is_empty() {
+            return;
+        }
+        if self.backlog.is_empty() {
+            return;
+        }
+
+        let batch_size = FETCH_BATCH_SIZE.min(self.backlog.len());
+        self.pending.extend(self.backlog.drain(..batch_size));
+
+        info!(
+            "Loaded batch of {} blocks from backlog ({} remaining)",
+            self.pending.len(),
+            self.backlog.len()
+        );
+
+        self.dispatch_pending_requests().await;
     }
 
     /// Send GetData::Block requests for pending blockhashes, respecting
@@ -292,9 +332,9 @@ impl BlockFetcher {
                 old_request.peer_id
             );
             self.peer_selector.record_completion(old_request.peer_id);
-            // Re-add to pending for retry from a different peer
+            // Re-add to front of pending for retry ahead of other pending
             if !self.pending.contains(&blockhash) {
-                self.pending.push_back(blockhash);
+                self.pending.push_front(blockhash);
             }
         }
     }
@@ -514,6 +554,76 @@ mod tests {
             other => panic!("Expected GetData::Block, got: {other:?}"),
         }
 
+        let result = fetcher_handle.await.unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_block_fetcher_batches_from_backlog() {
+        let (block_fetcher_tx, block_fetcher_rx) = create_block_fetcher_channel();
+        let (swarm_tx, mut swarm_rx) = mpsc::channel(2048);
+        let fetcher = BlockFetcher::new(block_fetcher_rx, swarm_tx);
+
+        let peer_id = PeerId::random();
+        let total_blocks = FETCH_BATCH_SIZE + 500;
+        let blockhashes: Vec<BlockHash> = (0..total_blocks).map(|_| random_blockhash()).collect();
+
+        block_fetcher_tx
+            .send(BlockFetcherEvent::FetchBlocks {
+                blockhashes: blockhashes.clone(),
+                peer_id,
+            })
+            .await
+            .unwrap();
+
+        let fetcher_handle = tokio::spawn(fetcher.run());
+
+        // Yield to let the fetcher process the FetchBlocks event
+        tokio::task::yield_now().await;
+
+        // With 1 peer and MAX_IN_FLIGHT_PER_PEER=16, only 16 blocks
+        // are dispatched at a time. Drain and complete them all,
+        // counting the total dispatched across all batches.
+        let mut total_dispatched = 0usize;
+        loop {
+            match swarm_rx.try_recv() {
+                Ok(SwarmSend::Request(_, Message::GetData(GetData::Block(hash)))) => {
+                    total_dispatched += 1;
+                    block_fetcher_tx
+                        .send(BlockFetcherEvent::BlockRequestCompleted(hash))
+                        .await
+                        .unwrap();
+                    // Yield so the fetcher processes the completion
+                    tokio::task::yield_now().await;
+                }
+                _ => {
+                    // Yield and try once more in case the fetcher
+                    // needs a cycle to refill from backlog
+                    tokio::task::yield_now().await;
+                    match swarm_rx.try_recv() {
+                        Ok(SwarmSend::Request(_, Message::GetData(GetData::Block(hash)))) => {
+                            total_dispatched += 1;
+                            block_fetcher_tx
+                                .send(BlockFetcherEvent::BlockRequestCompleted(hash))
+                                .await
+                                .unwrap();
+                            tokio::task::yield_now().await;
+                        }
+                        _ => {
+                            // Truly done
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        assert_eq!(
+            total_dispatched, total_blocks,
+            "All blocks should be dispatched across batches"
+        );
+
+        drop(block_fetcher_tx);
         let result = fetcher_handle.await.unwrap();
         assert!(result.is_ok());
     }

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -649,7 +649,7 @@ impl ChainStoreHandle {
     pub async fn add_share_block_and_organise_header(
         &self,
         share: ShareBlock,
-    ) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError> {
+    ) -> Result<Option<u32>, StoreError> {
         let blockhash = share.block_hash();
         debug!("Adding share and organising header atomically: {blockhash:?}");
         self.store_handle
@@ -658,11 +658,11 @@ impl ChainStoreHandle {
     }
 
     /// Organise a header into the candidate chain.
-    /// Returns the new candidate height and chain if the candidate chain changed.
+    /// Returns the new candidate height if the candidate chain changed.
     pub async fn organise_header(
         &self,
         header: ShareHeader,
-    ) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError> {
+    ) -> Result<Option<u32>, StoreError> {
         let blockhash = header.block_hash();
         let result = self.store_handle.organise_header(header).await?;
         info!("Organised header {blockhash} into candidate chain");
@@ -781,11 +781,11 @@ mockall::mock! {
         pub fn is_confirmed_or_confirmed_uncle(&self, blockhash: &BlockHash) -> bool;
         pub fn get_btcaddresses_for_user_ids(&self, user_ids: &[u64]) -> Result<Vec<(u64, String)>, StoreError>;
         pub async fn init_or_setup_genesis(&self, genesis_block: ShareBlock) -> Result<(), StoreError>;
-        pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>;
+        pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;
         pub async fn organise_block(&self) -> Result<Option<u32>, StoreError>;
         pub async fn promote_block(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;
         pub async fn add_share_block(&self, share: ShareBlock) -> Result<(), StoreError>;
-        pub async fn add_share_block_and_organise_header(&self, share: ShareBlock) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>;
+        pub async fn add_share_block_and_organise_header(&self, share: ShareBlock) -> Result<Option<u32>, StoreError>;
         pub async fn add_pplns_share(&self, pplns_share: SimplePplnsShare) -> Result<(), StoreError>;
         pub async fn add_user(&self, btcaddress: String) -> Result<u64, StoreError>;
     }

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -285,15 +285,19 @@ impl ChainStoreHandle {
         }
     }
 
-    /// Check whether the candidate chain tip is current.
+    /// Check whether the confirmed chain tip is current.
     ///
-    /// Returns true when the candidate chain tip timestamp is within
+    /// Returns true when the confirmed chain tip timestamp is within
     /// MAX_TIP_AGE_SECS seconds of the current system time. Returns
     /// false when the tip is stale or when any store lookup fails
-    /// (e.g. no chain yet). Falls back to the confirmed tip if no
-    /// candidate exists.
+    /// (e.g. no chain yet).
+    ///
+    /// Uses the confirmed tip (not candidate) so that during initial
+    /// sync the chain is correctly identified as not-current, which
+    /// suppresses per-inv getheaders and lets the bulk header-first
+    /// pipeline run in batches.
     pub fn is_current(&self) -> bool {
-        let tip_header = match self.get_candidate_tip_header() {
+        let tip_header = match self.get_chain_tip_header() {
             Ok(header) => header,
             Err(_) => return false,
         };

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -663,10 +663,7 @@ impl ChainStoreHandle {
 
     /// Organise a header into the candidate chain.
     /// Returns the new candidate height if the candidate chain changed.
-    pub async fn organise_header(
-        &self,
-        header: ShareHeader,
-    ) -> Result<Option<u32>, StoreError> {
+    pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<u32>, StoreError> {
         let blockhash = header.block_hash();
         let result = self.store_handle.organise_header(header).await?;
         info!("Organised header {blockhash} into candidate chain");

--- a/p2poolv2_lib/src/shares/genesis/mod.rs
+++ b/p2poolv2_lib/src/shares/genesis/mod.rs
@@ -50,7 +50,7 @@ const TESTNET4_GENESIS_DATA: GenesisData = GenesisData {
     // for bitcoin blockhash 00000000000000013c0a1f4152b458118ed666282e6235d744bf2a5d66ecf022
     bitcoin_block_hex: include!("testnet4.rs"),
     bitcoin_height: 130754,
-    timestamp: 1777388400,
+    timestamp: 1777757400,
 };
 
 // Using the following JSON data for the genesis block

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -330,7 +330,7 @@ impl Store {
     ///
     /// Computes height and chain_work from parent metadata, creates
     /// BlockMetadata, and updates the candidate chain.
-    /// Returns the new candidate height and chain if changed, or None.
+    /// Returns the new candidate height, or None.
     pub fn push_to_candidate_chain(&self, share: &ShareBlock) -> Result<Option<u32>, StoreError> {
         let mut batch = Store::get_write_batch();
         let result = self.organise_header(&share.header, &mut batch)?;

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -331,10 +331,7 @@ impl Store {
     /// Computes height and chain_work from parent metadata, creates
     /// BlockMetadata, and updates the candidate chain.
     /// Returns the new candidate height and chain if changed, or None.
-    pub fn push_to_candidate_chain(
-        &self,
-        share: &ShareBlock,
-    ) -> Result<Option<u32>, StoreError> {
+    pub fn push_to_candidate_chain(&self, share: &ShareBlock) -> Result<Option<u32>, StoreError> {
         let mut batch = Store::get_write_batch();
         let result = self.organise_header(&share.header, &mut batch)?;
         self.commit_batch(batch)?;

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -334,7 +334,7 @@ impl Store {
     pub fn push_to_candidate_chain(
         &self,
         share: &ShareBlock,
-    ) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError> {
+    ) -> Result<Option<u32>, StoreError> {
         let mut batch = Store::get_write_batch();
         let result = self.organise_header(&share.header, &mut batch)?;
         self.commit_batch(batch)?;

--- a/p2poolv2_lib/src/store/organise/candidate.rs
+++ b/p2poolv2_lib/src/store/organise/candidate.rs
@@ -225,61 +225,91 @@ impl Store {
         &self,
         min_scan_height: Option<u32>,
     ) -> Result<Vec<BlockHash>, StoreError> {
-        let confirmed_height = match self.get_top_confirmed_height() {
-            Ok(height) => height,
-            Err(StoreError::NotFound(_)) => 0,
-            Err(error) => return Err(error),
-        };
-
+        let scan_start = self.missing_data_scan_start(min_scan_height)?;
         let candidate_height = match self.get_top_candidate_height() {
             Ok(height) => height,
             Err(StoreError::NotFound(_)) => return Ok(Vec::new()),
             Err(error) => return Err(error),
         };
 
-        let default_start = confirmed_height + 1;
-        let scan_start = match min_scan_height {
-            Some(hint) => std::cmp::min(hint, default_start),
-            None => default_start,
-        };
-
         if candidate_height < scan_start {
             return Ok(Vec::new());
         }
 
+        let (all_blockhashes, missing) =
+            self.scan_heights_for_missing_blocks(scan_start, candidate_height);
+
+        let missing_uncles = self.collect_missing_uncle_blocks(&all_blockhashes);
+        debug!(
+            "get_candidate_blocks_missing_data: scan_start={scan_start}, candidate_height={candidate_height}, all_blocks={}, missing_blocks={}, missing_uncles={}",
+            all_blockhashes.len(),
+            missing.len(),
+            missing_uncles.len()
+        );
+
+        let mut result = Vec::with_capacity(missing_uncles.len() + missing.len());
+        result.extend(missing_uncles);
+        result.extend(missing);
+        Ok(result)
+    }
+
+    /// Compute the starting height for the missing-data scan.
+    ///
+    /// Defaults to `confirmed_top + 1`. When `min_scan_height` is
+    /// provided, uses the lower of the two so that fork blocks below
+    /// the confirmed tip are included.
+    fn missing_data_scan_start(&self, min_scan_height: Option<u32>) -> Result<u32, StoreError> {
+        let confirmed_height = match self.get_top_confirmed_height() {
+            Ok(height) => height,
+            Err(StoreError::NotFound(_)) => 0,
+            Err(error) => return Err(error),
+        };
+        let default_start = confirmed_height + 1;
+        Ok(match min_scan_height {
+            Some(hint) => std::cmp::min(hint, default_start),
+            None => default_start,
+        })
+    }
+
+    /// Walk heights from `scan_start` to `candidate_height`, collecting
+    /// all blockhashes and identifying those that need block data.
+    ///
+    /// Returns `(all_blockhashes, missing)` where `missing` contains
+    /// hashes whose block body is not stored and whose status is not
+    /// yet BlockValid or Confirmed.
+    fn scan_heights_for_missing_blocks(
+        &self,
+        scan_start: u32,
+        candidate_height: u32,
+    ) -> (Vec<BlockHash>, Vec<BlockHash>) {
         let height_range = (candidate_height - scan_start + 1) as usize;
+        let mut all_blockhashes = Vec::with_capacity(height_range);
         let mut missing = Vec::with_capacity(height_range);
 
         let mut height = scan_start;
         while height <= candidate_height {
             let blockhashes = self.get_blockhashes_for_height(height);
             for blockhash in blockhashes {
-                match self.get_block_metadata(&blockhash) {
-                    Ok(metadata) => {
-                        if metadata.status == Status::Candidate
-                            || metadata.status == Status::HeaderValid
-                        {
-                            missing.push(blockhash);
-                        }
-                    }
-                    Err(_) => {
-                        missing.push(blockhash);
-                    }
+                all_blockhashes.push(blockhash);
+                if !self.share_block_exists(&blockhash)
+                    && !self.is_block_valid_or_confirmed(&blockhash)
+                {
+                    missing.push(blockhash);
                 }
             }
             height += 1;
         }
 
-        let missing_uncles = self.collect_missing_uncle_blocks(&missing);
-        missing.extend(missing_uncles);
-
-        Ok(missing)
+        (all_blockhashes, missing)
     }
 
-    /// Read the header for each blockhash and return any referenced
-    /// uncle that lacks full block data.
+    /// Collect uncle blocks whose bodies are missing, recursively
+    /// following each uncle's own uncles until no new missing bodies
+    /// are found.
     fn collect_missing_uncle_blocks(&self, blockhashes: &[BlockHash]) -> Vec<BlockHash> {
-        let mut missing_uncles = Vec::new();
+        let mut missing_uncles: Vec<BlockHash> = Vec::new();
+
+        // First pass: scan uncles of all provided blockhashes
         for blockhash in blockhashes {
             let Ok(Some(header)) = self.get_share_header(blockhash) else {
                 continue;
@@ -289,11 +319,52 @@ impl Store {
                     && !missing_uncles.contains(uncle_hash)
                     && !blockhashes.contains(uncle_hash)
                 {
+                    debug!(
+                        "collect_missing_uncle_blocks: uncle {uncle_hash} missing body (referenced by {blockhash})"
+                    );
                     missing_uncles.push(*uncle_hash);
                 }
             }
         }
-        missing_uncles
+
+        // Recursive passes: each newly discovered missing uncle may
+        // itself reference further uncles whose bodies are also missing.
+        let mut scan_start = 0;
+        loop {
+            let scan_end = missing_uncles.len();
+            if scan_start >= scan_end {
+                return missing_uncles;
+            }
+
+            let mut new_uncles: Vec<BlockHash> = Vec::new();
+            for index in scan_start..scan_end {
+                let uncle_hash = missing_uncles[index];
+                let Ok(Some(header)) = self.get_share_header(&uncle_hash) else {
+                    continue;
+                };
+                for nested_uncle in &header.uncles {
+                    if !self.share_block_exists(nested_uncle)
+                        && !missing_uncles.contains(nested_uncle)
+                        && !blockhashes.contains(nested_uncle)
+                        && !new_uncles.contains(nested_uncle)
+                    {
+                        debug!(
+                            "collect_missing_uncle_blocks: nested uncle {nested_uncle} missing body (referenced by {uncle_hash})"
+                        );
+                        new_uncles.push(*nested_uncle);
+                    }
+                }
+            }
+            scan_start = scan_end;
+            missing_uncles.extend(new_uncles);
+        }
+    }
+
+    /// Check if a blockhash has BlockValid or Confirmed status.
+    fn is_block_valid_or_confirmed(&self, blockhash: &BlockHash) -> bool {
+        self.get_block_metadata(blockhash)
+            .map(|m| m.status == Status::BlockValid || m.status == Status::Confirmed)
+            .unwrap_or(false)
     }
 
     /// Check if a blockhash has Candidate status in its metadata.

--- a/p2poolv2_lib/src/store/organise/organise_header.rs
+++ b/p2poolv2_lib/src/store/organise/organise_header.rs
@@ -78,20 +78,11 @@ impl Store {
         if let Some(extended_height) =
             self.should_extend_candidates(header, &metadata, top_candidate.as_ref())?
         {
-            return self.extend_candidate_chain(
-                &blockhash,
-                extended_height,
-                &mut metadata,
-                batch,
-            );
+            return self.extend_candidate_chain(&blockhash, extended_height, &mut metadata, batch);
         }
 
         if self.should_reorg_candidate(&blockhash, &metadata, top_candidate.as_ref()) {
-            return self.reorg_candidate_chain(
-                &blockhash,
-                top_candidate.as_ref(),
-                batch,
-            );
+            return self.reorg_candidate_chain(&blockhash, top_candidate.as_ref(), batch);
         }
 
         Ok(None)

--- a/p2poolv2_lib/src/store/organise/organise_header.rs
+++ b/p2poolv2_lib/src/store/organise/organise_header.rs
@@ -22,7 +22,7 @@ use crate::{
 use bitcoin::BlockHash;
 use tracing::debug;
 
-use super::{Chain, Height, Store, TopResult};
+use super::{Height, Store, TopResult};
 
 impl Store {
     /// Organise a share header into the candidate chain.
@@ -38,7 +38,7 @@ impl Store {
         &self,
         header: &ShareHeader,
         batch: &mut rocksdb::WriteBatch,
-    ) -> Result<Option<(Height, Chain)>, StoreError> {
+    ) -> Result<Option<Height>, StoreError> {
         let blockhash = header.block_hash();
         debug!(
             "organise_header called for {blockhash} with prev blockhash {}",
@@ -82,8 +82,6 @@ impl Store {
                 &blockhash,
                 extended_height,
                 &mut metadata,
-                top_candidate.as_ref(),
-                &top_confirmed,
                 batch,
             );
         }
@@ -92,7 +90,6 @@ impl Store {
             return self.reorg_candidate_chain(
                 &blockhash,
                 top_candidate.as_ref(),
-                &top_confirmed,
                 batch,
             );
         }
@@ -107,27 +104,20 @@ impl Store {
         blockhash: &BlockHash,
         extended_height: Height,
         metadata: &mut BlockMetadata,
-        top_candidate: Option<&TopResult>,
-        top_confirmed: &TopResult,
         batch: &mut rocksdb::WriteBatch,
-    ) -> Result<Option<(Height, Chain)>, StoreError> {
+    ) -> Result<Option<Height>, StoreError> {
         debug!("Extending candidate");
         self.append_to_candidates(blockhash, extended_height, metadata, batch)?;
 
-        let old_top = top_candidate
-            .map(|top| top.height)
-            .unwrap_or(top_confirmed.height);
-        let mut candidates = self.get_candidates(top_confirmed.height + 1, old_top)?;
-        candidates.push((extended_height, *blockhash));
-
+        let mut new_entries = vec![(extended_height, *blockhash)];
         let final_height = self.extend_candidates_with_children(
             extended_height,
             blockhash,
-            &mut candidates,
+            &mut new_entries,
             batch,
         )?;
         debug!("new candidate height after extending candidates {final_height}");
-        Ok(Some((final_height, candidates)))
+        Ok(Some(final_height))
     }
 
     /// Reorg the candidate chain to a fork with more work, then walk
@@ -136,29 +126,21 @@ impl Store {
         &self,
         blockhash: &BlockHash,
         top_candidate: Option<&TopResult>,
-        top_confirmed: &TopResult,
         batch: &mut rocksdb::WriteBatch,
-    ) -> Result<Option<(Height, Chain)>, StoreError> {
+    ) -> Result<Option<Height>, StoreError> {
         let (new_height, reorg_chain) = self.reorg_candidate(blockhash, top_candidate, batch)?;
         debug!("new candidate height after reorging candidates {new_height}");
 
-        let branch_start = reorg_chain.first().map(|(height, _)| *height).unwrap_or(0);
-        let mut full_chain = if branch_start > top_confirmed.height + 1 {
-            self.get_candidates(top_confirmed.height + 1, branch_start - 1)?
-        } else {
-            Vec::new()
-        };
-        full_chain.extend(reorg_chain);
-
-        let reorg_tip_hash = full_chain.last().expect("reorg chain is non-empty").1;
+        let reorg_tip_hash = reorg_chain.last().expect("reorg chain is non-empty").1;
+        let mut new_entries = Vec::new();
         let final_height = self.extend_candidates_with_children(
             new_height,
             &reorg_tip_hash,
-            &mut full_chain,
+            &mut new_entries,
             batch,
         )?;
         debug!("new candidate height after reorg + forward walk {final_height}");
-        Ok(Some((final_height, full_chain)))
+        Ok(Some(final_height))
     }
 
     /// Ensure the height-to-blockhash index contains this block.
@@ -270,10 +252,8 @@ mod tests {
 
         // Candidate chain should be updated
         assert!(result.is_some());
-        let (height, candidates) = result.unwrap();
+        let height = result.unwrap();
         assert_eq!(height, 1);
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0], (1, share.block_hash()));
 
         // Top candidate work is cumulative: genesis_work + share_work
         let cumulative_work = genesis.header.get_work() + share.header.get_work();
@@ -408,13 +388,6 @@ mod tests {
 
         // Candidate chain should be reorged
         assert!(result.is_some());
-        let (_height, candidates) = result.unwrap();
-        // Chain should contain share1 and fork_share
-        assert!(
-            candidates
-                .iter()
-                .any(|(_, hash)| *hash == fork_share.block_hash())
-        );
 
         // Top candidate should be fork_share
         let top = store.get_top_candidate().unwrap();
@@ -687,18 +660,8 @@ mod tests {
             result.is_some(),
             "fork_share2 should trigger candidate reorg"
         );
-        let (height, candidates) = result.unwrap();
+        let height = result.unwrap();
         assert_eq!(height, 2);
-        assert!(
-            candidates
-                .iter()
-                .any(|(_, hash)| *hash == fork_share1.block_hash())
-        );
-        assert!(
-            candidates
-                .iter()
-                .any(|(_, hash)| *hash == fork_share2.block_hash())
-        );
 
         // Top candidate should be fork_share2
         let top = store.get_top_candidate().unwrap();

--- a/p2poolv2_lib/src/store/writer/handle.rs
+++ b/p2poolv2_lib/src/store/writer/handle.rs
@@ -258,7 +258,7 @@ impl StoreHandle {
     pub async fn add_share_block_and_organise_header(
         &self,
         share: ShareBlock,
-    ) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError> {
+    ) -> Result<Option<u32>, StoreError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.write_tx
             .send(WriteCommand::AddShareBlockAndOrganiseHeader {
@@ -309,11 +309,11 @@ impl StoreHandle {
     }
 
     /// Organise a header into the candidate chain.
-    /// Returns the new candidate height and chain if changed.
+    /// Returns the new candidate height if changed.
     pub async fn organise_header(
         &self,
         header: ShareHeader,
-    ) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError> {
+    ) -> Result<Option<u32>, StoreError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.write_tx
             .send(WriteCommand::OrganiseHeader {
@@ -386,10 +386,10 @@ mockall::mock! {
         pub fn get_children_blockhashes(&self, blockhash: &BlockHash) -> Result<Option<Vec<BlockHash>>, StoreError>;
 
         // Serialized writes (async)
-        pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>;
+        pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;
         pub async fn organise_block(&self) -> Result<Option<u32>, StoreError>;
         pub async fn add_share_block(&self, share: ShareBlock) -> Result<(), StoreError>;
-        pub async fn add_share_block_and_organise_header(&self, share: ShareBlock) -> Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>;
+        pub async fn add_share_block_and_organise_header(&self, share: ShareBlock) -> Result<Option<u32>, StoreError>;
         pub async fn setup_genesis(&self, genesis: ShareBlock) -> Result<(), StoreError>;
         pub async fn init_chain_state_from_store(&self, genesis_hash: BlockHash) -> Result<(), StoreError>;
         pub async fn add_user(&self, btcaddress: String) -> Result<u64, StoreError>;

--- a/p2poolv2_lib/src/store/writer/handle.rs
+++ b/p2poolv2_lib/src/store/writer/handle.rs
@@ -310,10 +310,7 @@ impl StoreHandle {
 
     /// Organise a header into the candidate chain.
     /// Returns the new candidate height if changed.
-    pub async fn organise_header(
-        &self,
-        header: ShareHeader,
-    ) -> Result<Option<u32>, StoreError> {
+    pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<u32>, StoreError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.write_tx
             .send(WriteCommand::OrganiseHeader {

--- a/p2poolv2_lib/src/store/writer/mod.rs
+++ b/p2poolv2_lib/src/store/writer/mod.rs
@@ -131,7 +131,7 @@ pub enum WriteCommand {
     SetGenesisBlockHash { hash: BlockHash },
 
     /// Organise a header into the candidate chain.
-    /// Returns the new candidate height and chain if changed.
+    /// Returns the new candidate height.
     OrganiseHeader {
         header: ShareHeader,
         reply: oneshot::Sender<Result<Option<u32>, StoreError>>,

--- a/p2poolv2_lib/src/store/writer/mod.rs
+++ b/p2poolv2_lib/src/store/writer/mod.rs
@@ -100,7 +100,7 @@ pub enum WriteCommand {
     /// not organised.
     AddShareBlockAndOrganiseHeader {
         share: ShareBlock,
-        reply: oneshot::Sender<Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>>,
+        reply: oneshot::Sender<Result<Option<u32>, StoreError>>,
     },
 
     /// Setup genesis block
@@ -134,7 +134,7 @@ pub enum WriteCommand {
     /// Returns the new candidate height and chain if changed.
     OrganiseHeader {
         header: ShareHeader,
-        reply: oneshot::Sender<Result<Option<(u32, Vec<(u32, BlockHash)>)>, StoreError>>,
+        reply: oneshot::Sender<Result<Option<u32>, StoreError>>,
     },
 
     /// Promote candidates to confirmed.


### PR DESCRIPTION
Sync improvements for correctness and speed.

- buffer out of order block confirmations in block receiver
- streamline fetching headers when doing header sync by avoiding rereading entire chain on each header organised
- fetch blocks in batches and buffer till entire batch is ready before fetching next batch
- block receiver correctly fetches missing uncles and uncles of uncles, recursively. This is more a defensive measure, should trigger rarely, but is required for correctness
- use confirmed tip for is_current
- drain next pending blocks makes it redundant to schedule children, so removed that