### PR TITLE
Remove disconnected peer from blockfetcher

### DIFF
--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -367,7 +367,7 @@ impl Node {
                     self.connected_dial_addresses.retain(|addr| addr != address);
                 }
                 self.swarm.behaviour_mut().remove_peer(&peer_id);
-                self.request_response_handler.remove_peer(&peer_id);
+                self.request_response_handler.remove_peer(&peer_id).await;
                 let _ = self
                     .monitoring_event_sender
                     .send(MonitoringEvent::Peer(PeerResponse {

--- a/p2poolv2_lib/src/node/request_response_handler/block_fetcher/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/block_fetcher/mod.rs
@@ -70,6 +70,8 @@ pub enum BlockFetcherEvent {
     BlockRequestCompleted(BlockHash),
     /// Peers list updated -- used for round-robin distribution.
     PeersUpdated(Vec<PeerId>),
+    /// A peer disconnected and should be removed from the selector.
+    PeerRemoved(PeerId),
 }
 
 impl fmt::Display for BlockFetcherEvent {
@@ -89,6 +91,9 @@ impl fmt::Display for BlockFetcherEvent {
             }
             BlockFetcherEvent::PeersUpdated(peers) => {
                 write!(formatter, "PeersUpdated({} peers)", peers.len())
+            }
+            BlockFetcherEvent::PeerRemoved(peer_id) => {
+                write!(formatter, "PeerRemoved({peer_id})")
             }
         }
     }
@@ -183,6 +188,9 @@ impl BlockFetcher {
                             debug!("Peers list updated in block fetcher");
                             self.peer_selector.update_peers(peers);
                         }
+                        Some(BlockFetcherEvent::PeerRemoved(peer_id)) => {
+                            self.handle_peer_removed(peer_id);
+                        }
                         None => {
                             info!("Block fetcher stopped -- channel closed");
                             return Ok(());
@@ -234,6 +242,36 @@ impl BlockFetcher {
         }
         self.pending.retain(|hash| *hash != blockhash);
         self.backlog.retain(|hash| *hash != blockhash);
+    }
+
+    /// Remove a disconnected peer from the selector and drop any
+    /// in-flight requests that were assigned to it.
+    ///
+    /// In-flight requests are intentionally not re-queued to other
+    /// peers. A peer may have sent cheap headers and then disconnected,
+    /// and propagating those requests to other peers who do not have
+    /// the blocks would waste their bandwidth.
+    fn handle_peer_removed(&mut self, peer_id: PeerId) {
+        info!("Removing peer {peer_id} from block fetcher");
+        self.peer_selector.remove_peer(&peer_id);
+
+        let dropped: Vec<BlockHash> = self
+            .in_flight
+            .iter()
+            .filter(|(_, request)| request.peer_id == peer_id)
+            .map(|(blockhash, _)| *blockhash)
+            .collect();
+
+        for blockhash in &dropped {
+            self.in_flight.remove(blockhash);
+        }
+
+        if !dropped.is_empty() {
+            info!(
+                "Dropped {} in-flight requests from removed peer {peer_id}",
+                dropped.len()
+            );
+        }
     }
 
     /// Move the next batch of blockhashes from the backlog into
@@ -624,6 +662,99 @@ mod tests {
         );
 
         drop(block_fetcher_tx);
+        let result = fetcher_handle.await.unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_block_fetcher_peer_removed_drops_in_flight() {
+        let (block_fetcher_tx, block_fetcher_rx) = create_block_fetcher_channel();
+        let (swarm_tx, mut swarm_rx) = mpsc::channel(64);
+        let fetcher = BlockFetcher::new(block_fetcher_rx, swarm_tx);
+
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+
+        // Register both peers
+        block_fetcher_tx
+            .send(BlockFetcherEvent::PeersUpdated(vec![peer_a, peer_b]))
+            .await
+            .unwrap();
+
+        let blockhash = random_blockhash();
+
+        block_fetcher_tx
+            .send(BlockFetcherEvent::FetchBlocks {
+                blockhashes: vec![blockhash],
+                peer_id: peer_a,
+            })
+            .await
+            .unwrap();
+
+        let fetcher_handle = tokio::spawn(fetcher.run());
+
+        // Drain the initial request
+        let initial_request = swarm_rx.recv().await.unwrap();
+        let initial_peer = match initial_request {
+            SwarmSend::Request(peer, Message::GetData(GetData::Block(hash))) => {
+                assert_eq!(hash, blockhash);
+                peer
+            }
+            other => panic!("Expected GetData::Block, got: {other:?}"),
+        };
+
+        // Remove the peer that got the request -- in-flight should be
+        // dropped, not re-queued to other peers
+        block_fetcher_tx
+            .send(BlockFetcherEvent::PeerRemoved(initial_peer))
+            .await
+            .unwrap();
+
+        // Give the fetcher time to process the event
+        tokio::task::yield_now().await;
+
+        drop(block_fetcher_tx);
+
+        // No retry request should be sent
+        assert!(
+            swarm_rx.try_recv().is_err(),
+            "in-flight requests from removed peer should be dropped, not retried"
+        );
+
+        let result = fetcher_handle.await.unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_block_fetcher_peer_removed_no_in_flight_is_noop() {
+        let (block_fetcher_tx, block_fetcher_rx) = create_block_fetcher_channel();
+        let (swarm_tx, mut swarm_rx) = mpsc::channel(32);
+        let fetcher = BlockFetcher::new(block_fetcher_rx, swarm_tx);
+
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+
+        block_fetcher_tx
+            .send(BlockFetcherEvent::PeersUpdated(vec![peer_a, peer_b]))
+            .await
+            .unwrap();
+
+        // Remove a peer with nothing in-flight
+        block_fetcher_tx
+            .send(BlockFetcherEvent::PeerRemoved(peer_a))
+            .await
+            .unwrap();
+
+        drop(block_fetcher_tx);
+
+        let fetcher_handle = tokio::spawn(fetcher.run());
+
+        // No requests should be sent
+        assert!(
+            swarm_rx.try_recv().is_err(),
+            "no requests should be sent when removed peer has no in-flight"
+        );
+
         let result = fetcher_handle.await.unwrap();
         assert!(result.is_ok());
     }

--- a/p2poolv2_lib/src/node/request_response_handler/block_fetcher/peer_selector.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/block_fetcher/peer_selector.rs
@@ -19,6 +19,9 @@
 use super::MAX_IN_FLIGHT_PER_PEER;
 use libp2p::PeerId;
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::time::Instant;
 
 /// Manages peer selection for block fetching using round-robin distribution.
 ///
@@ -56,6 +59,22 @@ impl PeerSelector {
     /// Add a single peer if not already known (starts with count zero).
     pub(super) fn add_peer(&mut self, peer_id: PeerId) {
         self.peers.entry(peer_id).or_insert(0);
+    }
+
+    /// Remove a disconnected peer from the selector.
+    ///
+    /// Sets the round-robin index to a hash-derived position to avoid
+    /// bias toward the first peer in the map.
+    pub(super) fn remove_peer(&mut self, peer_id: &PeerId) {
+        self.peers.remove(peer_id);
+        let peer_count = self.peers.len();
+        if peer_count == 0 {
+            self.next_peer_index = 0;
+            return;
+        }
+        let mut hasher = DefaultHasher::new();
+        Instant::now().hash(&mut hasher);
+        self.next_peer_index = hasher.finish() as usize % peer_count;
     }
 
     /// Select a peer using round-robin, skipping peers at capacity.
@@ -222,6 +241,50 @@ mod tests {
         let expected_set: std::collections::HashSet<PeerId> =
             [peer_b, peer_c].into_iter().collect();
         assert_eq!(selected_set, expected_set);
+    }
+
+    #[test]
+    fn test_peer_selector_remove_peer() {
+        let mut selector = PeerSelector::new();
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+        let peer_c = PeerId::random();
+        selector.update_peers(vec![peer_a, peer_b, peer_c]);
+
+        selector.remove_peer(&peer_b);
+
+        // Only peer_a and peer_c remain
+        let mut selected = std::collections::HashSet::new();
+        selected.insert(selector.select_peer().unwrap());
+        selected.insert(selector.select_peer().unwrap());
+        assert!(selected.contains(&peer_a));
+        assert!(selected.contains(&peer_c));
+        assert!(!selected.contains(&peer_b));
+    }
+
+    #[test]
+    fn test_peer_selector_remove_last_peer() {
+        let mut selector = PeerSelector::new();
+        let peer_a = PeerId::random();
+        selector.add_peer(peer_a);
+
+        selector.remove_peer(&peer_a);
+
+        assert!(!selector.has_peers());
+        assert!(selector.select_peer().is_none());
+    }
+
+    #[test]
+    fn test_peer_selector_remove_unknown_peer_is_noop() {
+        let mut selector = PeerSelector::new();
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+        selector.add_peer(peer_a);
+
+        selector.remove_peer(&peer_b);
+
+        assert!(selector.has_peers());
+        assert_eq!(selector.select_peer().unwrap(), peer_a);
     }
 
     #[test]

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -17,7 +17,7 @@
 pub mod block_fetcher;
 pub mod peer_block_knowledge;
 
-use self::block_fetcher::BlockFetcherHandle;
+use self::block_fetcher::{BlockFetcherEvent, BlockFetcherHandle};
 use self::peer_block_knowledge::PeerBlockKnowledge;
 use crate::config::NetworkConfig;
 use crate::node::SwarmSend;
@@ -187,10 +187,14 @@ impl<C: Send + Sync + 'static> RequestResponseHandler<C> {
     ///
     /// Drops the peer handle, which closes the channel and causes
     /// the peer's service task to exit. Also removes peer block
-    /// knowledge.
+    /// knowledge and notifies the block fetcher so it stops sending
+    /// requests to this peer.
     pub fn remove_peer(&mut self, peer_id: &PeerId) {
         self.peer_handles.remove(peer_id);
         self.peer_block_knowledge.remove_peer(peer_id);
+        let _ = self
+            .block_fetcher_handle
+            .try_send(BlockFetcherEvent::PeerRemoved(*peer_id));
     }
 
     /// Records which blocks a peer knows about based on a message.

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -189,12 +189,16 @@ impl<C: Send + Sync + 'static> RequestResponseHandler<C> {
     /// the peer's service task to exit. Also removes peer block
     /// knowledge and notifies the block fetcher so it stops sending
     /// requests to this peer.
-    pub fn remove_peer(&mut self, peer_id: &PeerId) {
+    pub async fn remove_peer(&mut self, peer_id: &PeerId) {
         self.peer_handles.remove(peer_id);
         self.peer_block_knowledge.remove_peer(peer_id);
-        let _ = self
+        if let Err(send_error) = self
             .block_fetcher_handle
-            .try_send(BlockFetcherEvent::PeerRemoved(*peer_id));
+            .send(BlockFetcherEvent::PeerRemoved(*peer_id))
+            .await
+        {
+            error!("Failed to notify block fetcher of peer removal for {peer_id}: {send_error}");
+        }
     }
 
     /// Records which blocks a peer knows about based on a message.
@@ -730,7 +734,7 @@ mod tests {
         );
         assert!(handler.peer_handles.contains_key(&peer_id));
 
-        handler.remove_peer(&peer_id);
+        handler.remove_peer(&peer_id).await;
         assert!(
             !handler
                 .peer_block_knowledge()


### PR DESCRIPTION
Do not pass on the in flight requests to another peer. This is to avoid a malicious peer flooding us with cheap headers and then disconnecting. This will result in other healthy peers being spammed for non-existent share blocks. 