### PR TITLE
Add cli commmand to query raw dag

### DIFF
--- a/docs/architecture/store-architecture.md
+++ b/docs/architecture/store-architecture.md
@@ -166,7 +166,7 @@ tokio::task::spawn_blocking(move || store_writer.run());
 let store_handle = StoreHandle::new(store, write_tx);
 let chain_store_handle = ChainStoreHandle::new(store_handle, network);
 
-// 5. Initialize genesis
+// 5. Initialise genesis
 let genesis = ShareBlock::build_genesis_for_network(network);
 chain_store_handle.init_or_setup_genesis(genesis).await?;
 ```

--- a/docs/difficulty_adjustment/ckpool.md
+++ b/docs/difficulty_adjustment/ckpool.md
@@ -98,7 +98,7 @@ The final difficulty is bounded by:
    - Difficulty is not adjusted until 72 shares have been collected or 240 seconds have passed since the last adjustment.
    - Instead of aiming for a precise 0.3 drr, ckpool doesn't change difficulty until drr falls out of [0.15, 0.4] range.
 
-1. There's special handling for first shares in a session. We just need to initialize the ldc timestamp and return.
+1. There's special handling for first shares in a session. We just need to initialise the ldc timestamp and return.
 
 1. Retain difficulty change information for debugging purposes.
    - Old difficulty preserved in client->old_diff

--- a/load-tests/diagnosis/tcp-monitor.sh
+++ b/load-tests/diagnosis/tcp-monitor.sh
@@ -24,7 +24,7 @@ NC='\033[0m' # No Color
 PREVIOUS_PORT_CONNECTIONS=0
 MONITOR_START_TIME=$(date +%s)
 
-# Initialize all metrics to 0
+# Initialise all metrics to 0
 PORT_TOTAL=0
 PORT_ESTABLISHED=0
 PORT_TIME_WAIT=0

--- a/p2poolv2_api/src/api/endpoints/dag.rs
+++ b/p2poolv2_api/src/api/endpoints/dag.rs
@@ -60,15 +60,30 @@ pub(crate) async fn dag(
         )));
     }
 
-    let tip_height = chain_store_handle
+    let confirmed_height = chain_store_handle
         .get_tip_height()
-        .map_err(|error| ApiError::ServerError(format!("Failed to get tip height: {error}")))?
-        .ok_or_else(|| ApiError::ServerError("No confirmed chain tip found".to_string()))?;
+        .map_err(|error| ApiError::ServerError(format!("Failed to get tip height: {error}")))?;
+    let candidate_height = chain_store_handle
+        .get_candidate_tip_height()
+        .map_err(|error| {
+            ApiError::ServerError(format!("Failed to get candidate tip height: {error}"))
+        })?;
+
+    let max_height = match (confirmed_height, candidate_height) {
+        (Some(confirmed), Some(candidate)) => confirmed.max(candidate),
+        (Some(confirmed), None) => confirmed,
+        (None, Some(candidate)) => candidate,
+        (None, None) => {
+            return Err(ApiError::ServerError(
+                "No confirmed or candidate chain found".to_string(),
+            ));
+        }
+    };
 
     let to_height = match query.to {
-        Some(height) if height > tip_height => tip_height,
+        Some(height) if height > max_height => max_height,
         Some(height) => height,
-        None => tip_height,
+        None => max_height,
     };
 
     let from_height = to_height.saturating_sub(num.saturating_sub(1));

--- a/p2poolv2_api/src/api/endpoints/dag.rs
+++ b/p2poolv2_api/src/api/endpoints/dag.rs
@@ -1,0 +1,86 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::api::endpoints::MAX_NUM_SHARES_IN_RESPONSE;
+use crate::api::error::ApiError;
+use crate::api::server::AppState;
+use axum::{
+    Json,
+    extract::{Query, State},
+};
+use p2poolv2_lib::store::dag_store::DagEntry;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Query parameters for the /dag endpoint.
+#[derive(Deserialize)]
+pub struct DagQuery {
+    /// Height to query up to (inclusive). Defaults to confirmed chain tip.
+    pub to: Option<u32>,
+    /// Number of heights going back from `to`. Defaults to 10.
+    pub num: Option<u32>,
+}
+
+/// JSON response for the /dag endpoint.
+#[derive(Serialize)]
+pub struct DagResponse {
+    pub from_height: u32,
+    pub to_height: u32,
+    pub entries: Vec<DagEntry>,
+}
+
+/// Returns all share headers in the height index for a range of heights.
+///
+/// Unlike /shares and /candidates which only return confirmed or candidate
+/// chain entries, this returns every block at each height regardless of
+/// status (Confirmed, Candidate, HeaderValid, etc.).
+pub(crate) async fn dag(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<DagQuery>,
+) -> Result<Json<DagResponse>, ApiError> {
+    let chain_store_handle = &state.chain_store_handle;
+    let num = query.num.unwrap_or(10);
+
+    if !(1..=MAX_NUM_SHARES_IN_RESPONSE).contains(&num) {
+        return Err(ApiError::BadRequest(format!(
+            "num must be between 1 and {MAX_NUM_SHARES_IN_RESPONSE}, got {num}"
+        )));
+    }
+
+    let tip_height = chain_store_handle
+        .get_tip_height()
+        .map_err(|error| ApiError::ServerError(format!("Failed to get tip height: {error}")))?
+        .ok_or_else(|| ApiError::ServerError("No confirmed chain tip found".to_string()))?;
+
+    let to_height = match query.to {
+        Some(height) if height > tip_height => tip_height,
+        Some(height) => height,
+        None => tip_height,
+    };
+
+    let from_height = to_height.saturating_sub(num.saturating_sub(1));
+
+    let entries = chain_store_handle
+        .store_handle()
+        .store()
+        .query_dag(from_height, to_height);
+
+    Ok(Json(DagResponse {
+        from_height,
+        to_height,
+        entries,
+    }))
+}

--- a/p2poolv2_api/src/api/endpoints/dag.rs
+++ b/p2poolv2_api/src/api/endpoints/dag.rs
@@ -84,3 +84,96 @@ pub(crate) async fn dag(
         entries,
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::server::{AppConfig, AppState};
+    use axum::extract::{Query, State};
+    use p2poolv2_lib::accounting::stats::metrics;
+    use p2poolv2_lib::monitoring_events::create_monitoring_event_channel;
+    use p2poolv2_lib::node::actor::NodeHandle;
+    use p2poolv2_lib::stratum::work::tracker::start_tracker_actor;
+    use p2poolv2_lib::test_utils::{genesis_for_tests, setup_test_chain_store_handle};
+
+    async fn build_test_state(node_handle: NodeHandle) -> (Arc<AppState>, tempfile::TempDir) {
+        let (chain_store_handle, temp_dir) = setup_test_chain_store_handle(true).await;
+        let metrics_temp = tempfile::tempdir().unwrap();
+        let metrics_handle =
+            metrics::start_metrics(metrics_temp.path().to_str().unwrap().to_string())
+                .await
+                .unwrap();
+        let tracker_handle = start_tracker_actor();
+        let state = Arc::new(AppState {
+            app_config: AppConfig {
+                pool_signature_length: 0,
+                network: bitcoin::Network::Signet,
+                cors_allowed: false,
+            },
+            chain_store_handle,
+            metrics_handle,
+            tracker_handle,
+            node_handle,
+            monitoring_event_sender: create_monitoring_event_channel().0,
+            auth_user: None,
+            auth_token: None,
+        });
+        (state, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn test_dag_rejects_num_zero() {
+        let node_handle = NodeHandle::new_for_test();
+        let (state, _temp_dir) = build_test_state(node_handle).await;
+
+        let query = Query(DagQuery {
+            to: None,
+            num: Some(0),
+        });
+
+        let result = dag(State(state), query).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_dag_rejects_num_above_max() {
+        let node_handle = NodeHandle::new_for_test();
+        let (state, _temp_dir) = build_test_state(node_handle).await;
+
+        let query = Query(DagQuery {
+            to: None,
+            num: Some(1001),
+        });
+
+        let result = dag(State(state), query).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_dag_returns_genesis_entries() {
+        let node_handle = NodeHandle::new_for_test();
+        let (state, _temp_dir) = build_test_state(node_handle).await;
+
+        let genesis = genesis_for_tests();
+        state
+            .chain_store_handle
+            .init_or_setup_genesis(genesis.clone())
+            .await
+            .unwrap();
+
+        let query = Query(DagQuery {
+            to: Some(0),
+            num: Some(1),
+        });
+
+        let result = dag(State(state), query).await;
+        assert!(result.is_ok());
+        let response = result.unwrap().0;
+        assert_eq!(response.from_height, 0);
+        assert_eq!(response.to_height, 0);
+        assert_eq!(response.entries.len(), 1);
+        assert_eq!(response.entries[0].blockhash, genesis.block_hash());
+        assert_eq!(response.entries[0].status, "Confirmed");
+        assert!(response.entries[0].has_block_data);
+    }
+}

--- a/p2poolv2_api/src/api/server.rs
+++ b/p2poolv2_api/src/api/server.rs
@@ -111,6 +111,7 @@ fn build_router(app_state: Arc<AppState>, app_config: AppConfig) -> Router {
         .route("/shares", get(endpoints::shares::shares))
         .route("/candidates", get(endpoints::candidates::candidates))
         .route("/share", get(endpoints::share::share))
+        .route("/dag", get(endpoints::dag::dag))
         .route(
             "/share_headers",
             get(endpoints::share_headers::share_headers),

--- a/p2poolv2_cli/src/commands/dag.rs
+++ b/p2poolv2_cli/src/commands/dag.rs
@@ -14,12 +14,24 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod candidates;
-pub mod chain_info;
-pub mod dag;
-pub mod share;
-pub mod share_headers;
-pub mod shares;
+use crate::commands::api_client::ApiClient;
+use p2poolv2_lib::config::ApiConfig;
+use std::error::Error;
 
-/// Maximum number of candidates and shares that can be requested in a single query.
-pub(crate) const MAX_NUM_SHARES_IN_RESPONSE: u32 = 100;
+/// Execute the dag command by querying the running node's API.
+pub async fn execute(
+    api_config: &ApiConfig,
+    to: Option<u32>,
+    num: u32,
+) -> Result<(), Box<dyn Error>> {
+    let api_client = ApiClient::new(api_config);
+
+    let mut path = format!("/dag?num={num}");
+    if let Some(to_height) = to {
+        path.push_str(&format!("&to={to_height}"));
+    }
+
+    let response: serde_json::Value = api_client.get_json(&path).await?;
+    println!("{}", serde_json::to_string_pretty(&response)?);
+    Ok(())
+}

--- a/p2poolv2_cli/src/commands/db_query.rs
+++ b/p2poolv2_cli/src/commands/db_query.rs
@@ -219,14 +219,20 @@ pub fn pplns_shares(
 
 /// Query all share headers at each height in the height index.
 pub fn dag(store: &Store, to: Option<u32>, num: u32, dot: bool) -> Result<(), Box<dyn Error>> {
-    let tip_height = store
-        .get_top_confirmed_height()
-        .map_err(|error| format!("Failed to get tip height: {error}"))?;
+    let confirmed_height = store.get_top_confirmed_height().ok();
+    let candidate_height = store.get_top_candidate_height().ok();
+
+    let max_height = match (confirmed_height, candidate_height) {
+        (Some(confirmed), Some(candidate)) => confirmed.max(candidate),
+        (Some(confirmed), None) => confirmed,
+        (None, Some(candidate)) => candidate,
+        (None, None) => return Err("No confirmed or candidate chain found in store".into()),
+    };
 
     let to_height = match to {
-        Some(height) if height > tip_height => tip_height,
+        Some(height) if height > max_height => max_height,
         Some(height) => height,
-        None => tip_height,
+        None => max_height,
     };
 
     let from_height = to_height.saturating_sub(num.saturating_sub(1));

--- a/p2poolv2_cli/src/commands/db_query.rs
+++ b/p2poolv2_cli/src/commands/db_query.rs
@@ -22,7 +22,7 @@
 use bitcoin::BlockHash;
 use p2poolv2_lib::store::Store;
 use p2poolv2_lib::store::block_tx_metadata::Status;
-use p2poolv2_lib::store::dag_store::MAX_UNCLES_DEPTH;
+use p2poolv2_lib::store::dag_store::{DagEntry, MAX_UNCLES_DEPTH};
 use p2poolv2_lib::store::writer::StoreError;
 use p2poolv2_lib::utils::time_provider::format_timestamp;
 use serde::Serialize;
@@ -217,6 +217,35 @@ pub fn pplns_shares(
     Ok(())
 }
 
+/// Query all share headers at each height in the height index.
+pub fn dag(store: &Store, to: Option<u32>, num: u32, dot: bool) -> Result<(), Box<dyn Error>> {
+    let tip_height = store
+        .get_top_confirmed_height()
+        .map_err(|error| format!("Failed to get tip height: {error}"))?;
+
+    let to_height = match to {
+        Some(height) if height > tip_height => tip_height,
+        Some(height) => height,
+        None => tip_height,
+    };
+
+    let from_height = to_height.saturating_sub(num.saturating_sub(1));
+
+    let entries = store.query_dag(from_height, to_height);
+
+    if dot {
+        print_dag_dot(&entries);
+    } else {
+        let response = serde_json::json!({
+            "from_height": from_height,
+            "to_height": to_height,
+            "entries": entries,
+        });
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    }
+    Ok(())
+}
+
 // --- DOT output helpers ---
 
 use p2poolv2_lib::store::dag_store::ShareInfo;
@@ -304,6 +333,71 @@ fn print_shares_dot(shares: &[ShareInfo], graph_name: &str) {
             let uncle_hash = uncle.blockhash.to_string();
             let uncle_prev = uncle.prev_blockhash.to_string();
             println!("    \"{uncle_hash}\" -> \"{uncle_prev}\" [color=\"#999999\"];");
+        }
+    }
+
+    println!("}}");
+    use std::io::Write;
+    std::io::stdout().flush().ok();
+}
+
+/// Render DagEntry list as a Graphviz DOT digraph.
+///
+/// Colours nodes by status: green for Confirmed, yellow for Candidate,
+/// grey for HeaderValid/other. Marks nodes without block data with a
+/// double border. Only emits edges between nodes present in the result.
+fn print_dag_dot(entries: &[DagEntry]) {
+    let known_hashes: std::collections::HashSet<String> = entries
+        .iter()
+        .map(|entry| entry.blockhash.to_string())
+        .collect();
+
+    println!("digraph dag {{");
+    println!("    node [shape=record, style=filled];");
+    println!();
+
+    for entry in entries {
+        let hash = entry.blockhash.to_string();
+        let identifier = short(&hash, 8);
+        let miner = short(&entry.miner_address, 8);
+        let data_marker = if entry.has_block_data { "D" } else { "-" };
+        let label = format!(
+            "{}|h:{}|{}|{}|{}",
+            identifier, entry.height, miner, entry.status, data_marker
+        );
+        let fill_color = match entry.status.as_str() {
+            "Confirmed" => "#a8d5ba",
+            "Candidate" => "#ffffb3",
+            "HeaderValid" | "BlockValid" => "#d9d9d9",
+            _ => "#f4a582",
+        };
+        let border = if entry.has_block_data {
+            ""
+        } else {
+            ", peripheries=2"
+        };
+        println!("    \"{hash}\" [label=\"{label}\", fillcolor=\"{fill_color}\"{border}];");
+    }
+
+    println!();
+
+    // Edges: block -> parent (only if parent is in result set)
+    for entry in entries {
+        let hash = entry.blockhash.to_string();
+        let parent = entry.parent.to_string();
+        if known_hashes.contains(&parent) {
+            println!("    \"{hash}\" -> \"{parent}\";");
+        }
+    }
+
+    // Edges: block -> uncles (only if uncle is in result set)
+    for entry in entries {
+        let hash = entry.blockhash.to_string();
+        for uncle in &entry.uncles {
+            let uncle_hash = uncle.to_string();
+            if known_hashes.contains(&uncle_hash) {
+                println!("    \"{hash}\" -> \"{uncle_hash}\" [style=dashed, color=\"#cc6633\"];");
+            }
         }
     }
 

--- a/p2poolv2_cli/src/commands/db_query.rs
+++ b/p2poolv2_cli/src/commands/db_query.rs
@@ -783,6 +783,30 @@ mod tests {
         print_shares_dot(&shares, "test_graph");
     }
 
+    // --- dag tests ---
+
+    #[tokio::test]
+    async fn test_dag_with_genesis() {
+        let (store, _temp_dir) = setup_store_with_genesis().await;
+        let result = dag(&store, Some(0), 1, false);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dag_errors_on_empty_store() {
+        let (chain_store_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+        let store = chain_store_handle.store_handle().store();
+        let result = dag(store, None, 10, false);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_dag_dot_with_genesis() {
+        let (store, _temp_dir) = setup_store_with_genesis().await;
+        let result = dag(&store, Some(0), 1, true);
+        assert!(result.is_ok());
+    }
+
     // --- format_status tests ---
 
     #[test]

--- a/p2poolv2_cli/src/commands/mod.rs
+++ b/p2poolv2_cli/src/commands/mod.rs
@@ -17,6 +17,7 @@
 pub mod api_client;
 pub mod candidates;
 pub mod chain_info;
+pub mod dag;
 pub mod db_query;
 pub mod gen_auth;
 pub mod peers_info;
@@ -105,6 +106,18 @@ pub enum Commands {
         #[arg(short, long, default_value = "false")]
         full: bool,
     },
+    /// Display all share headers at each height in the height index (DAG view)
+    Dag {
+        /// Height to query up to, inclusive. Default is confirmed chain tip.
+        #[arg(short, long)]
+        to: Option<u32>,
+        /// Number of heights to display going back from --to. Default 10.
+        #[arg(short, long, default_value = "10")]
+        num: u32,
+        /// Output as Graphviz DOT format DAG (requires --db-path)
+        #[arg(short, long, default_value = "false")]
+        dot: bool,
+    },
     /// Show connected peers by querying the running node's API
     PeersInfo,
     /// Generate API authentication credentials (salt, password, HMAC)
@@ -131,7 +144,8 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
             | Commands::PplnsShares { .. }
             | Commands::Shares { .. }
             | Commands::Candidates { .. }
-            | Commands::Share { .. },
+            | Commands::Share { .. }
+            | Commands::Dag { .. },
         ) => {
             if let Some(db_path) = &cli.db_path {
                 // Direct database query mode (offline, no running node required)
@@ -169,6 +183,9 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                     }
                     Some(Commands::Share { hash, height, full }) => {
                         commands::db_query::share_lookup(&store, hash.clone(), *height, *full)?;
+                    }
+                    Some(Commands::Dag { to, num, dot }) => {
+                        commands::db_query::dag(&store, *to, *num, *dot)?;
                     }
                     _ => unreachable!(),
                 }
@@ -221,6 +238,9 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                     }
                     Some(Commands::Share { hash, height, full }) => {
                         commands::share::execute(&config.api, hash.clone(), *height, *full).await?;
+                    }
+                    Some(Commands::Dag { to, num, dot: _ }) => {
+                        commands::dag::execute(&config.api, *to, *num).await?;
                     }
                     _ => unreachable!(),
                 }

--- a/p2poolv2_lib/src/node/behaviour/mod.rs
+++ b/p2poolv2_lib/src/node/behaviour/mod.rs
@@ -59,7 +59,7 @@ pub enum P2PoolBehaviourEvent {
 #[allow(dead_code)]
 impl P2PoolBehaviour {
     pub fn new(local_key: &Keypair, config: &Config) -> Result<Self, Box<dyn Error>> {
-        // Initialize Kademlia
+        // Initialise Kademlia
         let store = MemoryStore::new(local_key.public().to_peer_id());
         let mut kad_config = kad::Config::default();
         kad_config.set_query_timeout(tokio::time::Duration::from_secs(60));

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -68,9 +68,9 @@ impl ChainStoreHandle {
         }
     }
 
-    /// Initialize the chain from an existing store or set up genesis.
+    /// Initialise the chain from an existing store or set up genesis.
     ///
-    /// If genesis is already in store, initializes chain state from existing data.
+    /// If genesis is already in store, initialises chain state from existing data.
     /// Otherwise, adds genesis block to create a new chain.
     pub async fn init_or_setup_genesis(&self, genesis_block: ShareBlock) -> Result<(), StoreError> {
         let genesis_block_hash = genesis_block.header.block_hash();
@@ -80,7 +80,7 @@ impl ChainStoreHandle {
             // Set up new chain with genesis
             self.add_share_block(genesis_block).await?;
         } else {
-            // Initialize chain state from existing store data
+            // Initialise chain state from existing store data
             self.store_handle
                 .init_chain_state_from_store(genesis_block_hash)
                 .await?;

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -182,7 +182,7 @@ pub trait ShareValidator {
 
 /// Production implementation of ShareValidator.
 ///
-/// Stores a `PoolDifficulty` instance initialized at construction time,
+/// Stores a `PoolDifficulty` instance initialised at construction time,
 /// avoiding repeated builds on each validation call.
 pub struct DefaultShareValidator {
     pool_difficulty: PoolDifficulty,

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -20,6 +20,7 @@ use crate::shares::chain::chain_store_handle::{COMMON_ANCESTOR_DEPTH, ConfirmedH
 use crate::shares::share_block::{ShareBlock, ShareHeader};
 use crate::shares::validation::MAX_UNCLES;
 use bitcoin::consensus::{self, Encodable, encode};
+use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, CompactTarget, Work};
 use serde::Serialize;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -603,6 +604,66 @@ impl Store {
         let header_map = self.fetch_header_map(&candidate_chain)?;
         Ok(self.assemble_share_infos(&candidate_chain, &header_map))
     }
+
+    /// Query ALL share headers in the height index for a range of heights.
+    ///
+    /// Unlike query_shares/query_candidates which only return confirmed or
+    /// candidate chain entries, this returns every block at each height
+    /// regardless of status (Confirmed, Candidate, HeaderValid, etc.).
+    pub fn query_dag(&self, from_height: u32, to_height: u32) -> Vec<DagEntry> {
+        let estimated_capacity = ((to_height - from_height + 1) * 2) as usize;
+        let mut entries = Vec::with_capacity(estimated_capacity);
+
+        let mut height = from_height;
+        while height <= to_height {
+            let blockhashes = self.get_blockhashes_for_height(height);
+            for blockhash in &blockhashes {
+                let status = self
+                    .get_block_metadata(blockhash)
+                    .map(|metadata| format!("{:?}", metadata.status))
+                    .unwrap_or_else(|_| "Unknown".to_string());
+
+                let (parent, uncles, miner_address) = match self.get_share_header(blockhash) {
+                    Ok(Some(header)) => (
+                        header.prev_share_blockhash,
+                        header.uncles.clone(),
+                        header.miner_bitcoin_address.to_string(),
+                    ),
+                    _ => (BlockHash::all_zeros(), vec![], "unknown".to_string()),
+                };
+
+                let has_block_data = self.share_block_exists(blockhash);
+
+                entries.push(DagEntry {
+                    blockhash: *blockhash,
+                    height,
+                    status,
+                    parent,
+                    uncles,
+                    miner_address,
+                    has_block_data,
+                });
+            }
+            height += 1;
+        }
+
+        entries
+    }
+}
+
+/// Entry representing a single share header at a height in the DAG.
+///
+/// Includes all blocks at that height regardless of chain status,
+/// useful for debugging fork structure and missing block data.
+#[derive(Clone, Debug, Serialize)]
+pub struct DagEntry {
+    pub blockhash: BlockHash,
+    pub height: u32,
+    pub status: String,
+    pub parent: BlockHash,
+    pub uncles: Vec<BlockHash>,
+    pub miner_address: String,
+    pub has_block_data: bool,
 }
 
 #[cfg(test)]

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -2880,4 +2880,102 @@ mod tests {
         let result = store.first_confirmed_for_locator(&locator);
         assert_eq!(result, Some(share_a.block_hash()));
     }
+
+    // --- query_dag tests ---
+
+    #[test]
+    fn test_query_dag_returns_genesis() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let entries = store.query_dag(0, 0);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].blockhash, genesis.block_hash());
+        assert_eq!(entries[0].height, 0);
+        assert_eq!(entries[0].status, "Confirmed");
+        assert!(entries[0].has_block_data);
+    }
+
+    #[test]
+    fn test_query_dag_returns_multiple_blocks_at_same_height() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Two blocks at height 1 with same parent (genesis)
+        let share_a = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695792)
+            .build();
+        store.push_to_confirmed_chain(&share_a).unwrap();
+
+        let share_b = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695793)
+            .build();
+
+        // Store block + organise header so it appears in height index
+        let mut batch = Store::get_write_batch();
+        store.add_share_block(&share_b, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+        let mut batch = Store::get_write_batch();
+        store.organise_header(&share_b.header, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let entries = store.query_dag(1, 1);
+        assert_eq!(entries.len(), 2);
+
+        let hashes: Vec<BlockHash> = entries.iter().map(|e| e.blockhash).collect();
+        assert!(hashes.contains(&share_a.block_hash()));
+        assert!(hashes.contains(&share_b.block_hash()));
+    }
+
+    #[test]
+    fn test_query_dag_returns_empty_for_unpopulated_heights() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Query heights above the chain -- should return empty
+        let entries = store.query_dag(5, 10);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_query_dag_shows_has_block_data_false_for_header_only() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Organise header only (no block data stored)
+        let share = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695792)
+            .build();
+        let mut batch = Store::get_write_batch();
+        store.organise_header(&share.header, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let entries = store.query_dag(1, 1);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].blockhash, share.block_hash());
+        assert!(!entries[0].has_block_data);
+    }
 }

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -180,7 +180,7 @@ impl Store {
         let store = Self {
             path,
             db,
-            // Initialize chain state fields
+            // Initialise chain state fields
             genesis_blockhash: Arc::new(RwLock::new(None)),
         };
         Ok(store)
@@ -310,12 +310,12 @@ impl Store {
         Ok(())
     }
 
-    /// Initialize chain state from existing data in the store.
+    /// Initialise chain state from existing data in the store.
     /// Sets the genesis blockhash so chain tip and total work can be read from the confirmed chain index.
     pub fn init_chain_state_from_store(&self, genesis_hash: BlockHash) -> Result<(), StoreError> {
         self.set_genesis_blockhash(genesis_hash);
         debug!(
-            "Initialized chain state: tip={}, height={}, work={}",
+            "Initialised chain state: tip={}, height={}, work={}",
             self.get_chain_tip()?,
             self.get_top_confirmed_height()?,
             self.get_total_work()?,

--- a/p2poolv2_lib/src/store/writer/handle.rs
+++ b/p2poolv2_lib/src/store/writer/handle.rs
@@ -281,7 +281,7 @@ impl StoreHandle {
         reply_rx.await.map_err(|_| StoreError::ChannelClosed)?
     }
 
-    /// Initialize chain state from store.
+    /// Initialise chain state from store.
     pub async fn init_chain_state_from_store(
         &self,
         genesis_hash: BlockHash,

--- a/p2poolv2_lib/src/store/writer/mod.rs
+++ b/p2poolv2_lib/src/store/writer/mod.rs
@@ -109,7 +109,7 @@ pub enum WriteCommand {
         reply: oneshot::Sender<Result<(), StoreError>>,
     },
 
-    /// Initialize chain state from store
+    /// Initialise chain state from store
     InitChainStateFromStore {
         genesis_hash: BlockHash,
         reply: oneshot::Sender<Result<(), StoreError>>,

--- a/p2poolv2_lib/src/stratum/difficulty_adjuster/mod.rs
+++ b/p2poolv2_lib/src/stratum/difficulty_adjuster/mod.rs
@@ -194,7 +194,7 @@ impl DifficultyAdjusterTrait for DifficultyAdjuster {
     ) -> (Option<u64>, bool) {
         let mut first_share = false;
 
-        // If this is the first share, initialize timestamps
+        // If this is the first share, initialise timestamps
         if self.first_share_timestamp.is_none() {
             debug!("First share submission received, initializing timestamps.");
             self.first_share_timestamp = Some(current_timestamp);
@@ -492,7 +492,7 @@ mod tests {
         let mut adjuster = DifficultyAdjuster::new(start_difficulty, min_diff, Some(100000));
         let current_timestamp = SystemTime::now();
 
-        // Submit first share to initialize
+        // Submit first share to initialise
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None, current_timestamp);
 
         // Submit several shares but less than MIN_SHARES_BEFORE_ADJUST
@@ -521,7 +521,7 @@ mod tests {
         let mut adjuster = DifficultyAdjuster::new(start_difficulty, min_diff, Some(100000));
         let current_timestamp = SystemTime::now();
 
-        // Submit first share to initialize
+        // Submit first share to initialise
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None, current_timestamp);
 
         // Force the timestamps to be old enough to trigger adjustment
@@ -658,7 +658,7 @@ mod tests {
         let mut adjuster = DifficultyAdjuster::new(1000, min_diff, Some(100000));
         let current_timestamp = SystemTime::now();
 
-        // Submit first share to initialize
+        // Submit first share to initialise
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None, current_timestamp);
 
         // Simulate a miner with low performance
@@ -716,7 +716,7 @@ mod tests {
         let mut adjuster = DifficultyAdjuster::new(100, min_diff, Some(100_000));
         let current_timestamp = SystemTime::now();
 
-        // Submit first share to initialize
+        // Submit first share to initialise
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None, current_timestamp);
 
         // Set a 30-minute-old first share time to get bias close to 1.0
@@ -743,7 +743,7 @@ mod tests {
         let mut adjuster = DifficultyAdjuster::new(100, min_diff, Some(100000));
         let current_timestamp = SystemTime::now();
 
-        // Submit first share to initialize
+        // Submit first share to initialise
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None, current_timestamp);
 
         // Set bias close to 1.0 with an old first share time
@@ -767,7 +767,7 @@ mod tests {
         let mut adjuster = DifficultyAdjuster::new(100, min_diff, Some(100000));
         let current_timestamp = SystemTime::now();
 
-        // Submit first share to initialize
+        // Submit first share to initialise
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None, current_timestamp);
 
         // Set a first share time that's recent (1 minute ago)

--- a/p2poolv2_node/src/main.rs
+++ b/p2poolv2_node/src/main.rs
@@ -124,12 +124,12 @@ async fn main() -> ExitCode {
     let store_handle = StoreHandle::new(store.clone(), write_tx);
     let chain_store_handle = ChainStoreHandle::new(store_handle, config.stratum.network);
 
-    // Initialize chain with genesis (async)
+    // Initialise chain with genesis (async)
     if let Err(e) = chain_store_handle
         .init_or_setup_genesis(genesis.clone())
         .await
     {
-        error!("Failed to initialize chain: {e}");
+        error!("Failed to initialise chain: {e}");
         return ExitCode::FAILURE;
     }
 


### PR DESCRIPTION
The other commands shares and candidates only query confirmed and candidate indexes respectively.

This command queries all shares within a given height range irrespective of their status.