### PR TITLE
Fix merge operator bug

### DIFF
--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -118,7 +118,8 @@ pub async fn handle_share_headers<C: Send + Sync>(
 /// 1. Every header passes validate_header_minimum_difficulty
 /// 2. Every header's prev_share_blockhash references the anchor or another header in the batch
 /// 3. Main chain headers have bits matching ASERT-computed target
-/// 4. Cumulative work of extended main chain exceeds MIN_CUMULATIVE_CHAIN_WORK
+/// 4. Verifies all uncles have been received and stored [don't need to candidated or confirmed]
+/// 5. Cumulative work of extended main chain exceeds MIN_CUMULATIVE_CHAIN_WORK
 fn validate_header_chain(
     share_headers: &[ShareHeader],
     chain_store_handle: &ChainStoreHandle,

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -53,32 +53,52 @@ pub struct Store {
     genesis_blockhash: Arc<RwLock<Option<BlockHash>>>,
 }
 
-/// Merge operator for appending BlockHashes to a Vec<BlockHash>
-/// This allows atomic append operations without read-modify-write cycles
+/// Merge operator for appending BlockHashes to a Vec<BlockHash>.
+///
+/// This allows atomic append operations without read-modify-write cycles.
+///
+/// Registered via `set_merge_operator_associative`, so the same function
+/// handles both full merge and partial merge:
+/// - Full merge: `existing_val` is the base value from a prior Put/merge
+///   result (a serialized `Vec<BlockHash>`) or `None`.
+/// - Partial merge: `existing_val` is `Some(left_operand)` where the left
+///   operand may be a raw 32-byte `BlockHash` OR a previously merged
+///   `Vec<BlockHash>`. Operands may also be either format.
+///
+/// Each value passed in (existing_val or operand) is parsed by trying
+/// `Vec<BlockHash>` first, then falling back to a single `BlockHash`.
 fn blockhash_list_merge(
     _key: &[u8],
     existing_val: Option<&[u8]>,
     operands: &rocksdb::MergeOperands,
 ) -> Option<Vec<u8>> {
-    // Deserialize existing vector or start with empty
     let mut blockhashes: Vec<BlockHash> = existing_val
-        .and_then(|bytes| encode::deserialize(bytes).ok())
+        .map(|bytes| parse_blockhash_bytes(bytes))
         .unwrap_or_default();
 
-    // Process each merge operand (each is a single BlockHash to append)
     for op in operands {
-        if let Ok(new_hash) = encode::deserialize::<BlockHash>(op) {
-            // Only add if not already present
-            if !blockhashes.contains(&new_hash) {
-                blockhashes.push(new_hash);
+        for hash in parse_blockhash_bytes(op) {
+            if !blockhashes.contains(&hash) {
+                blockhashes.push(hash);
             }
         }
     }
 
-    // Serialize the result
     let mut result = Vec::new();
     blockhashes.consensus_encode(&mut result).ok()?;
     Some(result)
+}
+
+/// Parse bytes as either a serialized `Vec<BlockHash>` (with compact_size
+/// length prefix) or a single raw 32-byte `BlockHash`.
+fn parse_blockhash_bytes(bytes: &[u8]) -> Vec<BlockHash> {
+    if let Ok(hashes) = encode::deserialize::<Vec<BlockHash>>(bytes) {
+        return hashes;
+    }
+    if let Ok(hash) = encode::deserialize::<BlockHash>(bytes) {
+        return vec![hash];
+    }
+    Vec::new()
 }
 
 /// A rocksdb based store for share blocks.
@@ -424,6 +444,7 @@ mod tests {
     use super::*;
     use crate::test_utils::TestShareBlockBuilder;
     use crate::test_utils::multiplied_compact_target_as_work;
+    use bitcoin::consensus;
     use bitcoin::hashes::Hash;
     use tempfile::tempdir;
 
@@ -573,6 +594,110 @@ mod tests {
         assert!(hashes.contains(&hash1));
         assert!(hashes.contains(&hash2));
         assert!(hashes.contains(&hash3));
+    }
+
+    /// Tests parse_blockhash_bytes handles both formats correctly.
+    ///
+    /// In partial merge mode, RocksDB passes raw 32-byte BlockHash
+    /// operands. In full merge mode, existing_val is a serialized
+    /// Vec<BlockHash>. The parse function must handle both.
+    #[test]
+    fn test_parse_blockhash_bytes_handles_raw_and_vec_formats() {
+        let hash1 = BlockHash::from_byte_array([0xAAu8; 32]);
+        let hash2 = BlockHash::from_byte_array([0xBBu8; 32]);
+
+        // Raw 32-byte operand (as seen in partial merge)
+        let raw_operand = consensus::serialize(&hash1);
+        assert_eq!(raw_operand.len(), 32);
+        let parsed = parse_blockhash_bytes(&raw_operand);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0], hash1);
+
+        // Serialized Vec<BlockHash> (as seen in full merge existing_val)
+        let vec_value = consensus::serialize(&vec![hash1, hash2]);
+        assert_eq!(vec_value.len(), 65); // compact_size(2) + 32 + 32
+        let parsed = parse_blockhash_bytes(&vec_value);
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed.contains(&hash1));
+        assert!(parsed.contains(&hash2));
+
+        // Empty input
+        let parsed = parse_blockhash_bytes(&[]);
+        assert!(parsed.is_empty());
+    }
+
+    /// Tests the merge operator with compaction forcing SST-level merges.
+    ///
+    /// Writes two hashes at the same height in separate flushes, then
+    /// compacts. In a fresh DB compaction reaches the bottommost level
+    /// (full merge with existing_val=None), so both hashes survive.
+    /// This test verifies the baseline full-merge path works.
+    #[test]
+    fn test_merge_operator_survives_compaction() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let height = 3224u32;
+        let hash1 = BlockHash::from_byte_array([0xAAu8; 32]);
+        let hash2 = BlockHash::from_byte_array([0xBBu8; 32]);
+
+        // Write hash1 in its own batch and flush to an SST file
+        let mut batch = Store::get_write_batch();
+        store
+            .set_height_to_blockhash(&hash1, height, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+        let block_height_cf = store.db.cf_handle(&ColumnFamily::BlockHeight).unwrap();
+        store
+            .db
+            .flush_cf(&block_height_cf)
+            .expect("flush should succeed");
+
+        // Write hash2 in a separate batch and flush to a second SST file
+        let mut batch = Store::get_write_batch();
+        store
+            .set_height_to_blockhash(&hash2, height, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+        store
+            .db
+            .flush_cf(&block_height_cf)
+            .expect("flush should succeed");
+
+        // Force compaction -- this triggers partial merge on the two
+        // merge operands sitting in separate SST files
+        store
+            .db
+            .compact_range_cf(&block_height_cf, None::<&[u8]>, None::<&[u8]>);
+
+        // After compaction, both hashes must still be present
+        let hashes = store.get_blockhashes_for_height(height);
+        assert_eq!(
+            hashes.len(),
+            2,
+            "Both hashes should survive compaction, got: {:?}",
+            hashes
+        );
+        assert!(hashes.contains(&hash1), "hash1 lost after compaction");
+        assert!(hashes.contains(&hash2), "hash2 lost after compaction");
+    }
+
+    /// Verifies that parse_blockhash_bytes correctly handles a
+    /// partial-merge result (serialized Vec) appearing as an operand.
+    #[test]
+    fn test_parse_blockhash_bytes_handles_partial_merge_result_as_operand() {
+        let hash1 = BlockHash::from_byte_array([0xCCu8; 32]);
+        let hash2 = BlockHash::from_byte_array([0xDDu8; 32]);
+
+        // A partial merge result is a serialized Vec<BlockHash>
+        let partial_merge_result = consensus::serialize(&vec![hash1, hash2]);
+        assert_eq!(partial_merge_result.len(), 65);
+
+        // parse_blockhash_bytes must extract both hashes
+        let parsed = parse_blockhash_bytes(&partial_merge_result);
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed.contains(&hash1));
+        assert!(parsed.contains(&hash2));
     }
 
     #[test]

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -72,12 +72,13 @@ fn blockhash_list_merge(
     existing_val: Option<&[u8]>,
     operands: &rocksdb::MergeOperands,
 ) -> Option<Vec<u8>> {
-    let mut blockhashes: Vec<BlockHash> = existing_val
-        .map(|bytes| parse_blockhash_bytes(bytes))
-        .unwrap_or_default();
+    let mut blockhashes: Vec<BlockHash> = match existing_val {
+        Some(bytes) => parse_blockhash_bytes(bytes)?,
+        None => Vec::new(),
+    };
 
     for op in operands {
-        for hash in parse_blockhash_bytes(op) {
+        for hash in parse_blockhash_bytes(op)? {
             if !blockhashes.contains(&hash) {
                 blockhashes.push(hash);
             }
@@ -91,14 +92,17 @@ fn blockhash_list_merge(
 
 /// Parse bytes as either a serialized `Vec<BlockHash>` (with compact_size
 /// length prefix) or a single raw 32-byte `BlockHash`.
-fn parse_blockhash_bytes(bytes: &[u8]) -> Vec<BlockHash> {
+///
+/// Returns `None` on unrecognised input so the merge operator can
+/// propagate the failure to RocksDB instead of silently discarding data.
+fn parse_blockhash_bytes(bytes: &[u8]) -> Option<Vec<BlockHash>> {
     if let Ok(hashes) = encode::deserialize::<Vec<BlockHash>>(bytes) {
-        return hashes;
+        return Some(hashes);
     }
     if let Ok(hash) = encode::deserialize::<BlockHash>(bytes) {
-        return vec![hash];
+        return Some(vec![hash]);
     }
-    Vec::new()
+    None
 }
 
 /// A rocksdb based store for share blocks.
@@ -609,21 +613,23 @@ mod tests {
         // Raw 32-byte operand (as seen in partial merge)
         let raw_operand = consensus::serialize(&hash1);
         assert_eq!(raw_operand.len(), 32);
-        let parsed = parse_blockhash_bytes(&raw_operand);
+        let parsed = parse_blockhash_bytes(&raw_operand).expect("raw 32-byte operand should parse");
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0], hash1);
 
         // Serialized Vec<BlockHash> (as seen in full merge existing_val)
         let vec_value = consensus::serialize(&vec![hash1, hash2]);
         assert_eq!(vec_value.len(), 65); // compact_size(2) + 32 + 32
-        let parsed = parse_blockhash_bytes(&vec_value);
+        let parsed = parse_blockhash_bytes(&vec_value).expect("serialized Vec should parse");
         assert_eq!(parsed.len(), 2);
         assert!(parsed.contains(&hash1));
         assert!(parsed.contains(&hash2));
 
-        // Empty input
-        let parsed = parse_blockhash_bytes(&[]);
-        assert!(parsed.is_empty());
+        // Empty input returns None (unrecognised format)
+        assert!(parse_blockhash_bytes(&[]).is_none());
+
+        // Garbage input returns None
+        assert!(parse_blockhash_bytes(&[0xFF, 0xFF, 0xFF]).is_none());
     }
 
     /// Tests the merge operator with compaction forcing SST-level merges.
@@ -694,7 +700,8 @@ mod tests {
         assert_eq!(partial_merge_result.len(), 65);
 
         // parse_blockhash_bytes must extract both hashes
-        let parsed = parse_blockhash_bytes(&partial_merge_result);
+        let parsed = parse_blockhash_bytes(&partial_merge_result)
+            .expect("partial merge result should parse");
         assert_eq!(parsed.len(), 2);
         assert!(parsed.contains(&hash1));
         assert!(parsed.contains(&hash2));

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -90,19 +90,27 @@ fn blockhash_list_merge(
     Some(result)
 }
 
-/// Parse bytes as either a serialized `Vec<BlockHash>` (with compact_size
-/// length prefix) or a single raw 32-byte `BlockHash`.
+/// Parse bytes as either a single raw 32-byte `BlockHash` or a
+/// serialized `Vec<BlockHash>` (compact_size length prefix + N hashes).
+///
+/// Disambiguation is by length: a raw `BlockHash` is always exactly
+/// 32 bytes, while a serialized `Vec<BlockHash>` is never 32 bytes
+/// (0 elements = 1 byte, 1 element = 33 bytes, 2 elements = 65 bytes,
+/// etc.). This avoids relying on `encode::deserialize` trial order,
+/// which is unsafe because `deserialize` does not require full input
+/// consumption -- a 32-byte hash starting with 0x00 would decode as
+/// an empty Vec, silently losing the hash.
 ///
 /// Returns `None` on unrecognised input so the merge operator can
 /// propagate the failure to RocksDB instead of silently discarding data.
 fn parse_blockhash_bytes(bytes: &[u8]) -> Option<Vec<BlockHash>> {
-    if let Ok(hashes) = encode::deserialize::<Vec<BlockHash>>(bytes) {
-        return Some(hashes);
-    }
-    if let Ok(hash) = encode::deserialize::<BlockHash>(bytes) {
+    const BLOCKHASH_LEN: usize = 32;
+    if bytes.len() == BLOCKHASH_LEN {
+        let hash = encode::deserialize::<BlockHash>(bytes).ok()?;
         return Some(vec![hash]);
     }
-    None
+    let hashes = encode::deserialize::<Vec<BlockHash>>(bytes).ok()?;
+    Some(hashes)
 }
 
 /// A rocksdb based store for share blocks.
@@ -624,6 +632,15 @@ mod tests {
         assert_eq!(parsed.len(), 2);
         assert!(parsed.contains(&hash1));
         assert!(parsed.contains(&hash2));
+
+        // Hash with 0x00 first byte must NOT be misread as empty Vec
+        let mut zero_prefix_bytes = [0x00u8; 32];
+        zero_prefix_bytes[31] = 0x42;
+        let zero_prefix_hash = BlockHash::from_byte_array(zero_prefix_bytes);
+        let raw_zero = consensus::serialize(&zero_prefix_hash);
+        let parsed = parse_blockhash_bytes(&raw_zero).expect("0x00-prefixed hash should parse");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0], zero_prefix_hash);
 
         // Empty input returns None (unrecognised format)
         assert!(parse_blockhash_bytes(&[]).is_none());

--- a/p2poolv2_node/src/verify_chain.rs
+++ b/p2poolv2_node/src/verify_chain.rs
@@ -294,12 +294,16 @@ fn main() {
                 ));
             }
 
-            // 10d. Uncle is ancestor-type (its parent is an ancestor of the nephew)
+            // 10d. Uncle parent ancestry check (informational)
+            // An uncle's parent does NOT have to be on the confirmed chain.
+            // Deep-fork uncles (whose parents were never confirmed) are valid
+            // as long as the uncle itself has valid PoW and is at an ancestor
+            // height. This is a warning, not an error.
             if let Some(uncle_hdr) = &uncle_header {
                 let uncle_parent = uncle_hdr.prev_share_blockhash;
                 if !is_uncle_ancestor_type(&uncle_parent, height, &confirmed_hashes) {
-                    summary.error(format!(
-                        "h:{height} {blockhash} - uncle {uncle_hash} parent {uncle_parent} is not an ancestor on confirmed chain (uncle should be an ancestor, not a sibling)"
+                    summary.warn(format!(
+                        "h:{height} {blockhash} - uncle {uncle_hash} parent {uncle_parent} is not on confirmed chain (deep-fork uncle)"
                     ));
                 }
 


### PR DESCRIPTION
They were quitely failing on production when levels increase under
traffic. The quite failures left the dag in an unsyncable state and
there was no panic or error logging.

The fix is to fix the merge operator so it can handle a single blockhash
and a vector of blockhashes.