### PR TITLE
Include uncles recursively in share headers response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.10.10] - 2026-05-06
+
 ### Fixed
 
 - Locator response now starts the confirmed chain walk from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sync attempt during handshake left the node permanently stuck with
   no recovery path.
 
+- Locator response now chases transitive uncle references
+  (uncle-of-uncle chains) so the receiver has all declared uncle
+  bodies available. Previously only direct uncles of confirmed blocks
+  were included, causing "Declared uncle not delivered in batch"
+  errors when an uncle itself referenced another uncle.
+
 ## [v0.10.9] - 2026-05-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindrpc"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3252,7 +3252,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2poolv2_api"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_cli"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_config"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_lib"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_node"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_tests"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.9"
+version = "0.10.10"
 edition = "2024"
 authors = ["Kulpreet Singh<kp@opdup.com>"]
 license = "AGPL-3.0-or-later"

--- a/p2poolv2_lib/src/shares/genesis/mod.rs
+++ b/p2poolv2_lib/src/shares/genesis/mod.rs
@@ -50,7 +50,7 @@ const TESTNET4_GENESIS_DATA: GenesisData = GenesisData {
     // for bitcoin blockhash 00000000000000013c0a1f4152b458118ed666282e6235d744bf2a5d66ecf022
     bitcoin_block_hex: include!("testnet4.rs"),
     bitcoin_height: 130754,
-    timestamp: 1777757400,
+    timestamp: 1778097600,
 };
 
 // Using the following JSON data for the genesis block

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -1085,6 +1085,94 @@ mod tests {
         assert_eq!(descendants[0], share_a.block_hash());
     }
 
+    /// Uncle-of-uncle test: when a confirmed block references an uncle
+    /// that itself references another uncle, both are included in the
+    /// descendant response.
+    ///
+    /// Chain:
+    ///   genesis(h:0) -> A(h:1) -> B(h:2, uncles=[uncle1])
+    ///                \-> uncle2(h:1)
+    ///                \-> uncle1(h:1, uncles=[uncle2])
+    ///
+    /// uncle1 is referenced by B. uncle1 references uncle2.
+    /// Both uncle1 and uncle2 must appear in descendants.
+    #[test]
+    fn test_get_descendant_blockhashes_chases_uncle_of_uncle() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // uncle2: child of genesis, no uncles of its own
+        let uncle2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(200)
+            .build();
+        store.store_with_valid_metadata(&uncle2);
+
+        // uncle1: child of genesis, references uncle2
+        let uncle1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .uncles(vec![uncle2.block_hash()])
+            .nonce(100)
+            .build();
+        store.store_with_valid_metadata(&uncle1);
+
+        // A: confirmed at h:1
+        let share_a = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .work(2)
+            .nonce(1)
+            .build();
+        store.push_to_confirmed_chain(&share_a).unwrap();
+
+        // B: confirmed at h:2, references uncle1
+        let share_b = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share_a.block_hash().to_string())
+            .uncles(vec![uncle1.block_hash()])
+            .nonce(2)
+            .build();
+        store.push_to_confirmed_chain(&share_b).unwrap();
+
+        let descendants = store
+            .get_descendant_blockhashes(&genesis.block_hash(), &BlockHash::all_zeros(), 10)
+            .unwrap();
+
+        assert!(
+            descendants.contains(&share_a.block_hash()),
+            "confirmed A should be included"
+        );
+        assert!(
+            descendants.contains(&uncle1.block_hash()),
+            "uncle1 should be included (referenced by B)"
+        );
+        assert!(
+            descendants.contains(&uncle2.block_hash()),
+            "uncle2 should be included (uncle-of-uncle, referenced by uncle1)"
+        );
+        assert!(
+            descendants.contains(&share_b.block_hash()),
+            "confirmed B should be included"
+        );
+
+        // uncle2 must appear before share_b (transitive dependency)
+        let uncle2_pos = descendants
+            .iter()
+            .position(|h| *h == uncle2.block_hash())
+            .unwrap();
+        let share_b_pos = descendants
+            .iter()
+            .position(|h| *h == share_b.block_hash())
+            .unwrap();
+        assert!(
+            uncle2_pos < share_b_pos,
+            "uncle2 must appear before share_b"
+        );
+    }
+
     /// Long chain test: when the anchor is deep in the chain, the
     /// confirmed walk starts from anchor - MAX_UNCLES_DEPTH so that
     /// uncle references near the anchor are served. Blocks before the

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -21,7 +21,7 @@ use crate::store::dag_store::MAX_UNCLES_DEPTH;
 use bitcoin::consensus::{Encodable, encode};
 use bitcoin::{BlockHash, Work};
 use rocksdb::{ColumnFamilyDescriptor, DB, Options as RocksDbOptions};
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::sync::{Arc, RwLock};
 use tracing::debug;
 use writer::StoreError;
@@ -263,16 +263,7 @@ impl Store {
         while height <= top_confirmed_height && blockhashes.len() < limit {
             let confirmed_hash = self.get_confirmed_at_height(height)?;
 
-            // Insert uncle blockhashes before the confirmed block.
-            // We only check the limit at the top of the loop so that a
-            // confirmed block and its uncles are never split across batches.
-            if let Ok(Some(header)) = self.get_share_header(&confirmed_hash) {
-                for uncle_blockhash in &header.uncles {
-                    if seen.insert(*uncle_blockhash) {
-                        blockhashes.push(*uncle_blockhash);
-                    }
-                }
-            }
+            self.collect_uncle_chain(&confirmed_hash, &mut seen, &mut blockhashes);
 
             if seen.insert(confirmed_hash) {
                 blockhashes.push(confirmed_hash);
@@ -286,6 +277,35 @@ impl Store {
         }
 
         Ok(blockhashes)
+    }
+
+    /// Collect uncle blockhashes for a block, chasing transitive
+    /// uncle references (uncle-of-uncle) so the receiver has all
+    /// declared uncles available. The DAG is finite and acyclic, and
+    /// the seen set prevents revisits, so this always terminates.
+    fn collect_uncle_chain(
+        &self,
+        blockhash: &BlockHash,
+        seen: &mut HashSet<BlockHash>,
+        blockhashes: &mut Vec<BlockHash>,
+    ) {
+        let header = match self.get_share_header(blockhash) {
+            Ok(Some(header)) => header,
+            _ => return,
+        };
+        let mut uncle_queue: VecDeque<BlockHash> = header.uncles.iter().copied().collect();
+        while let Some(uncle_hash) = uncle_queue.pop_front() {
+            if seen.insert(uncle_hash) {
+                blockhashes.push(uncle_hash);
+                if let Ok(Some(uncle_header)) = self.get_share_header(&uncle_hash) {
+                    for nested_uncle in &uncle_header.uncles {
+                        if !seen.contains(nested_uncle) {
+                            uncle_queue.push_back(*nested_uncle);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Get genesis block hash from chain state


### PR DESCRIPTION
Include uncles recursively in share headers response so receiving node can validate the confirmed block that references them 