### PR TITLE
refactor(stratum): Respond with industry standard error codes and messages

### DIFF
--- a/p2poolv2_lib/src/stratum/error.rs
+++ b/p2poolv2_lib/src/stratum/error.rs
@@ -14,41 +14,165 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
-use std::fmt;
+use std::fmt::{Display, Formatter, Result};
 
-/// Error types for the Stratum server used to propagate errors and eventually
-/// disconnect misbehaving miners.
-#[derive(Debug)]
+/// Error types for the Stratum server used to propagate internal errors
+/// and eventually disconnect misbehaving miners. Not sent to miners on the wire.
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Invalid stratum method: {0}")]
     InvalidMethod(String),
+    #[error("Invalid parameters provided: {0}")]
     InvalidParams(String),
+    #[error("Authorization failed: {0}")]
     AuthorizationFailure(String),
+    #[error("Submit failure: {0}")]
     SubmitFailure(String),
+    #[error("Subscription failure: {0}")]
     SubscriptionFailure(String),
-    IoError(std::io::Error),
-    InsufficientWork,
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("Timeout Error")]
     TimeoutError,
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidMethod(method) => write!(f, "Invalid stratum method: {method}"),
-            Self::InvalidParams(msg) => write!(f, "Invalid parameters provided: {msg}"),
-            Self::AuthorizationFailure(reason) => write!(f, "Authorization failed: {reason}"),
-            Self::SubmitFailure(reason) => write!(f, "Submit failure: {reason}"),
-            Self::SubscriptionFailure(reason) => write!(f, "Subscription failure: {reason}"),
-            Self::IoError(err) => write!(f, "IO error: {err}"),
-            Self::InsufficientWork => write!(f, "Insufficient work"),
-            Self::TimeoutError => write!(f, "Timeout Error"),
-        }
+/// Stratum V1 JSON-RPC error codes sent to miners.
+///
+/// Share submission codes -9..5 follow ckpool's `share_err` enum
+/// (libckpool.h:340-355). Protocol codes 20-25 follow the blitzpool
+/// convention (eStratumErrorCode.ts). Negative codes -32700..-32600
+/// follow JSON-RPC 2.0.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StratumErrorCode {
+    /// Invalid nonce2 hex length
+    InvalidNonce2 = -9,
+    /// Worker name does not match session
+    WorkerMismatch = -8,
+    /// Missing nonce parameter
+    NoNonce = -7,
+    /// Missing ntime parameter
+    NoNtime = -6,
+    /// Missing nonce2 parameter
+    NoNonce2 = -5,
+    /// Missing job_id parameter
+    NoJobId = -4,
+    /// Missing username parameter
+    NoUsername = -3,
+    /// Submit params array too short
+    InvalidSize = -2,
+    /// Params is not a JSON array
+    NotArray = -1,
+    /// Unknown or expired job ID
+    InvalidJobId = 1,
+    /// Share submitted against a retired job
+    Stale = 2,
+    /// ntime out of allowed range
+    NtimeOutOfRange = 3,
+    /// Duplicate share submission
+    Duplicate = 4,
+    /// Share hash above pool target (below pool difficulty)
+    AboveTarget = 5,
+    /// Catch-all unknown error
+    OtherUnknown = 20,
+    /// Worker not authorized
+    UnauthorizedWorker = 24,
+    /// Must subscribe before submitting shares
+    NotSubscribed = 25,
+    /// Invalid JSON cannot be parsed
+    ParseError = -32700,
+    /// Unknown method name
+    MethodNotFound = -32601,
+    /// Invalid method parameters
+    InvalidParams = -32602,
+}
+
+impl Display for StratumErrorCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let msg = match self {
+            Self::InvalidNonce2 => "Invalid nonce2 length",
+            Self::WorkerMismatch => "Worker mismatch",
+            Self::NoNonce => "No nonce",
+            Self::NoNtime => "No ntime",
+            Self::NoNonce2 => "No nonce2",
+            Self::NoJobId => "No job_id",
+            Self::NoUsername => "No username",
+            Self::InvalidSize => "Invalid array size",
+            Self::NotArray => "Params not array",
+            Self::InvalidJobId => "Invalid JobID",
+            Self::Stale => "Stale",
+            Self::NtimeOutOfRange => "Ntime out of range",
+            Self::Duplicate => "Duplicate",
+            Self::AboveTarget => "Above target",
+            Self::OtherUnknown => "Unknown error",
+            Self::UnauthorizedWorker => "Unauthorized worker",
+            Self::NotSubscribed => "Not subscribed",
+            Self::ParseError => "Parse error",
+            Self::MethodNotFound => "Method not found",
+            Self::InvalidParams => "Invalid params",
+        };
+        f.write_str(msg)
     }
 }
 
-impl std::error::Error for Error {}
+#[cfg(test)]
+mod tests {
+    use std::io;
 
-impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Self {
-        Self::IoError(err)
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        assert_eq!(
+            Error::InvalidMethod("foo".into()).to_string(),
+            "Invalid stratum method: foo"
+        );
+        assert_eq!(
+            Error::InvalidParams("bar".into()).to_string(),
+            "Invalid parameters provided: bar"
+        );
+        assert_eq!(
+            Error::AuthorizationFailure("denied".into()).to_string(),
+            "Authorization failed: denied"
+        );
+        assert_eq!(Error::TimeoutError.to_string(), "Timeout Error");
+    }
+
+    #[test]
+    fn test_error_code_values() {
+        assert_eq!(StratumErrorCode::Duplicate as i32, 4);
+        assert_eq!(StratumErrorCode::AboveTarget as i32, 5);
+        assert_eq!(StratumErrorCode::Stale as i32, 2);
+        assert_eq!(StratumErrorCode::InvalidJobId as i32, 1);
+        assert_eq!(StratumErrorCode::UnauthorizedWorker as i32, 24);
+        assert_eq!(StratumErrorCode::NotSubscribed as i32, 25);
+        assert_eq!(StratumErrorCode::ParseError as i32, -32700);
+        assert_eq!(StratumErrorCode::OtherUnknown as i32, 20);
+    }
+
+    #[test]
+    fn test_error_code_display() {
+        assert_eq!(StratumErrorCode::Duplicate.to_string(), "Duplicate");
+        assert_eq!(StratumErrorCode::AboveTarget.to_string(), "Above target");
+        assert_eq!(StratumErrorCode::Stale.to_string(), "Stale");
+        assert_eq!(StratumErrorCode::InvalidJobId.to_string(), "Invalid JobID");
+        assert_eq!(
+            StratumErrorCode::UnauthorizedWorker.to_string(),
+            "Unauthorized worker"
+        );
+        assert_eq!(
+            StratumErrorCode::NotSubscribed.to_string(),
+            "Not subscribed"
+        );
+        assert_eq!(StratumErrorCode::ParseError.to_string(), "Parse error");
+        assert_eq!(StratumErrorCode::OtherUnknown.to_string(), "Unknown error");
+    }
+
+    #[test]
+    fn test_io_error_conversion() {
+        let io_err = io::Error::other("test");
+        let err: Error = io_err.into();
+        assert!(matches!(err, Error::IoError(_)));
+        assert_eq!(err.to_string(), "IO error: test");
     }
 }

--- a/p2poolv2_lib/src/stratum/error.rs
+++ b/p2poolv2_lib/src/stratum/error.rs
@@ -38,23 +38,21 @@ pub enum Error {
 
 /// Stratum V1 JSON-RPC error codes sent to miners.
 ///
-/// Share submission codes 1..5 follow ckpool's `share_err` enum
-/// (libckpool.h:340-355). Protocol codes 20-25 follow the blitzpool
-/// convention (eStratumErrorCode.ts). Negative codes -32700..-32600
-/// follow JSON-RPC 2.0.
+/// Codes 20-25 follow the stratum v1 convention from slush
+/// https://web.archive.org/web/20240225191319/https://braiins.com/stratum-v1/docs
+///
+/// Minimal negative codes -32700..-32600 from JSON-RPC 2.0 convention.
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StratumErrorCode {
-    /// Unknown or expired job ID
-    InvalidJobId = 1,
-    /// Share submitted against a retired job
-    Stale = 2,
-    /// Duplicate share submission
-    Duplicate = 4,
-    /// Share hash above pool target (below pool difficulty)
-    AboveTarget = 5,
     /// Catch-all unknown error
     OtherUnknown = 20,
+    /// Job not found or stale
+    JobNotFound = 21,
+    /// Duplicate share submission
+    DuplicateShare = 22,
+    /// Share hash does not meet pool difficulty
+    LowDifficultyShare = 23,
     /// Worker not authorized
     UnauthorizedWorker = 24,
     /// Must subscribe before submitting shares
@@ -68,11 +66,10 @@ pub enum StratumErrorCode {
 impl Display for StratumErrorCode {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let msg = match self {
-            Self::InvalidJobId => "Invalid JobID",
-            Self::Stale => "Stale",
-            Self::Duplicate => "Duplicate",
-            Self::AboveTarget => "Above target",
-            Self::OtherUnknown => "Unknown error",
+            Self::OtherUnknown => "Other/Unknown",
+            Self::JobNotFound => "Job not found",
+            Self::DuplicateShare => "Duplicate share",
+            Self::LowDifficultyShare => "Low difficulty share",
             Self::UnauthorizedWorker => "Unauthorized worker",
             Self::NotSubscribed => "Not subscribed",
             Self::ParseError => "Parse error",
@@ -107,23 +104,28 @@ mod tests {
 
     #[test]
     fn test_error_code_values() {
-        assert_eq!(StratumErrorCode::Duplicate as i32, 4);
-        assert_eq!(StratumErrorCode::AboveTarget as i32, 5);
-        assert_eq!(StratumErrorCode::Stale as i32, 2);
-        assert_eq!(StratumErrorCode::InvalidJobId as i32, 1);
+        assert_eq!(StratumErrorCode::OtherUnknown as i32, 20);
+        assert_eq!(StratumErrorCode::JobNotFound as i32, 21);
+        assert_eq!(StratumErrorCode::DuplicateShare as i32, 22);
+        assert_eq!(StratumErrorCode::LowDifficultyShare as i32, 23);
         assert_eq!(StratumErrorCode::UnauthorizedWorker as i32, 24);
         assert_eq!(StratumErrorCode::NotSubscribed as i32, 25);
         assert_eq!(StratumErrorCode::ParseError as i32, -32700);
-        assert_eq!(StratumErrorCode::OtherUnknown as i32, 20);
         assert_eq!(StratumErrorCode::MethodNotFound as i32, -32601);
     }
 
     #[test]
     fn test_error_code_display() {
-        assert_eq!(StratumErrorCode::Duplicate.to_string(), "Duplicate");
-        assert_eq!(StratumErrorCode::AboveTarget.to_string(), "Above target");
-        assert_eq!(StratumErrorCode::Stale.to_string(), "Stale");
-        assert_eq!(StratumErrorCode::InvalidJobId.to_string(), "Invalid JobID");
+        assert_eq!(StratumErrorCode::OtherUnknown.to_string(), "Other/Unknown");
+        assert_eq!(StratumErrorCode::JobNotFound.to_string(), "Job not found");
+        assert_eq!(
+            StratumErrorCode::DuplicateShare.to_string(),
+            "Duplicate share"
+        );
+        assert_eq!(
+            StratumErrorCode::LowDifficultyShare.to_string(),
+            "Low difficulty share"
+        );
         assert_eq!(
             StratumErrorCode::UnauthorizedWorker.to_string(),
             "Unauthorized worker"
@@ -133,7 +135,6 @@ mod tests {
             "Not subscribed"
         );
         assert_eq!(StratumErrorCode::ParseError.to_string(), "Parse error");
-        assert_eq!(StratumErrorCode::OtherUnknown.to_string(), "Unknown error");
         assert_eq!(
             StratumErrorCode::MethodNotFound.to_string(),
             "Method not found"

--- a/p2poolv2_lib/src/stratum/error.rs
+++ b/p2poolv2_lib/src/stratum/error.rs
@@ -38,37 +38,17 @@ pub enum Error {
 
 /// Stratum V1 JSON-RPC error codes sent to miners.
 ///
-/// Share submission codes -9..5 follow ckpool's `share_err` enum
+/// Share submission codes 1..5 follow ckpool's `share_err` enum
 /// (libckpool.h:340-355). Protocol codes 20-25 follow the blitzpool
 /// convention (eStratumErrorCode.ts). Negative codes -32700..-32600
 /// follow JSON-RPC 2.0.
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StratumErrorCode {
-    /// Invalid nonce2 hex length
-    InvalidNonce2 = -9,
-    /// Worker name does not match session
-    WorkerMismatch = -8,
-    /// Missing nonce parameter
-    NoNonce = -7,
-    /// Missing ntime parameter
-    NoNtime = -6,
-    /// Missing nonce2 parameter
-    NoNonce2 = -5,
-    /// Missing job_id parameter
-    NoJobId = -4,
-    /// Missing username parameter
-    NoUsername = -3,
-    /// Submit params array too short
-    InvalidSize = -2,
-    /// Params is not a JSON array
-    NotArray = -1,
     /// Unknown or expired job ID
     InvalidJobId = 1,
     /// Share submitted against a retired job
     Stale = 2,
-    /// ntime out of allowed range
-    NtimeOutOfRange = 3,
     /// Duplicate share submission
     Duplicate = 4,
     /// Share hash above pool target (below pool difficulty)
@@ -83,25 +63,13 @@ pub enum StratumErrorCode {
     ParseError = -32700,
     /// Unknown method name
     MethodNotFound = -32601,
-    /// Invalid method parameters
-    InvalidParams = -32602,
 }
 
 impl Display for StratumErrorCode {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let msg = match self {
-            Self::InvalidNonce2 => "Invalid nonce2 length",
-            Self::WorkerMismatch => "Worker mismatch",
-            Self::NoNonce => "No nonce",
-            Self::NoNtime => "No ntime",
-            Self::NoNonce2 => "No nonce2",
-            Self::NoJobId => "No job_id",
-            Self::NoUsername => "No username",
-            Self::InvalidSize => "Invalid array size",
-            Self::NotArray => "Params not array",
             Self::InvalidJobId => "Invalid JobID",
             Self::Stale => "Stale",
-            Self::NtimeOutOfRange => "Ntime out of range",
             Self::Duplicate => "Duplicate",
             Self::AboveTarget => "Above target",
             Self::OtherUnknown => "Unknown error",
@@ -109,7 +77,6 @@ impl Display for StratumErrorCode {
             Self::NotSubscribed => "Not subscribed",
             Self::ParseError => "Parse error",
             Self::MethodNotFound => "Method not found",
-            Self::InvalidParams => "Invalid params",
         };
         f.write_str(msg)
     }
@@ -148,6 +115,7 @@ mod tests {
         assert_eq!(StratumErrorCode::NotSubscribed as i32, 25);
         assert_eq!(StratumErrorCode::ParseError as i32, -32700);
         assert_eq!(StratumErrorCode::OtherUnknown as i32, 20);
+        assert_eq!(StratumErrorCode::MethodNotFound as i32, -32601);
     }
 
     #[test]
@@ -166,6 +134,10 @@ mod tests {
         );
         assert_eq!(StratumErrorCode::ParseError.to_string(), "Parse error");
         assert_eq!(StratumErrorCode::OtherUnknown.to_string(), "Unknown error");
+        assert_eq!(
+            StratumErrorCode::MethodNotFound.to_string(),
+            "Method not found"
+        );
     }
 
     #[test]

--- a/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
@@ -15,13 +15,14 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
-use crate::stratum::difficulty_adjuster::DifficultyAdjusterTrait;
-use crate::stratum::error::Error;
-use crate::stratum::messages::{Message, Response, SetDifficultyNotification, SimpleRequest};
-use crate::stratum::parse_password;
-use crate::stratum::server::StratumContext;
-use crate::stratum::session::Session;
-use crate::stratum::validate_username;
+use crate::stratum::{
+    difficulty_adjuster::DifficultyAdjusterTrait,
+    error::{Error, StratumErrorCode},
+    messages::{Message, Response, SetDifficultyNotification, SimpleRequest},
+    server::StratumContext,
+    session::Session,
+    validate_username,
+};
 use tracing::debug;
 
 /// Register user in the store and update session with their IDs
@@ -64,24 +65,22 @@ pub(crate) async fn handle_authorize<'a, D: DifficultyAdjusterTrait>(
     let username = match message.params[0].clone() {
         Some(name) => name,
         None => {
-            return Ok(vec![Message::Response(Response::new_error(
-                message.id,
-                -401,
-                "Empty username".to_string(),
-            ))]);
+            return Ok(vec![Message::Response(
+                Response::new_error(message.id, StratumErrorCode::UnauthorizedWorker)
+                    .with_message("Empty username".to_string()),
+            )]);
         }
     };
     let parsed_username =
         match validate_username::validate(&username, ctx.validate_addresses, ctx.network) {
             Ok(validated) => validated,
-            Err(e) => {
+            Err(_e) => {
                 if !session.auth_failed_once {
                     session.auth_failed_once = true;
-                    return Ok(vec![Message::Response(Response::new_error(
-                        message.id,
-                        -401,
-                        format!("Invalid username {e}"),
-                    ))]);
+                    return Ok(vec![Message::Response(
+                        Response::new_error(message.id, StratumErrorCode::UnauthorizedWorker)
+                            .with_message("Invalid username".to_string()),
+                    )]);
                 } else {
                     return Err(Error::AuthorizationFailure(
                         "Second invalid username. Disconnecting.".to_string(),
@@ -449,10 +448,10 @@ mod tests {
             Message::Response(response) => {
                 assert!(response.error.is_some(), "Response should have an error");
                 let error = response.error.as_ref().unwrap();
-                assert_eq!(error.code, -401, "Error code should be -401");
-                assert!(
-                    error.message.contains("Invalid username"),
-                    "Error message should mention invalid username"
+                assert_eq!(error.code, 24, "Error code should be 24");
+                assert_eq!(
+                    error.message, "Invalid username",
+                    "Error message should be 'Invalid username'"
                 );
             }
             _ => panic!("Expected Response message"),

--- a/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
@@ -19,6 +19,7 @@ use crate::stratum::{
     difficulty_adjuster::DifficultyAdjusterTrait,
     error::{Error, StratumErrorCode},
     messages::{Message, Response, SetDifficultyNotification, SimpleRequest},
+    parse_password::parse_password,
     server::StratumContext,
     session::Session,
     validate_username,
@@ -114,7 +115,7 @@ pub(crate) async fn handle_authorize<'a, D: DifficultyAdjusterTrait>(
 
     let start_difficulty = match &session.password {
         Some(password) => {
-            let parsed = parse_password::parse_password(password);
+            let parsed = parse_password(password);
             match parsed.difficulty {
                 Some(requested_difficulty) => {
                     let constrained = session.difficulty_adjuster.apply_difficulty_constraints(

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -92,10 +92,9 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
             Ok(result) => result,
             Err(e) => {
                 debug!("Share validation failed: {}", e);
-                return Ok(vec![Message::Response(Response::new_error(
-                    message.id,
-                    StratumErrorCode::OtherUnknown,
-                ))]);
+                let response = Response::new_error(message.id, StratumErrorCode::OtherUnknown)
+                    .with_message(e.to_string());
+                return Ok(vec![Message::Response(response)]);
             }
         };
 
@@ -1135,5 +1134,103 @@ mod handle_submit_tests {
         let err = response.error.as_ref().unwrap();
         assert_eq!(err.code, 21, "should be JobNotFound (code 21)");
         assert_eq!(err.message, "Job not found");
+    }
+
+    #[tokio::test]
+    async fn test_handle_submit_validation_failure_returns_other_unknown_with_message() {
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
+        session.enonce1_hex = "deadbeef".to_string();
+        session.user_id = Some(1);
+
+        let tracker_handle = start_tracker_actor();
+
+        let template: BlockTemplate = serde_json::from_value(json!({
+             "version": 536870912,
+            "rules": [],
+            "vbavailable": {},
+            "vbrequired": 0,
+            "previousblockhash": "0000000000000000000000000000000000000000000000000000000000000000",
+            "transactions": [],
+            "coinbaseaux": {},
+            "coinbasevalue": 5000000000_u64,
+            "longpollid": "0",
+            "target": "00000000ffff0000000000000000000000000000000000000000000000000000",
+            "mintime": 1,
+            "mutable": [],
+            "noncerange": "00000000ffffffff",
+            "sigoplimit": 80000,
+            "sizelimit": 4000000,
+            "weightlimit": 4000000,
+            "curtime": 1,
+            "bits": "1d00ffff",
+            "height": 1,
+            "default_witness_commitment": ""
+        }))
+        .unwrap();
+
+        // bad coinbase fields make sure the validation fails
+        let job_id = JobId(1);
+        let _ = tracker_handle.insert_job(
+            Arc::new(template),
+            "deadbeef".to_string(),
+            "cafebabe".to_string(),
+            None,
+            0,
+            vec![],
+            job_id,
+        );
+
+        let submit = SimpleRequest::new_submit(
+            4,
+            "worker".to_string(),
+            "1".to_string(),
+            "00000000".to_string(),
+            "504e86ed".to_string(),
+            "e9695791".to_string(),
+        );
+
+        let (_mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+        let (emissions_tx, _) = mpsc::channel(10);
+        let (notify_tx, _) = mpsc::channel(10);
+        let (chain_store_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+        let stats_dir = tempfile::tempdir().unwrap();
+        let metrics_handle = metrics::start_metrics(stats_dir.path().to_str().unwrap().to_string())
+            .await
+            .unwrap();
+
+        let ctx = StratumContext {
+            notify_tx,
+            tracker_handle: tracker_handle.clone(),
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
+            start_difficulty: 1,
+            minimum_difficulty: 1,
+            maximum_difficulty: None,
+            ignore_difficulty: false,
+            validate_addresses: true,
+            emissions_tx,
+            network: bitcoin::network::Network::Regtest,
+            metrics: metrics_handle,
+            chain_store_handle,
+        };
+
+        let messages = handle_submit(submit, &mut session, ctx).await.unwrap();
+        let response = match &messages[..] {
+            [Message::Response(r)] => r,
+            _ => panic!("expected Response"),
+        };
+        assert_eq!(response.result, None);
+        let err = response.error.as_ref().unwrap();
+        assert_eq!(err.code, 20, "should be OtherUnknown (code 20)");
+        assert!(
+            err.message.starts_with("Invalid parameters provided:"),
+            "error message should contain the validation failure reason, got: {}",
+            err.message
+        );
     }
 }

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -73,15 +73,10 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
     let job = match stratum_context.tracker_handle.get_job(JobId(job_id)) {
         Some(job) => job,
         None => {
-            let latest = stratum_context.tracker_handle.get_latest_job_id().0;
-            let code = if job_id <= latest {
-                StratumErrorCode::Stale
-            } else {
-                StratumErrorCode::InvalidJobId
-            };
-            debug!("Job not found for job_id: {job_id}, code: {code:?}");
+            debug!("Job not found for job_id: {job_id}");
             return Ok(vec![Message::Response(Response::new_error(
-                message.id, code,
+                message.id,
+                StratumErrorCode::JobNotFound,
             ))]);
         }
     };
@@ -111,7 +106,7 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
     if !is_new_share {
         return Ok(vec![Message::Response(Response::new_error(
             message.id,
-            StratumErrorCode::Duplicate,
+            StratumErrorCode::DuplicateShare,
         ))]);
     }
 
@@ -137,7 +132,7 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
             );
             return Ok(vec![Message::Response(Response::new_error(
                 message.id,
-                StratumErrorCode::AboveTarget,
+                StratumErrorCode::LowDifficultyShare,
             ))]);
         }
     }
@@ -704,8 +699,8 @@ mod handle_submit_tests {
         // Should return stale error
         assert_eq!(response.result, None);
         let err = response.error.as_ref().unwrap();
-        assert_eq!(err.code, 2, "should be Stale (code 2)");
-        assert_eq!(err.message, "Stale");
+        assert_eq!(err.code, 21, "should be JobNotFound (code 21)");
+        assert_eq!(err.message, "Job not found");
     }
 
     #[tokio::test]
@@ -908,8 +903,8 @@ mod handle_submit_tests {
         // Duplicate submission should return error code 4
         assert_eq!(response2.result, None);
         let err = response2.error.as_ref().unwrap();
-        assert_eq!(err.code, 4, "should be Duplicate (code 4)");
-        assert_eq!(err.message, "Duplicate");
+        assert_eq!(err.code, 22, "should be DuplicateShare (code 22)");
+        assert_eq!(err.message, "Duplicate share");
 
         // No additional emission should be sent for duplicate
         assert!(emissions_rx.try_recv().is_err());
@@ -1138,7 +1133,7 @@ mod handle_submit_tests {
         };
         assert_eq!(response.result, None);
         let err = response.error.as_ref().unwrap();
-        assert_eq!(err.code, 1, "should be InvalidJobID (code 1)");
-        assert_eq!(err.message, "Invalid JobID");
+        assert_eq!(err.code, 21, "should be JobNotFound (code 21)");
+        assert_eq!(err.message, "Job not found");
     }
 }

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -81,8 +81,7 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
             };
             debug!("Job not found for job_id: {job_id}, code: {code:?}");
             return Ok(vec![Message::Response(Response::new_error(
-                message.id,
-                code,
+                message.id, code,
             ))]);
         }
     };
@@ -1005,5 +1004,141 @@ mod handle_submit_tests {
             10000
         );
         assert_eq!(metrics_handle.get_metrics().await.rejected_total, 0);
+    }
+
+    #[tokio::test]
+    async fn test_handle_submit_not_subscribed_returns_error() {
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        // session.subscribed is false by default
+        let submit = SimpleRequest::new_submit(
+            1,
+            "worker".to_string(),
+            "1".to_string(),
+            "00000000".to_string(),
+            "504e86ed".to_string(),
+            "e9695791".to_string(),
+        );
+        let tracker_handle = start_tracker_actor();
+        let (emissions_tx, _) = mpsc::channel(10);
+        let (notify_tx, _) = mpsc::channel(10);
+        let (chain_store_handle, _) = setup_test_chain_store_handle(true).await;
+        let (_mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+        let stats_dir = tempfile::tempdir().unwrap();
+        let metrics_handle = metrics::start_metrics(stats_dir.path().to_str().unwrap().to_string())
+            .await
+            .unwrap();
+
+        let ctx = StratumContext {
+            notify_tx,
+            tracker_handle: tracker_handle.clone(),
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
+            start_difficulty: 1,
+            minimum_difficulty: 1,
+            maximum_difficulty: None,
+            ignore_difficulty: false,
+            validate_addresses: true,
+            emissions_tx,
+            network: bitcoin::network::Network::Regtest,
+            metrics: metrics_handle,
+            chain_store_handle,
+        };
+
+        let messages = handle_submit(submit, &mut session, ctx).await.unwrap();
+        let response = match &messages[..] {
+            [Message::Response(r)] => r,
+            _ => panic!("expected Response"),
+        };
+        assert_eq!(response.result, None);
+        let err = response.error.as_ref().unwrap();
+        assert_eq!(err.code, 25, "should be NotSubscribed (code 25)");
+        assert_eq!(err.message, "Not subscribed");
+    }
+
+    #[tokio::test]
+    async fn test_handle_submit_unknown_job_id_returns_invalid_jobid() {
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
+        let tracker_handle = start_tracker_actor();
+
+        let (_mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+
+        let (template, _notify, _submit, authorize_response) =
+            load_valid_stratum_work_components("../p2poolv2_tests/test_data/validation/stratum/a/");
+
+        let enonce1 = authorize_response.result.unwrap()[1].clone();
+        let enonce1: &str = enonce1.as_str().unwrap();
+        session.enonce1 =
+            u32::from_le_bytes(hex::decode(enonce1).unwrap().as_slice().try_into().unwrap());
+        session.enonce1_hex = enonce1.to_string();
+        session.btcaddress = Some("tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string());
+        session.user_id = Some(1);
+
+        // Insert a job to set latest_job_id, then submit an ID beyond it
+        let inserted_id = tracker_handle.insert_job(
+            Arc::new(template),
+            "cb1".to_string(),
+            "cb2".to_string(),
+            Some(create_test_commitment()),
+            TEST_COINBASE_NSECS,
+            vec![],
+            tracker_handle.get_next_job_id(),
+        );
+        let unknown_job_id = tracker_handle.get_latest_job_id().0 + 1;
+
+        let submit = SimpleRequest::new_submit(
+            1,
+            "worker".to_string(),
+            format!("{unknown_job_id:x}"),
+            "00000000".to_string(),
+            "504e86ed".to_string(),
+            "e9695791".to_string(),
+        );
+
+        let (emissions_tx, _) = mpsc::channel(10);
+        let stats_dir = tempfile::tempdir().unwrap();
+        let metrics_handle = metrics::start_metrics(stats_dir.path().to_str().unwrap().to_string())
+            .await
+            .unwrap();
+
+        let (notify_tx, _) = mpsc::channel(10);
+        let (chain_store_handle, _) = setup_test_chain_store_handle(true).await;
+
+        let ctx = StratumContext {
+            notify_tx,
+            tracker_handle: tracker_handle.clone(),
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
+            start_difficulty: 1,
+            minimum_difficulty: 1,
+            maximum_difficulty: None,
+            ignore_difficulty: false,
+            validate_addresses: true,
+            emissions_tx,
+            network: bitcoin::network::Network::Signet,
+            metrics: metrics_handle,
+            chain_store_handle,
+        };
+
+        // Verify the inserted job is properly registered
+        let _ = inserted_id;
+
+        let messages = handle_submit(submit, &mut session, ctx).await.unwrap();
+        let response = match &messages[..] {
+            [Message::Response(r)] => r,
+            _ => panic!("expected Response"),
+        };
+        assert_eq!(response.result, None);
+        let err = response.error.as_ref().unwrap();
+        assert_eq!(err.code, 1, "should be InvalidJobID (code 1)");
+        assert_eq!(err.message, "Invalid JobID");
     }
 }

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -16,18 +16,19 @@
 
 use crate::accounting::payout::simple_pplns::SimplePplnsShare;
 use crate::shares::extranonce::Extranonce;
-use crate::stratum::difficulty_adjuster::DifficultyAdjusterTrait;
-use crate::stratum::emission::Emission;
-use crate::stratum::error::Error;
-use crate::stratum::messages::{Message, Response, SetDifficultyNotification, SimpleRequest};
-use crate::stratum::server::StratumContext;
-use crate::stratum::session::Session;
-use crate::stratum::work::block_template::BlockTemplate;
-use crate::stratum::work::difficulty::validate::validate_bitcoin_difficulty;
-use crate::stratum::work::tracker::JobId;
-use bitcoin::block::Header;
-use bitcoin::blockdata::block::Block;
-use bitcoin::hashes::Hash;
+use crate::stratum::{
+    difficulty_adjuster::DifficultyAdjusterTrait,
+    emission::Emission,
+    error::{Error, StratumErrorCode},
+    messages::{Message, Response, SetDifficultyNotification, SimpleRequest},
+    server::StratumContext,
+    session::Session,
+    work::{
+        block_template::BlockTemplate, difficulty::validate::validate_bitcoin_difficulty,
+        tracker::JobId,
+    },
+};
+use bitcoin::{block::Header, blockdata::block::Block, hashes::Hash};
 use bitcoindrpc::BitcoindRpcClient;
 use serde_json::json;
 use std::time::SystemTime;
@@ -67,9 +68,9 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
         Some(job) => job,
         None => {
             debug!("Job not found for job_id: {}", job_id);
-            return Ok(vec![Message::Response(Response::new_ok(
+            return Ok(vec![Message::Response(Response::new_error(
                 message.id,
-                json!(false),
+                StratumErrorCode::InvalidJobId,
             ))]);
         }
     };
@@ -85,10 +86,9 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
             Ok(result) => result,
             Err(e) => {
                 debug!("Share validation failed: {}", e);
-                // return error to asic client if our server is failing to run validation. They will know something is wrong.
-                return Ok(vec![Message::Response(Response::new_ok(
+                return Ok(vec![Message::Response(Response::new_error(
                     message.id,
-                    json!(false),
+                    StratumErrorCode::OtherUnknown,
                 ))]);
             }
         };
@@ -98,10 +98,9 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
         .add_share(JobId(job_id), validation_result.header.block_hash());
 
     if !is_new_share {
-        // return error to asic client if share already exists or duplicate detection failed
-        return Ok(vec![Message::Response(Response::new_ok(
+        return Ok(vec![Message::Response(Response::new_error(
             message.id,
-            json!(false),
+            StratumErrorCode::Duplicate,
         ))]);
     }
 
@@ -125,9 +124,9 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
                 validation_result.header.block_hash(),
                 commitment.bits
             );
-            return Ok(vec![Message::Response(Response::new_ok(
+            return Ok(vec![Message::Response(Response::new_error(
                 message.id,
-                json!(false),
+                StratumErrorCode::AboveTarget,
             ))]);
         }
     }
@@ -686,8 +685,11 @@ mod handle_submit_tests {
             _ => panic!("Expected a Response message"),
         };
 
-        // Should return result false for unknown job_id
-        assert_eq!(response.result, Some(json!(false)));
+        // Should return error for unknown job_id
+        assert_eq!(response.result, None);
+        let err = response.error.as_ref().unwrap();
+        assert_eq!(err.code, 1, "should be Invalid JobID (code 1)");
+        assert_eq!(err.message, "Invalid JobID");
     }
 
     #[tokio::test]
@@ -885,8 +887,11 @@ mod handle_submit_tests {
             _ => panic!("Expected a Response message"),
         };
 
-        // Duplicate submission should return false
-        assert_eq!(response2.result, Some(json!(false)));
+        // Duplicate submission should return error code 4
+        assert_eq!(response2.result, None);
+        let err = response2.error.as_ref().unwrap();
+        assert_eq!(err.code, 4, "should be Duplicate (code 4)");
+        assert_eq!(err.message, "Duplicate");
 
         // No additional emission should be sent for duplicate
         assert!(emissions_rx.try_recv().is_err());

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -55,6 +55,12 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
     stratum_context: StratumContext,
 ) -> Result<Vec<Message<'a>>, Error> {
     debug!("Handling mining.submit message");
+    if !session.subscribed {
+        return Ok(vec![Message::Response(Response::new_error(
+            message.id,
+            StratumErrorCode::NotSubscribed,
+        ))]);
+    }
     if message.params.len() < 4 {
         return Err(Error::InvalidParams("Missing parameters".into()));
     }
@@ -67,10 +73,16 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
     let job = match stratum_context.tracker_handle.get_job(JobId(job_id)) {
         Some(job) => job,
         None => {
-            debug!("Job not found for job_id: {}", job_id);
+            let latest = stratum_context.tracker_handle.get_latest_job_id().0;
+            let code = if job_id <= latest {
+                StratumErrorCode::Stale
+            } else {
+                StratumErrorCode::InvalidJobId
+            };
+            debug!("Job not found for job_id: {job_id}, code: {code:?}");
             return Ok(vec![Message::Response(Response::new_error(
                 message.id,
-                StratumErrorCode::InvalidJobId,
+                code,
             ))]);
         }
     };
@@ -273,6 +285,7 @@ mod handle_submit_tests {
     #[tokio::test]
     async fn test_handle_submit_meets_difficulty_should_submit() {
         let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -369,6 +382,7 @@ mod handle_submit_tests {
     #[tokio::test]
     async fn test_handle_submit_a_meets_difficulty_should_submit() {
         let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -462,6 +476,7 @@ mod handle_submit_tests {
     #[tokio::test]
     async fn test_handle_submit_with_version_rolling_meets_difficulty_should_submit() {
         let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -553,6 +568,7 @@ mod handle_submit_tests {
         });
 
         let mut session = Session::<MockDifficultyAdjusterTrait>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -632,8 +648,9 @@ mod handle_submit_tests {
     }
 
     #[tokio::test]
-    async fn test_handle_submit_with_unknown_job_id_returns_false() {
+    async fn test_handle_submit_with_stale_job_returns_error() {
         let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
         let tracker_handle = start_tracker_actor();
 
         let (_mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -685,17 +702,18 @@ mod handle_submit_tests {
             _ => panic!("Expected a Response message"),
         };
 
-        // Should return error for unknown job_id
+        // Should return stale error
         assert_eq!(response.result, None);
         let err = response.error.as_ref().unwrap();
-        assert_eq!(err.code, 1, "should be Invalid JobID (code 1)");
-        assert_eq!(err.message, "Invalid JobID");
+        assert_eq!(err.code, 2, "should be Stale (code 2)");
+        assert_eq!(err.message, "Stale");
     }
 
     #[tokio::test]
     async fn test_handle_submit_with_less_difficulty_than_session_even_if_we_meet_bitcoin_diff_should_increment_rejected()
      {
         let mut session = Session::<DifficultyAdjuster>::new(10_000, 10_000, None, 0x1fffe000);
+        session.subscribed = true;
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -786,6 +804,7 @@ mod handle_submit_tests {
     #[tokio::test]
     async fn test_handle_submit_duplicate_share_is_rejected() {
         let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -904,6 +923,7 @@ mod handle_submit_tests {
     async fn test_handle_submit_accepts_low_difficulty_share_when_ignore_difficulty_is_true() {
         // Set high session difficulty (10_000) so the share won't meet it normally
         let mut session = Session::<DifficultyAdjuster>::new(10_000, 10_000, None, 0x1fffe000);
+        session.subscribed = true;
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;

--- a/p2poolv2_lib/src/stratum/messages.rs
+++ b/p2poolv2_lib/src/stratum/messages.rs
@@ -170,7 +170,7 @@ pub struct MiningConfigureParams<'a> {
 
 /// Response represents a Stratum response message from the server to the client
 /// We use Value in result to allow for different types of responses.
-/// TODO: Consider using various Response types to avoing using Value (which will result in memory allocations)
+/// TODO: Consider using various Response types to avoiding using Value (which will result in memory allocations)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Response<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -359,7 +359,7 @@ impl<'a> MiningConfigure<'a> {
 }
 
 /// Response represents a Stratum response message from the server to the client
-/// Supported resposes are set_difficulty (in response to subscribe), ok and error.
+/// Supported responses are set_difficulty (in response to subscribe), ok and error.
 impl Response<'_> {
     pub fn new_set_difficulty_response(
         id: Option<Id>,

--- a/p2poolv2_lib/src/stratum/messages.rs
+++ b/p2poolv2_lib/src/stratum/messages.rs
@@ -18,6 +18,7 @@
 use std::borrow::Cow;
 use std::vec;
 
+use crate::stratum::error::StratumErrorCode;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -60,13 +61,27 @@ impl PartialEq for Id {
 }
 
 /// StratumError represents the error structure in Stratum responses
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Error<'a> {
     pub code: i32,
     #[serde(borrow)]
     pub message: Cow<'a, str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Value>,
+}
+
+// Serialize as the standard 3-element array: [code, message, null]
+impl Serialize for Error<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(3))?;
+        seq.serialize_element(&self.code)?;
+        seq.serialize_element(&self.message)?;
+        seq.serialize_element(&self.data.clone().unwrap_or(json!("")))?;
+        seq.end()
+    }
 }
 
 /// Message type capturing all possible stratum message types.
@@ -373,16 +388,25 @@ impl Response<'_> {
         }
     }
 
-    pub fn new_error(id: Option<Id>, code: i32, message: String) -> Self {
+    pub fn new_error(id: Option<Id>, error_code: StratumErrorCode) -> Self {
         Response {
             id,
             result: None,
             error: Some(Error {
-                code,
-                message: Cow::Owned(message),
+                // SAFETY: [StratumErrorCode] is repr(i32)
+                code: error_code as i32,
+                message: Cow::Owned(error_code.to_string()),
                 data: None,
             }),
         }
+    }
+
+    /// Override the default error message with a custom one.
+    pub fn with_message(mut self, msg: String) -> Self {
+        if let Some(ref mut error) = self.error {
+            error.message = Cow::Owned(msg);
+        }
+        self
     }
 }
 
@@ -619,7 +643,7 @@ mod tests {
         let serialized_error = serde_json::to_string(&error).unwrap();
         assert_eq!(
             serialized_error,
-            r#"{"code":-1,"message":"An error occurred","data":"Additional error data"}"#
+            r#"[-1,"An error occurred","Additional error data"]"#
         );
     }
 
@@ -697,8 +721,7 @@ mod tests {
         // Test new_error
         let response = Response::new_error(
             Some(Id::String("abc".to_string())),
-            -32601,
-            "Method not found".to_string(),
+            StratumErrorCode::MethodNotFound,
         );
         assert_eq!(response.id, Some(Id::String("abc".to_string())));
         assert!(response.result.is_none());

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -24,8 +24,9 @@ use crate::stratum::client_connections::ClientConnectionsHandle;
 use crate::stratum::difficulty_adjuster::{DifficultyAdjuster, DifficultyAdjusterTrait};
 use crate::stratum::emission::EmissionSender;
 use crate::stratum::error::Error;
+use crate::stratum::error::StratumErrorCode;
 use crate::stratum::message_handlers::handle_message;
-use crate::stratum::messages::Request;
+use crate::stratum::messages::{Request, Response};
 use crate::stratum::session::Session;
 use crate::stratum::session_timeout::{self, check_session_timeouts};
 use crate::stratum::work::notify::NotifySender;
@@ -517,9 +518,15 @@ where
                 Err(Box::new(responses.unwrap_err()))
             }
         }
-        Err(e) => {
-            error!("Failed to parse message from {}: {}", addr, e);
-            Ok(())
+        Err(_) => {
+            let error_response = Response::new_error(None, StratumErrorCode::ParseError);
+            if let Ok(json) = serde_json::to_string(&error_response) {
+                let _ = writer.write_all(format!("{json}\n").as_bytes()).await;
+            }
+            Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Parse error",
+            )))
         }
     }
 }
@@ -784,17 +791,24 @@ mod stratum_server_tests {
         )
         .await;
 
-        // Verify results - even with bad json, we do not return an error to close the connection
+        // Verify results - invalid JSON should return a parse error and close
         assert!(
-            result.is_ok(),
-            "handle_connection should handle invalid JSON gracefully"
+            result.is_err(),
+            "handle_connection should return error for invalid JSON"
         );
 
-        // Check that no response was written
+        // Check that a parse error response was written
+        let response = String::from_utf8_lossy(&writer);
         assert!(
-            writer.is_empty(),
-            "No response should be written for invalid JSON"
+            !response.is_empty(),
+            "Parse error response should be written"
         );
+        let parsed: serde_json::Value =
+            serde_json::from_str(response.trim()).expect("Response should be valid JSON");
+        assert_eq!(parsed["result"], serde_json::Value::Null);
+        assert!(parsed["error"].is_array(), "Error should be an array");
+        assert_eq!(parsed["error"][0], -32700, "Error code should be -32700");
+        assert_eq!(parsed["error"][1], "Parse error");
     }
 
     #[tokio::test]


### PR DESCRIPTION
P2Poolv2's Stratum V1 server sent non-standard error responses: submit rejections
returned bare `result: false` with no error code or message, authentication errors used
`{"code": -401, "message": "..."}` as a JSON object, and malformed JSON was silently
ignored. Error handling was mapped across four reference implementations -- ckpool (C),
slush0/stratum (Python), blitzpool (TypeScript), and ESP-Miner/BitAxe (C firmware).

The critical finding came from ESP-Miner's stratum_api.c parsing logic: it only decodes
error as a JSON array ([error][ESP-Miner] for the message string), with no code path for
error-as-object. Every p2poolv2 error response displayed as `unknown` on BitAxe devices.
The array format `[code, message, null]` is universal across ckpool, [slush0][slush0/stratum writeJsonError], and blitzpool.
Following ckpool's [`share_err` enum][ckpoolenum] for submission errors and [blitzpool's convention][blitzpool-eStratumErrorCode] for
auth/subscription gives the widest miner firmware compatibility.

The stale detection heuristic (`job_id <= latest`) approximates ckpool's blockchange_id
tracking without adding persistent state. It may produce a false Stale classification
after tracker restart since there is no persistent block-change watermark.

 [ckpoolenum]: https://github.com/ctubio/ckpool/blob/master/src/libckpool.h#L255-L271
 [blitzpool-eStratumErrorCode]: https://github.com/warioishere/blitzpool/blob/0a14f8e8/src/models/enums/eStratumErrorCode.ts
 [ESP-Miner]: https://github.com/bitaxeorg/ESP-Miner/blob/18a5619d/components/stratum/stratum_api.c#L245-L261
 [slush0/stratum writeJsonError]: https://github.com/slush0/stratum/blob/master/stratum/protocol.py#L129
