### PR TITLE
Cleanup uncle traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Share header sync now uses height-based DAG walking instead of
+  confirmed-chain walk + uncle reference chasing. The sender collects
+  ALL valid blocks at each height from the height index, producing a
+  complete topologically sorted subgraph. This fixes sync failures
+  caused by missing fork block ancestors that the old approach never
+  included.
+
+- Locator matching relaxed from confirmed-only to any valid block
+  status (HeaderValid, Candidate, Confirmed, BlockValid). This
+  prevents follow-up batch failures when the last header in a batch
+  was a fork block.
+
+- Receiver supports multiple chain anchors per batch, allowing
+  height-based batches with blocks from different branches to
+  validate correctly.
+
+### Fixed
+
+- Fork block ancestors missing from header sync response. The old
+  confirmed-chain walk + `collect_uncle_chain` missed fork blocks whose
+  `prev_share_blockhash` pointed to non-confirmed blocks, causing
+  "parent not in batch or store" errors during testnet4 sync.
+
+- Out-of-order header arrival no longer creates phantom entries at
+  height 1 in the height index. `initialise_new_header` now returns an
+  error when the parent is missing instead of silently defaulting.
+
+- Missing external parents in a share headers batch now trigger a
+  retry with a deeper locator instead of dropping the batch.
+  HeaderSyncError enum distinguishes retryable errors (missing
+  parent/uncle) from non-retryable errors (ASERT mismatch,
+  insufficient work). Retry depth is computed from the lowest anchor
+  height in the failed batch.
+
+- `build_locator` and `send_getheaders` accept a depth parameter so
+  the retry locator can start further back than the confirmed tip.
+
 ## [v0.10.10] - 2026-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.10.11] - 2026-05-09
+
 ### Changed
 
 - Share header sync now uses height-based DAG walking instead of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindrpc"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3252,7 +3252,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2poolv2_api"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_cli"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_config"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_lib"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_node"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_tests"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.10"
+version = "0.10.11"
 edition = "2024"
 authors = ["Kulpreet Singh<kp@opdup.com>"]
 license = "AGPL-3.0-or-later"

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -579,6 +579,7 @@ impl NodeActor {
                             peer_id,
                             self.chain_store_handle.clone(),
                             self.node.swarm_tx.clone(),
+                            0,
                         ).await {
                             error!("Sync retry getheaders failed: {error}");
                         }

--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -361,7 +361,7 @@ mod tests {
             .returning(move |_| missing.clone());
         chain_store_handle
             .expect_build_locator()
-            .return_once(|| Ok(vec![BlockHash::all_zeros()]));
+            .return_once(|_| Ok(vec![BlockHash::all_zeros()]));
 
         let inventory = InventoryMessage::BlockHashes(block_hashes);
 

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/handshake.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/handshake.rs
@@ -89,7 +89,7 @@ pub async fn handle_handshake<C: Send + Sync>(
     };
 
     if needs_sync {
-        send_getheaders(peer, chain_store_handle, swarm_tx).await?;
+        send_getheaders(peer, chain_store_handle, swarm_tx, 0).await?;
     }
 
     Ok(())
@@ -131,7 +131,7 @@ mod tests {
         chain_store_handle
             .expect_build_locator()
             .times(1)
-            .return_once(move || Ok(vec![locator_hash]));
+            .return_once(move |_| Ok(vec![locator_hash]));
 
         let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
         let response_channel = 1u32;
@@ -296,7 +296,7 @@ mod tests {
         chain_store_handle
             .expect_build_locator()
             .times(1)
-            .return_once(move || Ok(vec![locator_hash]));
+            .return_once(move |_| Ok(vec![locator_hash]));
 
         let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
         let response_channel = 5u32;
@@ -355,7 +355,7 @@ mod tests {
         chain_store_handle
             .expect_build_locator()
             .times(1)
-            .return_once(move || Ok(vec![genesis_hash]));
+            .return_once(move |_| Ok(vec![genesis_hash]));
 
         let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
         let response_channel = 4u32;

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/inventory.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/inventory.rs
@@ -71,7 +71,7 @@ pub async fn handle_inventory<C: Send + Sync>(
                     missing_blocks.len(),
                     peer
                 );
-                send_getheaders(peer, chain_store_handle, swarm_tx).await?;
+                send_getheaders(peer, chain_store_handle, swarm_tx, 0).await?;
             }
         }
         InventoryMessage::TransactionHashes(transaction_hashes) => {
@@ -115,7 +115,7 @@ mod tests {
             .returning(move |_| missing_blocks.clone());
         chain_store_handle
             .expect_build_locator()
-            .return_once(|| Ok(vec![BlockHash::all_zeros()]));
+            .return_once(|_| Ok(vec![BlockHash::all_zeros()]));
 
         let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
         let response_channel = 1u32;

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -430,6 +430,8 @@ fn find_chain_anchors(
         .iter()
         .map(|header| header.prev_share_blockhash)
         .filter(|parent| !batch_hashes.contains(parent))
+        .collect::<HashSet<_>>()
+        .into_iter()
         .collect();
 
     let metadata_results = chain_store_handle.get_block_metadata_batch(&external_parents);

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -15,6 +15,7 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::node::p2p_message_handlers::MAX_HEADERS_IN_RESPONSE;
+use crate::node::p2p_message_handlers::senders::send_getheaders;
 use crate::node::request_response_handler::block_fetcher::{BlockFetcherEvent, BlockFetcherHandle};
 use crate::node::{SwarmSend, messages::Message};
 #[cfg(test)]
@@ -37,8 +38,102 @@ use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, CompactTarget, Target, Work};
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
+use std::fmt;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
+
+/// Depth to go back when retrying getheaders after missing parents/uncles.
+const DEEP_LOCATOR_DEPTH: u32 = 100;
+
+/// Errors from share header batch validation. Retryable variants
+/// indicate missing data that a deeper getheaders may resolve.
+/// Non-retryable variants indicate invalid data from the peer.
+#[derive(Debug)]
+enum HeaderSyncError {
+    MissingExternalParents(Vec<BlockHash>),
+    MissingUncle(BlockHash),
+    MissingParentInBatch {
+        header: BlockHash,
+        parent: BlockHash,
+    },
+    AsertMismatch {
+        block_hash: BlockHash,
+        declared: u32,
+        expected: u32,
+    },
+    InsufficientWork,
+    Other(Box<dyn Error + Send + Sync>),
+}
+
+impl HeaderSyncError {
+    fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            HeaderSyncError::MissingExternalParents(_)
+                | HeaderSyncError::MissingUncle(_)
+                | HeaderSyncError::MissingParentInBatch { .. }
+        )
+    }
+}
+
+impl fmt::Display for HeaderSyncError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HeaderSyncError::MissingExternalParents(hashes) => {
+                write!(
+                    formatter,
+                    "External parent(s) not found in store: {hashes:?}"
+                )
+            }
+            HeaderSyncError::MissingUncle(hash) => {
+                write!(
+                    formatter,
+                    "Declared uncle {hash} not delivered in batch and not in store"
+                )
+            }
+            HeaderSyncError::MissingParentInBatch { header, parent } => {
+                write!(
+                    formatter,
+                    "Header {header} has parent {parent} which is not in batch or store"
+                )
+            }
+            HeaderSyncError::AsertMismatch {
+                block_hash,
+                declared,
+                expected,
+            } => {
+                write!(
+                    formatter,
+                    "ASERT mismatch for {block_hash}: declared bits {declared:#010x}, expected {expected:#010x}"
+                )
+            }
+            HeaderSyncError::InsufficientWork => {
+                write!(formatter, "Cumulative chain work below minimum")
+            }
+            HeaderSyncError::Other(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for HeaderSyncError {}
+
+impl From<Box<dyn Error + Send + Sync>> for HeaderSyncError {
+    fn from(error: Box<dyn Error + Send + Sync>) -> Self {
+        HeaderSyncError::Other(error)
+    }
+}
+
+impl From<StoreError> for HeaderSyncError {
+    fn from(error: StoreError) -> Self {
+        HeaderSyncError::Other(error.into())
+    }
+}
+
+impl From<crate::shares::validation::ValidationError> for HeaderSyncError {
+    fn from(error: crate::shares::validation::ValidationError) -> Self {
+        HeaderSyncError::Other(error.into())
+    }
+}
 
 /// Handle ShareHeaders received from a peer.
 ///
@@ -80,7 +175,16 @@ pub async fn handle_share_headers<C: Send + Sync>(
     }
 
     // Phase 1: Validate the header chain in memory
-    validate_header_chain(&share_headers, &chain_store_handle, share_validator)?;
+    if let Err(sync_error) =
+        validate_header_chain(&share_headers, &chain_store_handle, share_validator)
+    {
+        if sync_error.is_retryable() {
+            info!("Retryable header sync error, sending deeper getheaders: {sync_error}");
+            send_getheaders(peer_id, chain_store_handle, swarm_tx, DEEP_LOCATOR_DEPTH).await?;
+            return Ok(());
+        }
+        return Err(sync_error.into());
+    }
 
     // Phase 2: Organise validated headers into the candidate chain
     for header in &share_headers {
@@ -119,7 +223,7 @@ fn validate_header_chain(
     share_headers: &[ShareHeader],
     chain_store_handle: &ChainStoreHandle,
     share_validator: &(dyn ShareValidator + Send + Sync),
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+) -> Result<(), HeaderSyncError> {
     let pool_difficulty = share_validator.pool_difficulty();
 
     let anchors = find_chain_anchors(share_headers, chain_store_handle)?;
@@ -184,7 +288,7 @@ fn validate_dag_connectivity_and_difficulty(
     pool_difficulty: &PoolDifficulty,
     anchor_hashes: &HashSet<BlockHash>,
     chain_store_handle: &ChainStoreHandle,
-) -> Result<(HashSet<BlockHash>, Work), Box<dyn Error + Send + Sync>> {
+) -> Result<(HashSet<BlockHash>, Work), HeaderSyncError> {
     let mut known_hashes: HashSet<BlockHash> =
         HashSet::with_capacity(share_headers.len() + anchor_hashes.len());
     known_hashes.extend(anchor_hashes);
@@ -200,12 +304,10 @@ fn validate_dag_connectivity_and_difficulty(
         if !known_hashes.contains(&parent_hash)
             && chain_store_handle.get_block_metadata(&parent_hash).is_err()
         {
-            return Err(format!(
-                "Header {} has parent {} which is not in batch or store",
-                header.block_hash(),
-                parent_hash
-            )
-            .into());
+            return Err(HeaderSyncError::MissingParentInBatch {
+                header: header.block_hash(),
+                parent: parent_hash,
+            });
         }
 
         let (parent_time, parent_height) =
@@ -213,13 +315,11 @@ fn validate_dag_connectivity_and_difficulty(
 
         let expected_bits = pool_difficulty.calculate_target_clamped(parent_time, parent_height);
         if header.bits != expected_bits {
-            let block_hash = header.block_hash();
-            return Err(format!(
-                "ASERT mismatch for {block_hash}: declared bits {:#010x}, expected {:#010x}",
-                header.bits.to_consensus(),
-                expected_bits.to_consensus()
-            )
-            .into());
+            return Err(HeaderSyncError::AsertMismatch {
+                block_hash: header.block_hash(),
+                declared: header.bits.to_consensus(),
+                expected: expected_bits.to_consensus(),
+            });
         }
 
         let header_hash = header.block_hash();
@@ -238,16 +338,13 @@ fn verify_all_uncles_available(
     share_headers: &[ShareHeader],
     batch_hashes: &HashSet<BlockHash>,
     chain_store_handle: &ChainStoreHandle,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+) -> Result<(), HeaderSyncError> {
     for header in share_headers {
         for uncle_hash in &header.uncles {
             if !batch_hashes.contains(uncle_hash)
                 && chain_store_handle.get_block_metadata(uncle_hash).is_err()
             {
-                return Err(format!(
-                    "Declared uncle {uncle_hash} not delivered in batch and not in store"
-                )
-                .into());
+                return Err(HeaderSyncError::MissingUncle(*uncle_hash));
             }
         }
     }
@@ -265,7 +362,7 @@ fn verify_all_uncles_available(
 fn find_chain_anchors(
     share_headers: &[ShareHeader],
     chain_store_handle: &ChainStoreHandle,
-) -> Result<Vec<(BlockHash, BlockMetadata)>, Box<dyn Error + Send + Sync>> {
+) -> Result<Vec<(BlockHash, BlockMetadata)>, HeaderSyncError> {
     let batch_hashes: HashSet<BlockHash> = share_headers
         .iter()
         .map(|header| header.block_hash())
@@ -279,18 +376,13 @@ fn find_chain_anchors(
 
     let metadata_results = chain_store_handle.get_block_metadata_batch(&external_parents);
 
-    // If the sender's DAG changed between batches (new fork blocks or
-    // reorg), some external parents may be missing from our store. We
-    // reject the batch and the stale tip retry will restart sync.
-    // TODO: instead of rejecting, request the missing parents via a
-    // targeted GetShareHeaders to preserve partial sync progress.
     if metadata_results.len() != external_parents.len() {
         let found: HashSet<BlockHash> = metadata_results.iter().map(|(hash, _)| *hash).collect();
-        let missing: Vec<&BlockHash> = external_parents
-            .iter()
-            .filter(|hash| !found.contains(*hash))
+        let missing: Vec<BlockHash> = external_parents
+            .into_iter()
+            .filter(|hash| !found.contains(hash))
             .collect();
-        return Err(format!("External parent(s) not found in store: {missing:?}").into());
+        return Err(HeaderSyncError::MissingExternalParents(missing));
     }
 
     Ok(metadata_results)
@@ -300,7 +392,7 @@ fn find_chain_anchors(
 fn validate_cumulative_work(
     anchor_chain_work: Work,
     batch_chain_work: Work,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+) -> Result<(), HeaderSyncError> {
     let single_share_work =
         Target::from_compact(CompactTarget::from_consensus(MAX_POOL_TARGET)).to_work();
     let zero_work = Work::from_hex("0x00").unwrap();
@@ -309,10 +401,7 @@ fn validate_cumulative_work(
     let candidate_work = anchor_chain_work + batch_chain_work;
 
     if candidate_work < min_cumulative_work {
-        return Err(format!(
-            "Cumulative chain work {candidate_work} below minimum {min_cumulative_work}"
-        )
-        .into());
+        return Err(HeaderSyncError::InsufficientWork);
     }
     Ok(())
 }
@@ -1167,6 +1256,134 @@ mod tests {
         let headers = vec![share_a, share_b];
         let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
+    }
+
+    /// Missing external parent is a retryable error.
+    #[test]
+    fn test_missing_external_parent_is_retryable() {
+        let error = HeaderSyncError::MissingExternalParents(vec![BlockHash::all_zeros()]);
+        assert!(error.is_retryable());
+    }
+
+    /// Missing uncle is a retryable error.
+    #[test]
+    fn test_missing_uncle_is_retryable() {
+        let error = HeaderSyncError::MissingUncle(BlockHash::all_zeros());
+        assert!(error.is_retryable());
+    }
+
+    /// Missing parent in batch is a retryable error.
+    #[test]
+    fn test_missing_parent_in_batch_is_retryable() {
+        let error = HeaderSyncError::MissingParentInBatch {
+            header: BlockHash::all_zeros(),
+            parent: BlockHash::all_zeros(),
+        };
+        assert!(error.is_retryable());
+    }
+
+    /// ASERT mismatch is not retryable.
+    #[test]
+    fn test_asert_mismatch_is_not_retryable() {
+        let error = HeaderSyncError::AsertMismatch {
+            block_hash: BlockHash::all_zeros(),
+            declared: 0,
+            expected: 1,
+        };
+        assert!(!error.is_retryable());
+    }
+
+    /// Insufficient work is not retryable.
+    #[test]
+    fn test_insufficient_work_is_not_retryable() {
+        let error = HeaderSyncError::InsufficientWork;
+        assert!(!error.is_retryable());
+    }
+
+    /// When handle_share_headers gets a missing external parent error,
+    /// it sends a deeper getheaders instead of propagating the error.
+    #[tokio::test]
+    async fn test_handle_share_headers_retries_on_missing_external_parent() {
+        let peer_id = libp2p::PeerId::random();
+        let unknown_parent = TestShareBlockBuilder::new().nonce(99).build();
+
+        let mut share = TestShareBlockBuilder::new()
+            .prev_share_blockhash(unknown_parent.block_hash().to_string())
+            .nonce(10)
+            .build()
+            .header;
+        share.bits = CompactTarget::from_consensus(MAX_POOL_TARGET);
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+        // External parent not found in store
+        chain_store_handle
+            .expect_get_block_metadata_batch()
+            .returning(|_| Vec::new());
+        // build_locator for the retry getheaders
+        chain_store_handle
+            .expect_build_locator()
+            .return_once(|_| Ok(vec![BlockHash::all_zeros()]));
+        let mut mock_validator = MockDefaultShareValidator::default();
+        setup_minimum_difficulty_mock(&mut mock_validator);
+
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<oneshot::Sender<Message>>>(32);
+        let (block_fetcher_handle, _block_fetcher_rx) =
+            block_fetcher::create_block_fetcher_channel();
+
+        let result = handle_share_headers(
+            peer_id,
+            vec![share],
+            chain_store_handle,
+            swarm_tx,
+            block_fetcher_handle,
+            &mock_validator,
+        )
+        .await;
+
+        // Should succeed (retry sent, not an error)
+        assert!(result.is_ok());
+
+        // Should have sent a getheaders request
+        let message = swarm_rx.try_recv().expect("expected a getheaders retry");
+        match message {
+            SwarmSend::Request(sent_peer, Message::GetShareHeaders(_, _)) => {
+                assert_eq!(sent_peer, peer_id);
+            }
+            other => panic!("expected GetShareHeaders, got: {other:?}"),
+        }
+    }
+
+    /// When handle_share_headers gets an ASERT mismatch, it propagates
+    /// the error instead of retrying.
+    #[tokio::test]
+    async fn test_handle_share_headers_propagates_asert_mismatch() {
+        let peer_id = libp2p::PeerId::random();
+        let mut chain_store_handle = ChainStoreHandle::default();
+        setup_chain_validation_mocks(&mut chain_store_handle);
+
+        let (swarm_tx, _swarm_rx) = mpsc::channel::<SwarmSend<oneshot::Sender<Message>>>(32);
+        let (block_fetcher_handle, _block_fetcher_rx) =
+            block_fetcher::create_block_fetcher_channel();
+
+        let mut mock_validator = MockDefaultShareValidator::default();
+        setup_minimum_difficulty_mock(&mut mock_validator);
+
+        // Header with wrong bits -- will trigger ASERT mismatch
+        let header = TestShareBlockBuilder::new().build().header;
+        let share_headers = vec![header];
+
+        let result = handle_share_headers(
+            peer_id,
+            share_headers,
+            chain_store_handle,
+            swarm_tx,
+            block_fetcher_handle,
+            &mock_validator,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ASERT mismatch"));
     }
 
     /// Batch has an external parent that is completely unknown to the

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -48,13 +48,22 @@ const DEEP_LOCATOR_DEPTH: u32 = 100;
 /// Errors from share header batch validation. Retryable variants
 /// indicate missing data that a deeper getheaders may resolve.
 /// Non-retryable variants indicate invalid data from the peer.
+/// Retryable variants carry the lowest anchor height so the retry
+/// locator can start from that point minus a margin.
 #[derive(Debug)]
 enum HeaderSyncError {
-    MissingExternalParents(Vec<BlockHash>),
-    MissingUncle(BlockHash),
+    MissingExternalParents {
+        missing: Vec<BlockHash>,
+        lowest_anchor_height: u32,
+    },
+    MissingUncle {
+        uncle_hash: BlockHash,
+        lowest_anchor_height: u32,
+    },
     MissingParentInBatch {
         header: BlockHash,
         parent: BlockHash,
+        lowest_anchor_height: u32,
     },
     AsertMismatch {
         block_hash: BlockHash,
@@ -69,29 +78,52 @@ impl HeaderSyncError {
     fn is_retryable(&self) -> bool {
         matches!(
             self,
-            HeaderSyncError::MissingExternalParents(_)
-                | HeaderSyncError::MissingUncle(_)
+            HeaderSyncError::MissingExternalParents { .. }
+                | HeaderSyncError::MissingUncle { .. }
                 | HeaderSyncError::MissingParentInBatch { .. }
         )
+    }
+
+    /// Returns the retry depth if this error is retryable.
+    /// The depth is calculated so the locator starts 100 blocks
+    /// before the lowest anchor height from the failed batch.
+    fn retry_depth(&self, tip_height: u32) -> Option<u32> {
+        let lowest_anchor_height = match self {
+            HeaderSyncError::MissingExternalParents {
+                lowest_anchor_height,
+                ..
+            } => *lowest_anchor_height,
+            HeaderSyncError::MissingUncle {
+                lowest_anchor_height,
+                ..
+            } => *lowest_anchor_height,
+            HeaderSyncError::MissingParentInBatch {
+                lowest_anchor_height,
+                ..
+            } => *lowest_anchor_height,
+            _ => return None,
+        };
+        let target_height = lowest_anchor_height.saturating_sub(DEEP_LOCATOR_DEPTH);
+        Some(tip_height.saturating_sub(target_height))
     }
 }
 
 impl fmt::Display for HeaderSyncError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            HeaderSyncError::MissingExternalParents(hashes) => {
+            HeaderSyncError::MissingExternalParents { missing, .. } => {
                 write!(
                     formatter,
-                    "External parent(s) not found in store: {hashes:?}"
+                    "External parent(s) not found in store: {missing:?}"
                 )
             }
-            HeaderSyncError::MissingUncle(hash) => {
+            HeaderSyncError::MissingUncle { uncle_hash, .. } => {
                 write!(
                     formatter,
-                    "Declared uncle {hash} not delivered in batch and not in store"
+                    "Declared uncle {uncle_hash} not delivered in batch and not in store"
                 )
             }
-            HeaderSyncError::MissingParentInBatch { header, parent } => {
+            HeaderSyncError::MissingParentInBatch { header, parent, .. } => {
                 write!(
                     formatter,
                     "Header {header} has parent {parent} which is not in batch or store"
@@ -179,8 +211,16 @@ pub async fn handle_share_headers<C: Send + Sync>(
         validate_header_chain(&share_headers, &chain_store_handle, share_validator)
     {
         if sync_error.is_retryable() {
-            info!("Retryable header sync error, sending deeper getheaders: {sync_error}");
-            send_getheaders(peer_id, chain_store_handle, swarm_tx, DEEP_LOCATOR_DEPTH).await?;
+            let tip_height = chain_store_handle
+                .get_tip_height()
+                .ok()
+                .flatten()
+                .unwrap_or(0);
+            let depth = sync_error.retry_depth(tip_height).unwrap_or(0);
+            info!(
+                "Retryable header sync error, sending getheaders with depth {depth}: {sync_error}"
+            );
+            send_getheaders(peer_id, chain_store_handle, swarm_tx, depth).await?;
             return Ok(());
         }
         return Err(sync_error.into());
@@ -230,6 +270,12 @@ fn validate_header_chain(
     let anchor_hashes: HashSet<BlockHash> = anchors.iter().map(|(hash, _)| *hash).collect();
     debug!("Found {} anchor(s) for header batch", anchors.len());
 
+    let lowest_anchor_height = anchors
+        .iter()
+        .filter_map(|(_, metadata)| metadata.expected_height)
+        .min()
+        .unwrap_or(0);
+
     let best_anchor_work = anchors
         .iter()
         .map(|(_, metadata)| metadata.chain_work)
@@ -242,8 +288,14 @@ fn validate_header_chain(
         pool_difficulty,
         &anchor_hashes,
         chain_store_handle,
+        lowest_anchor_height,
     )?;
-    verify_all_uncles_available(share_headers, &batch_hashes, chain_store_handle)?;
+    verify_all_uncles_available(
+        share_headers,
+        &batch_hashes,
+        chain_store_handle,
+        lowest_anchor_height,
+    )?;
     validate_cumulative_work(best_anchor_work, cumulative_chain_work)?;
 
     debug!(
@@ -288,6 +340,7 @@ fn validate_dag_connectivity_and_difficulty(
     pool_difficulty: &PoolDifficulty,
     anchor_hashes: &HashSet<BlockHash>,
     chain_store_handle: &ChainStoreHandle,
+    lowest_anchor_height: u32,
 ) -> Result<(HashSet<BlockHash>, Work), HeaderSyncError> {
     let mut known_hashes: HashSet<BlockHash> =
         HashSet::with_capacity(share_headers.len() + anchor_hashes.len());
@@ -307,6 +360,7 @@ fn validate_dag_connectivity_and_difficulty(
             return Err(HeaderSyncError::MissingParentInBatch {
                 header: header.block_hash(),
                 parent: parent_hash,
+                lowest_anchor_height,
             });
         }
 
@@ -338,13 +392,17 @@ fn verify_all_uncles_available(
     share_headers: &[ShareHeader],
     batch_hashes: &HashSet<BlockHash>,
     chain_store_handle: &ChainStoreHandle,
+    lowest_anchor_height: u32,
 ) -> Result<(), HeaderSyncError> {
     for header in share_headers {
         for uncle_hash in &header.uncles {
             if !batch_hashes.contains(uncle_hash)
                 && chain_store_handle.get_block_metadata(uncle_hash).is_err()
             {
-                return Err(HeaderSyncError::MissingUncle(*uncle_hash));
+                return Err(HeaderSyncError::MissingUncle {
+                    uncle_hash: *uncle_hash,
+                    lowest_anchor_height,
+                });
             }
         }
     }
@@ -382,7 +440,15 @@ fn find_chain_anchors(
             .into_iter()
             .filter(|hash| !found.contains(hash))
             .collect();
-        return Err(HeaderSyncError::MissingExternalParents(missing));
+        let lowest_anchor_height = metadata_results
+            .iter()
+            .filter_map(|(_, metadata)| metadata.expected_height)
+            .min()
+            .unwrap_or(0);
+        return Err(HeaderSyncError::MissingExternalParents {
+            missing,
+            lowest_anchor_height,
+        });
     }
 
     Ok(metadata_results)
@@ -1258,46 +1324,56 @@ mod tests {
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
     }
 
-    /// Missing external parent is a retryable error.
+    /// Missing external parent returns a retry depth.
     #[test]
-    fn test_missing_external_parent_is_retryable() {
-        let error = HeaderSyncError::MissingExternalParents(vec![BlockHash::all_zeros()]);
-        assert!(error.is_retryable());
+    fn test_missing_external_parent_has_retry_depth() {
+        let error = HeaderSyncError::MissingExternalParents {
+            missing: vec![BlockHash::all_zeros()],
+            lowest_anchor_height: 500,
+        };
+        // tip=600, target=500-100=400, depth=600-400=200
+        assert_eq!(error.retry_depth(600), Some(200));
     }
 
-    /// Missing uncle is a retryable error.
+    /// Missing uncle returns a retry depth.
     #[test]
-    fn test_missing_uncle_is_retryable() {
-        let error = HeaderSyncError::MissingUncle(BlockHash::all_zeros());
-        assert!(error.is_retryable());
+    fn test_missing_uncle_has_retry_depth() {
+        let error = HeaderSyncError::MissingUncle {
+            uncle_hash: BlockHash::all_zeros(),
+            lowest_anchor_height: 300,
+        };
+        // tip=400, target=300-100=200, depth=400-200=200
+        assert_eq!(error.retry_depth(400), Some(200));
     }
 
-    /// Missing parent in batch is a retryable error.
+    /// Missing parent in batch returns a retry depth.
     #[test]
-    fn test_missing_parent_in_batch_is_retryable() {
+    fn test_missing_parent_in_batch_has_retry_depth() {
         let error = HeaderSyncError::MissingParentInBatch {
             header: BlockHash::all_zeros(),
             parent: BlockHash::all_zeros(),
+            lowest_anchor_height: 50,
         };
-        assert!(error.is_retryable());
+        // tip=100, target=50-100=0 (saturating), depth=100-0=100
+        assert_eq!(error.retry_depth(100), Some(100));
     }
 
-    /// ASERT mismatch is not retryable.
+    /// ASERT mismatch has no retry depth.
     #[test]
-    fn test_asert_mismatch_is_not_retryable() {
+    fn test_asert_mismatch_has_no_retry_depth() {
         let error = HeaderSyncError::AsertMismatch {
             block_hash: BlockHash::all_zeros(),
             declared: 0,
             expected: 1,
         };
-        assert!(!error.is_retryable());
+        assert_eq!(error.retry_depth(600), None);
     }
 
-    /// Insufficient work is not retryable.
+    /// Insufficient work has no retry depth.
     #[test]
-    fn test_insufficient_work_is_not_retryable() {
+    fn test_insufficient_work_has_no_retry_depth() {
         let error = HeaderSyncError::InsufficientWork;
-        assert!(!error.is_retryable());
+        assert_eq!(error.retry_depth(600), None);
     }
 
     /// When handle_share_headers gets a missing external parent error,
@@ -1319,6 +1395,10 @@ mod tests {
         chain_store_handle
             .expect_get_block_metadata_batch()
             .returning(|_| Vec::new());
+        // get_tip_height for computing retry depth
+        chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(100)));
         // build_locator for the retry getheaders
         chain_store_handle
             .expect_build_locator()

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -122,21 +122,25 @@ fn validate_header_chain(
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     let pool_difficulty = share_validator.pool_difficulty();
 
-    let (anchor_hash, anchor_metadata) = find_chain_anchor(share_headers, chain_store_handle)?;
-    debug!(
-        "Anchor hash {:?} and anchor height {:?}",
-        anchor_hash, anchor_metadata.expected_height
-    );
+    let anchors = find_chain_anchors(share_headers, chain_store_handle)?;
+    let anchor_hashes: HashSet<BlockHash> = anchors.iter().map(|(hash, _)| *hash).collect();
+    debug!("Found {} anchor(s) for header batch", anchors.len());
+
+    let best_anchor_work = anchors
+        .iter()
+        .map(|(_, metadata)| metadata.chain_work)
+        .max()
+        .unwrap_or(Work::from_hex("0x00").unwrap());
 
     let (batch_hashes, cumulative_chain_work) = validate_dag_connectivity_and_difficulty(
         share_headers,
         share_validator,
         pool_difficulty,
-        anchor_hash,
+        &anchor_hashes,
         chain_store_handle,
     )?;
     verify_all_uncles_available(share_headers, &batch_hashes, chain_store_handle)?;
-    validate_cumulative_work(anchor_metadata.chain_work, cumulative_chain_work)?;
+    validate_cumulative_work(best_anchor_work, cumulative_chain_work)?;
 
     debug!(
         "Validated {} headers, cumulative chain work: {cumulative_chain_work}",
@@ -178,11 +182,12 @@ fn validate_dag_connectivity_and_difficulty(
     share_headers: &[ShareHeader],
     share_validator: &(dyn ShareValidator + Send + Sync),
     pool_difficulty: &PoolDifficulty,
-    anchor_hash: BlockHash,
+    anchor_hashes: &HashSet<BlockHash>,
     chain_store_handle: &ChainStoreHandle,
 ) -> Result<(HashSet<BlockHash>, Work), Box<dyn Error + Send + Sync>> {
-    let mut known_hashes: HashSet<BlockHash> = HashSet::with_capacity(share_headers.len() + 1);
-    known_hashes.insert(anchor_hash);
+    let mut known_hashes: HashSet<BlockHash> =
+        HashSet::with_capacity(share_headers.len() + anchor_hashes.len());
+    known_hashes.extend(anchor_hashes);
 
     let mut cumulative_work = Work::from_hex("0x00").unwrap();
     let mut time_height_cache: HashMap<BlockHash, (u32, u32)> =
@@ -249,20 +254,18 @@ fn verify_all_uncles_available(
     Ok(())
 }
 
-/// Find the chain anchor: the highest-height parent from the batch that
-/// exists in our store.
+/// Find all chain anchors: external parents from the batch that exist
+/// in our store.
 ///
 /// Collects all `prev_share_blockhash` values that are NOT themselves
 /// hashes of headers in this batch (i.e., external parents from the
-/// store). Among those, picks the one with the highest expected_height
-/// to avoid deep-fork uncle parents pulling the anchor too far back.
-///
-/// Uncle references will all be the hash which is also the anchor
-/// point, or lower, they can't be higher than the anchor point.
-fn find_chain_anchor(
+/// store). With height-based batches, multiple blocks may have
+/// external parents at the previous batch boundary on different
+/// branches.
+fn find_chain_anchors(
     share_headers: &[ShareHeader],
     chain_store_handle: &ChainStoreHandle,
-) -> Result<(BlockHash, BlockMetadata), Box<dyn Error + Send + Sync>> {
+) -> Result<Vec<(BlockHash, BlockMetadata)>, Box<dyn Error + Send + Sync>> {
     let batch_hashes: HashSet<BlockHash> = share_headers
         .iter()
         .map(|header| header.block_hash())
@@ -276,11 +279,21 @@ fn find_chain_anchor(
 
     let metadata_results = chain_store_handle.get_block_metadata_batch(&external_parents);
 
-    let best_anchor = metadata_results
-        .into_iter()
-        .max_by_key(|(_, metadata)| metadata.expected_height);
+    // If the sender's DAG changed between batches (new fork blocks or
+    // reorg), some external parents may be missing from our store. We
+    // reject the batch and the stale tip retry will restart sync.
+    // TODO: instead of rejecting, request the missing parents via a
+    // targeted GetShareHeaders to preserve partial sync progress.
+    if metadata_results.len() != external_parents.len() {
+        let found: HashSet<BlockHash> = metadata_results.iter().map(|(hash, _)| *hash).collect();
+        let missing: Vec<&BlockHash> = external_parents
+            .iter()
+            .filter(|hash| !found.contains(*hash))
+            .collect();
+        return Err(format!("External parent(s) not found in store: {missing:?}").into());
+    }
 
-    best_anchor.ok_or_else(|| "No header in batch has a parent in the store".into())
+    Ok(metadata_results)
 }
 
 /// Verify cumulative chain work exceeds the minimum threshold.
@@ -780,7 +793,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("No header in batch has a parent in the store"),
+                .contains("External parent(s) not found in store"),
         );
     }
 
@@ -851,8 +864,8 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("not in batch or store"),
-            "Expected 'not in batch or store' error for disconnected subtree"
+                .contains("External parent(s) not found in store"),
+            "Expected external parent not found error for disconnected subtree"
         );
     }
 
@@ -1080,5 +1093,135 @@ mod tests {
         let headers = vec![share_a, fork_parent, share_b, uncle_u, share_c];
         let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
+    }
+
+    /// Multiple anchors: two headers in the batch have different
+    /// external parents, both present in the store. This models a
+    /// height-based batch where blocks at the first height have
+    /// parents on different branches from the previous batch.
+    ///
+    /// anchor_a(h:0) -> share_a(h:1)
+    /// anchor_b(h:0) -> share_b(h:1)
+    ///
+    /// Both anchor_a and anchor_b are external parents in the store.
+    #[test]
+    fn test_validate_header_chain_accepts_multiple_anchors() {
+        let anchor_a = TestShareBlockBuilder::new().nonce(1).build();
+        let anchor_b = TestShareBlockBuilder::new().nonce(2).build();
+        let anchor_a_hash = anchor_a.block_hash();
+        let anchor_b_hash = anchor_b.block_hash();
+
+        let mut share_a = TestShareBlockBuilder::new()
+            .prev_share_blockhash(anchor_a.block_hash().to_string())
+            .nonce(10)
+            .build()
+            .header;
+        share_a.bits = CompactTarget::from_consensus(MAX_POOL_TARGET);
+
+        let mut share_b = TestShareBlockBuilder::new()
+            .prev_share_blockhash(anchor_b.block_hash().to_string())
+            .nonce(20)
+            .build()
+            .header;
+        share_b.bits = CompactTarget::from_consensus(MAX_POOL_TARGET);
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+        let template_header = build_valid_test_header();
+        chain_store_handle
+            .expect_get_share_header()
+            .returning(move |_| Ok(template_header.clone()));
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(move |hash| {
+                if *hash == anchor_a_hash || *hash == anchor_b_hash {
+                    Ok(BlockMetadata {
+                        expected_height: Some(0),
+                        chain_work: Work::from_hex("0x00").unwrap(),
+                        status: Status::Confirmed,
+                    })
+                } else {
+                    Err(StoreError::NotFound(format!("{hash} not found")))
+                }
+            });
+        chain_store_handle
+            .expect_get_block_metadata_batch()
+            .returning(move |hashes| {
+                hashes
+                    .iter()
+                    .filter(|hash| **hash == anchor_a_hash || **hash == anchor_b_hash)
+                    .map(|hash| {
+                        (
+                            *hash,
+                            BlockMetadata {
+                                expected_height: Some(0),
+                                chain_work: Work::from_hex("0x00").unwrap(),
+                                status: Status::Confirmed,
+                            },
+                        )
+                    })
+                    .collect()
+            });
+        let mut mock_validator = MockDefaultShareValidator::default();
+        setup_minimum_difficulty_mock(&mut mock_validator);
+
+        let headers = vec![share_a, share_b];
+        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
+        assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
+    }
+
+    /// Batch has an external parent that is completely unknown to the
+    /// receiver. This can happen if the sender's DAG changed between
+    /// batches. The batch should be rejected.
+    #[test]
+    fn test_validate_header_chain_rejects_batch_with_unknown_external_parent() {
+        let known_anchor = TestShareBlockBuilder::new().nonce(1).build();
+        let unknown_anchor = TestShareBlockBuilder::new().nonce(99).build();
+        let known_anchor_hash = known_anchor.block_hash();
+
+        let mut share_a = TestShareBlockBuilder::new()
+            .prev_share_blockhash(known_anchor.block_hash().to_string())
+            .nonce(10)
+            .build()
+            .header;
+        share_a.bits = CompactTarget::from_consensus(MAX_POOL_TARGET);
+
+        let mut share_b = TestShareBlockBuilder::new()
+            .prev_share_blockhash(unknown_anchor.block_hash().to_string())
+            .nonce(20)
+            .build()
+            .header;
+        share_b.bits = CompactTarget::from_consensus(MAX_POOL_TARGET);
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_get_block_metadata_batch()
+            .returning(move |hashes| {
+                hashes
+                    .iter()
+                    .filter(|hash| **hash == known_anchor_hash)
+                    .map(|hash| {
+                        (
+                            *hash,
+                            BlockMetadata {
+                                expected_height: Some(0),
+                                chain_work: Work::from_hex("0x00").unwrap(),
+                                status: Status::Confirmed,
+                            },
+                        )
+                    })
+                    .collect()
+            });
+        let mut mock_validator = MockDefaultShareValidator::default();
+        setup_minimum_difficulty_mock(&mut mock_validator);
+
+        let headers = vec![share_a, share_b];
+        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("External parent(s) not found in store"),
+        );
     }
 }

--- a/p2poolv2_lib/src/node/p2p_message_handlers/senders/getheaders.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/senders/getheaders.rs
@@ -27,14 +27,19 @@ use std::error::Error;
 use tokio::sync::mpsc;
 use tracing::{debug, error};
 
-/// Handle outbound connection established events
-/// Send a getheaders request to the peer
+/// Send a getheaders request to the peer.
+///
+/// When depth is 0, the locator starts from the confirmed tip
+/// (normal behavior). When depth > 0, the locator starts from
+/// confirmed_tip - depth, providing overlap to cover fork block
+/// parents that the receiver may not have.
 pub async fn send_getheaders<C>(
     peer_id: libp2p::PeerId,
     chain_store_handle: ChainStoreHandle,
     swarm_tx: mpsc::Sender<SwarmSend<C>>,
+    depth: u32,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    let locator = chain_store_handle.build_locator()?;
+    let locator = chain_store_handle.build_locator(depth)?;
     let stop_block_hash: BlockHash = BlockHash::all_zeros();
     let getheaders_request = Message::GetShareHeaders(locator.clone(), stop_block_hash);
     debug!("Sending GetHeaders to peer {peer_id}: {getheaders_request:?}");
@@ -71,9 +76,9 @@ mod tests {
         chain_store_handle
             .expect_build_locator()
             .times(1)
-            .return_once(move || Ok(test_locator_clone));
+            .return_once(move |_| Ok(test_locator_clone));
 
-        let send_result = send_getheaders(peer_id, chain_store_handle, swarm_tx).await;
+        let send_result = send_getheaders(peer_id, chain_store_handle, swarm_tx, 0).await;
         assert!(send_result.is_ok());
 
         if let Some(SwarmSend::Request(received_peer_id, message)) = swarm_rx.recv().await {
@@ -110,14 +115,14 @@ mod tests {
         chain_store_handle
             .expect_build_locator()
             .times(1)
-            .return_once(move || Ok(test_locator.clone()));
+            .return_once(move |_| Ok(test_locator.clone()));
 
         let swarm_tx_clone = swarm_tx.clone();
 
         // Drop receiver to close channel
         drop(swarm_tx_clone);
 
-        let send_result = send_getheaders(peer_id, chain_store_handle, swarm_tx).await;
+        let send_result = send_getheaders(peer_id, chain_store_handle, swarm_tx, 0).await;
         assert!(send_result.is_err());
         assert!(
             send_result
@@ -133,12 +138,12 @@ mod tests {
 
         mock_chain_store
             .expect_build_locator()
-            .returning(|| Err(StoreError::Database("Build locator failed".to_string())));
+            .returning(|_| Err(StoreError::Database("Build locator failed".to_string())));
 
         let (swarm_tx, _swarm_rx) = channel::<SwarmSend<()>>(1);
         let peer_id = libp2p::PeerId::random();
 
-        let send_result = send_getheaders(peer_id, mock_chain_store, swarm_tx).await;
+        let send_result = send_getheaders(peer_id, mock_chain_store, swarm_tx, 0).await;
         assert!(send_result.is_err());
     }
 }

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -455,10 +455,14 @@ impl ChainStoreHandle {
     /// Build a locator for the chain using only confirmed chain blocks.
     ///
     /// Returns blockhashes at exponentially spaced heights from the
-    /// confirmed chain tip back to genesis. Only confirmed blocks are
-    /// included so that the peer can match against its own confirmed
-    /// chain and find the true fork point.
-    pub fn build_locator(&self) -> Result<Vec<BlockHash>, StoreError> {
+    /// starting height back to genesis. Only confirmed blocks are
+    /// included so that the peer can match against its own chain.
+    ///
+    /// When depth is 0, starts from the confirmed tip (normal
+    /// behavior). When depth > 0, starts from confirmed_tip - depth,
+    /// providing a deeper locator to cover fork block parents that
+    /// the receiver may not have.
+    pub fn build_locator(&self, depth: u32) -> Result<Vec<BlockHash>, StoreError> {
         let tip_height = self.get_tip_height()?;
         match tip_height {
             Some(tip_height) => {
@@ -476,10 +480,12 @@ impl ChainStoreHandle {
             }
         }
 
+        let start_height = tip_height.unwrap().saturating_sub(depth);
+
         let mut indexes = Vec::new();
         let mut step = 1;
 
-        let mut height = tip_height.unwrap();
+        let mut height = start_height;
         while height > 0 {
             if indexes.len() >= 10 {
                 step *= 2;
@@ -769,7 +775,7 @@ mockall::mock! {
         pub fn get_blockhashes_for_locator(&self, locator: &[BlockHash], stop_block_hash: &BlockHash, max_blockhashes: usize) -> Result<Vec<BlockHash>, StoreError>;
         pub fn get_tip_height(&self) -> Result<Option<u32>, StoreError>;
         pub fn get_candidate_tip_height(&self) -> Result<Option<u32>, StoreError>;
-        pub fn build_locator(&self) -> Result<Vec<BlockHash>, StoreError>;
+        pub fn build_locator(&self, depth: u32) -> Result<Vec<BlockHash>, StoreError>;
         pub fn get_chain_tip(&self) -> Result<BlockHash, StoreError>;
         pub fn get_chain_tip_header(&self) -> Result<ShareHeader, StoreError>;
         pub fn get_candidate_tip_header(&self) -> Result<ShareHeader, StoreError>;
@@ -869,7 +875,7 @@ mod tests {
             .await
             .unwrap();
 
-        let locator = chain_handle.build_locator().unwrap();
+        let locator = chain_handle.build_locator(0).unwrap();
         assert_eq!(locator.len(), 1, "Locator should contain exactly genesis");
         assert_eq!(
             locator[0],
@@ -881,7 +887,7 @@ mod tests {
     #[tokio::test]
     async fn test_build_locator_empty_chain() {
         let (chain_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
-        let locator = chain_handle.build_locator().unwrap();
+        let locator = chain_handle.build_locator(0).unwrap();
         assert!(
             locator.is_empty(),
             "Locator for empty chain should be empty"
@@ -917,7 +923,7 @@ mod tests {
             shares.push(share);
         }
 
-        let locator = chain_handle.build_locator().unwrap();
+        let locator = chain_handle.build_locator(0).unwrap();
         // With tip at height 5, step=1 for all entries: heights 5,4,3,2,1,0
         assert_eq!(
             locator.len(),
@@ -984,7 +990,7 @@ mod tests {
             shares.push(share);
         }
 
-        let locator = chain_handle.build_locator().unwrap();
+        let locator = chain_handle.build_locator(0).unwrap();
         // The locator should have fewer entries than the chain length
         // due to step doubling after 10 entries
         assert!(
@@ -1201,7 +1207,7 @@ mod tests {
             "Height 1 should have both confirmed share and uncle"
         );
 
-        let locator = chain_handle.build_locator().unwrap();
+        let locator = chain_handle.build_locator(0).unwrap();
 
         // Locator should contain only confirmed blocks
         assert!(

--- a/p2poolv2_lib/src/shares/share_block/mod.rs
+++ b/p2poolv2_lib/src/shares/share_block/mod.rs
@@ -23,7 +23,6 @@ use crate::shares::extranonce::Extranonce;
 use crate::shares::genesis;
 use crate::shares::share_commitment::ShareCommitment;
 use crate::shares::witness_commitment::WitnessCommitment;
-use crate::stratum::work::coinbase::extract_height_from_coinbase;
 use bitcoin::consensus::encode::Error::ParseFailed;
 use bitcoin::{
     Address, BlockHash, CompactTarget, CompressedPublicKey, Target, TxMerkleNode, Txid, VarInt,

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -179,7 +179,7 @@ impl Store {
         stop_blockhash: &BlockHash,
         limit: usize,
     ) -> Result<Vec<BlockHash>, StoreError> {
-        let start_blockhash = self.first_confirmed_for_locator(locator);
+        let start_blockhash = self.first_known_for_locator(locator);
         // If no blockhash found, return vector with genesis block
         let start_blockhash = match start_blockhash {
             Some(hash) => hash,
@@ -192,19 +192,23 @@ impl Store {
         self.get_descendant_blockhashes(&start_blockhash, stop_blockhash, limit)
     }
 
-    /// Find the first locator hash that is on our confirmed chain.
+    /// Find the first locator hash that we know about.
     ///
     /// Uses a single batch metadata lookup and then walks the locator
-    /// in order to return the first hash with Confirmed status. This
-    /// prevents matching on uncles or stale blocks, which would cause
-    /// get_descendant_blockhashes to walk the confirmed chain from the
-    /// wrong branch.
-    fn first_confirmed_for_locator(&self, locator: &[BlockHash]) -> Option<BlockHash> {
+    /// in order to return the first hash with a valid status
+    /// (HeaderValid, Candidate, Confirmed, or BlockValid). Pending
+    /// and Invalid blocks are skipped.
+    ///
+    /// With height-based walking, get_descendant_blockhashes sends all
+    /// blocks at each height regardless of status, so matching any
+    /// valid block is correct. The locator is ordered newest-first, so
+    /// the first match gives the highest known height.
+    fn first_known_for_locator(&self, locator: &[BlockHash]) -> Option<BlockHash> {
         let metadata_results: HashMap<BlockHash, BlockMetadata> =
             self.get_block_metadata_batch(locator).into_iter().collect();
         for blockhash in locator {
             if let Some(metadata) = metadata_results.get(blockhash) {
-                if metadata.status == Status::Confirmed {
+                if metadata.status != Status::Pending && metadata.status != Status::Invalid {
                     return Some(*blockhash);
                 }
             }
@@ -3428,21 +3432,19 @@ mod tests {
         assert!(result.is_empty());
     }
 
-    /// Locator containing only a non-confirmed block (uncle) must not
-    /// be matched. The old code used get_first_existing_blockhash which
-    /// matched any block in the store regardless of confirmed status.
-    /// That caused get_descendant_blockhashes to walk the confirmed
-    /// chain from the wrong height, returning headers whose parents
-    /// the requester does not have.
+    /// Locator containing a non-confirmed block (uncle) matches it.
+    /// With height-based walking, any valid block in the store is a
+    /// valid locator match. The uncle at h:1 matches, so descendants
+    /// start from h:2.
     ///
     /// Chain:
     ///   genesis(h:0) -> share_a(h:1) -> share_b(h:2)
-    ///                \-> uncle(h:1, not confirmed)
+    ///                \-> uncle(h:1, HeaderValid)
     ///
     /// Locator: [uncle_hash]
-    /// Expected: falls back to genesis, returns share_a then share_b.
+    /// Expected: matches uncle at h:1, returns share_b at h:2.
     #[test]
-    fn test_get_blockhashes_for_locator_skips_non_confirmed_block() {
+    fn test_get_blockhashes_for_locator_matches_non_confirmed_block() {
         let temp_dir = tempdir().unwrap();
         let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
 
@@ -3451,7 +3453,7 @@ mod tests {
         store.setup_genesis(&genesis, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
-        // uncle: child of genesis, stored but not confirmed
+        // uncle: child of genesis, stored as HeaderValid
         let uncle = TestShareBlockBuilder::new()
             .prev_share_blockhash(genesis.block_hash().to_string())
             .nonce(100)
@@ -3472,27 +3474,27 @@ mod tests {
             .build();
         store.push_to_confirmed_chain(&share_b).unwrap();
 
-        // Locator with only the uncle hash
+        // Locator with only the uncle hash -- uncle is HeaderValid at
+        // h:1, so it matches. Descendants start from h:2 (share_b).
         let locator = vec![uncle.block_hash()];
         let result = store
             .get_blockhashes_for_locator(&locator, &BlockHash::all_zeros(), 10)
             .unwrap();
 
-        // Uncle is not confirmed, so no locator match is found.
-        // Falls back to returning just the genesis hash so the
-        // requester can restart sync from the beginning.
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0], genesis.block_hash());
+        assert_eq!(result[0], share_b.block_hash());
     }
 
-    /// first_confirmed_locator_match returns the first confirmed hash
-    /// from the locator, skipping uncles and unknown hashes.
+    /// first_known_for_locator returns the first known hash from the
+    /// locator, matching any valid status (HeaderValid, Candidate,
+    /// Confirmed, BlockValid). Only unknown and invalid hashes are
+    /// skipped.
     ///
     /// Chain:
     ///   genesis(h:0) -> share_a(h:1) -> share_b(h:2)
-    ///                \-> uncle(h:1, not confirmed)
+    ///                \-> uncle(h:1, HeaderValid)
     #[test]
-    fn test_first_confirmed_locator_match_skips_non_confirmed() {
+    fn test_first_known_for_locator_matches_any_valid_status() {
         let temp_dir = tempdir().unwrap();
         let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
 
@@ -3526,29 +3528,33 @@ mod tests {
             .unwrap();
 
         // Locator: [unknown, uncle, share_b, genesis]
-        // Should skip unknown (not in store) and uncle (not confirmed),
-        // then match share_b (confirmed at h:2).
+        // Skips unknown (not in store), matches uncle (HeaderValid).
         let locator = vec![
             unknown_hash,
             uncle.block_hash(),
             share_b.block_hash(),
             genesis.block_hash(),
         ];
-        let result = store.first_confirmed_for_locator(&locator);
-        assert_eq!(result, Some(share_b.block_hash()));
+        let result = store.first_known_for_locator(&locator);
+        assert_eq!(result, Some(uncle.block_hash()));
 
-        // Locator with only non-confirmed entries returns None
-        let locator = vec![unknown_hash, uncle.block_hash()];
-        let result = store.first_confirmed_for_locator(&locator);
+        // Locator with only unknown entries returns None
+        let locator = vec![unknown_hash];
+        let result = store.first_known_for_locator(&locator);
         assert_eq!(result, None);
 
         // Empty locator returns None
-        let result = store.first_confirmed_for_locator(&[]);
+        let result = store.first_known_for_locator(&[]);
         assert_eq!(result, None);
+
+        // Locator with HeaderValid entry matches it
+        let locator = vec![uncle.block_hash(), genesis.block_hash()];
+        let result = store.first_known_for_locator(&locator);
+        assert_eq!(result, Some(uncle.block_hash()));
 
         // Locator with only confirmed entries returns the first one
         let locator = vec![share_a.block_hash(), genesis.block_hash()];
-        let result = store.first_confirmed_for_locator(&locator);
+        let result = store.first_known_for_locator(&locator);
         assert_eq!(result, Some(share_a.block_hash()));
     }
 

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -1051,11 +1051,13 @@ mod tests {
         expected.push(share_b.block_hash());
         assert_eq!(descendants, expected);
 
-        // Descendants from share_a (h:1): starts at h:2, only share_b
+        // Descendants from share_a (h:1): with MAX_UNCLES_DEPTH overlap,
+        // starts at max(1-3,0)+1 = h:1. Includes h:1 (share_a, uncle1)
+        // and h:2 (share_b).
         let descendants = store
             .get_descendant_blockhashes(&share_a.block_hash(), &BlockHash::all_zeros(), 10)
             .unwrap();
-        assert_eq!(descendants, vec![share_b.block_hash()]);
+        assert_eq!(descendants, expected);
 
         // Test with limit: limit=2 completes h:1 (2 blocks) then stops
         let descendants = store
@@ -1147,17 +1149,17 @@ mod tests {
     }
 
     /// Long chain test: locator match deep in the chain. Height-based
-    /// walk starts at locator_height+1 and includes all blocks at each
-    /// height up to top confirmed. Blocks at or below the locator
-    /// height are not included (receiver already has them from a
-    /// previous batch).
+    /// walk starts at locator_height - MAX_UNCLES_DEPTH + 1 and
+    /// includes all blocks at each height up to top confirmed. The
+    /// overlap ensures fork block parents near the boundary are
+    /// included.
     ///
     /// Chain:
     ///   genesis(h:0) -> h:1 -> ... -> h:5 -> h:6 -> ... -> h:8 -> h:9(uncles=[uncle]) -> h:10
     ///                                      \-> uncle(h:6, parent=h:5)
     ///
-    /// Locator at h:8. Walk starts at h:9. Uncle at h:6 is below
-    /// locator height so it is NOT in this batch (was in previous batch).
+    /// Locator at h:8. Walk starts at max(8-3,0)+1 = h:6. Uncle at
+    /// h:6 is included in the overlap.
     #[test]
     fn test_get_descendant_blockhashes_long_chain_starts_at_uncle_depth() {
         let temp_dir = tempdir().unwrap();
@@ -1209,15 +1211,25 @@ mod tests {
         store.push_to_confirmed_chain(&block_h10).unwrap();
         chain.push(block_h10);
 
-        // Locator at h:8 (chain[7]). Walk starts at h:9.
+        // Locator at h:8 (chain[7]). With MAX_UNCLES_DEPTH=3 overlap,
+        // walk starts at max(8-3,0)+1 = h:6. Includes h:6 (chain[5] +
+        // uncle), h:7 (chain[6]), h:8 (chain[7]), h:9 (chain[8]),
+        // h:10 (chain[9]).
         let locator_block = &chain[7];
         let descendants = store
             .get_descendant_blockhashes(&locator_block.block_hash(), &BlockHash::all_zeros(), 100)
             .unwrap();
 
-        // h:9 has confirmed + uncle (both at h:9... wait, uncle is at h:6)
-        // Actually uncle is at h:6, below locator. Only h:9 and h:10.
-        let expected = vec![chain[8].block_hash(), chain[9].block_hash()];
+        let mut expected: Vec<BlockHash> = Vec::new();
+        // h:6: chain[5] + uncle
+        let mut height_6 = vec![chain[5].block_hash(), uncle.block_hash()];
+        height_6.sort();
+        expected.extend(height_6);
+        // h:7, h:8, h:9, h:10
+        expected.push(chain[6].block_hash());
+        expected.push(chain[7].block_hash());
+        expected.push(chain[8].block_hash());
+        expected.push(chain[9].block_hash());
         assert_eq!(descendants, expected);
     }
 
@@ -3475,14 +3487,18 @@ mod tests {
         store.push_to_confirmed_chain(&share_b).unwrap();
 
         // Locator with only the uncle hash -- uncle is HeaderValid at
-        // h:1, so it matches. Descendants start from h:2 (share_b).
+        // h:1, so it matches. With MAX_UNCLES_DEPTH overlap, start
+        // height is max(1-3,0)+1 = 1. Returns all blocks at h:1
+        // (uncle, share_a) and h:2 (share_b).
         let locator = vec![uncle.block_hash()];
         let result = store
             .get_blockhashes_for_locator(&locator, &BlockHash::all_zeros(), 10)
             .unwrap();
 
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0], share_b.block_hash());
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&uncle.block_hash()));
+        assert!(result.contains(&share_a.block_hash()));
+        assert!(result.contains(&share_b.block_hash()));
     }
 
     /// first_known_for_locator returns the first known hash from the

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -996,8 +996,9 @@ mod tests {
         assert_eq!(result[1], block_hashes[2]);
     }
 
-    /// Test that get_descendant_blockhashes walks the confirmed chain
-    /// and includes uncle blockhashes before the nephew that references them.
+    /// Test that get_descendant_blockhashes gets all descendants from
+    /// height index and includes uncle blockhashes before the nephew
+    /// that references them.
     ///
     /// Chain:
     ///   genesis(h:0) -> share_a(h:1) -> share_b(h:2, uncles=[uncle1])
@@ -1036,66 +1037,45 @@ mod tests {
             .build();
         store.push_to_confirmed_chain(&share_b).unwrap();
 
-        // Descendants from genesis: should get share_a, uncle1, share_b
+        // Descendants from genesis: h:1 (share_a, uncle1 lex sorted), h:2 (share_b)
         let descendants = store
             .get_descendant_blockhashes(&genesis.block_hash(), &BlockHash::all_zeros(), 10)
             .unwrap();
-        assert_eq!(descendants.len(), 3);
-        assert_eq!(descendants[0], share_a.block_hash());
-        // uncle1 must appear before share_b (its nephew)
-        assert_eq!(descendants[1], uncle1.block_hash());
-        assert_eq!(descendants[2], share_b.block_hash());
+        let mut height_1 = vec![share_a.block_hash(), uncle1.block_hash()];
+        height_1.sort();
+        let mut expected = height_1.clone();
+        expected.push(share_b.block_hash());
+        assert_eq!(descendants, expected);
 
-        // Descendants from share_a: uncle scan covers h:0..=1, so both
-        // share_a and uncle1 at h:1 are included, then share_b from the
-        // confirmed chain walk.
+        // Descendants from share_a (h:1): starts at h:2, only share_b
         let descendants = store
             .get_descendant_blockhashes(&share_a.block_hash(), &BlockHash::all_zeros(), 10)
             .unwrap();
-        assert_eq!(descendants.len(), 3);
-        assert!(descendants.contains(&share_a.block_hash()));
-        assert!(descendants.contains(&uncle1.block_hash()));
-        assert!(descendants.contains(&share_b.block_hash()));
-        // uncle1 must appear before share_b (its nephew)
-        let uncle1_pos = descendants
-            .iter()
-            .position(|h| *h == uncle1.block_hash())
-            .unwrap();
-        let share_b_pos = descendants
-            .iter()
-            .position(|h| *h == share_b.block_hash())
-            .unwrap();
-        assert!(uncle1_pos < share_b_pos);
+        assert_eq!(descendants, vec![share_b.block_hash()]);
 
-        // Test with limit: limit=2 stops after height 1 (share_a) but height 2
-        // adds uncle1 + share_b atomically so the batch contains all 3
+        // Test with limit: limit=2 completes h:1 (2 blocks) then stops
         let descendants = store
             .get_descendant_blockhashes(&genesis.block_hash(), &BlockHash::all_zeros(), 2)
             .unwrap();
-        assert_eq!(descendants.len(), 3);
-        assert_eq!(descendants[0], share_a.block_hash());
-        assert_eq!(descendants[1], uncle1.block_hash());
-        assert_eq!(descendants[2], share_b.block_hash());
+        assert_eq!(descendants, height_1);
 
-        // Test with stop_blockhash - stop at share_a includes share_a
+        // Test with stop_blockhash: stop hash at h:1, completes h:1
         let descendants = store
             .get_descendant_blockhashes(&genesis.block_hash(), &share_a.block_hash(), 10)
             .unwrap();
-        assert_eq!(descendants.len(), 1);
-        assert_eq!(descendants[0], share_a.block_hash());
+        assert_eq!(descendants, height_1);
     }
 
-    /// Uncle-of-uncle test: when a confirmed block references an uncle
-    /// that itself references another uncle, both are included in the
-    /// descendant response.
+    /// Uncle-of-uncle test with valid ancestor relationships.
+    /// Height-based walk includes all blocks at each height.
     ///
     /// Chain:
-    ///   genesis(h:0) -> A(h:1) -> B(h:2, uncles=[uncle1])
+    ///   genesis(h:0) -> A(h:1) -> B(h:2) -> C(h:3, uncles=[uncle1])
     ///                \-> uncle2(h:1)
-    ///                \-> uncle1(h:1, uncles=[uncle2])
+    ///                    A(h:1) -> uncle1(h:2, uncles=[uncle2])
     ///
-    /// uncle1 is referenced by B. uncle1 references uncle2.
-    /// Both uncle1 and uncle2 must appear in descendants.
+    /// uncle1 at h:2 is uncle of C at h:3 (ancestor height).
+    /// uncle2 at h:1 is uncle of uncle1 at h:2 (ancestor height).
     #[test]
     fn test_get_descendant_blockhashes_chases_uncle_of_uncle() {
         let temp_dir = tempdir().unwrap();
@@ -1106,21 +1086,6 @@ mod tests {
         store.setup_genesis(&genesis, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
-        // uncle2: child of genesis, no uncles of its own
-        let uncle2 = TestShareBlockBuilder::new()
-            .prev_share_blockhash(genesis.block_hash().to_string())
-            .nonce(200)
-            .build();
-        store.store_with_valid_metadata(&uncle2);
-
-        // uncle1: child of genesis, references uncle2
-        let uncle1 = TestShareBlockBuilder::new()
-            .prev_share_blockhash(genesis.block_hash().to_string())
-            .uncles(vec![uncle2.block_hash()])
-            .nonce(100)
-            .build();
-        store.store_with_valid_metadata(&uncle1);
-
         // A: confirmed at h:1
         let share_a = TestShareBlockBuilder::new()
             .prev_share_blockhash(genesis.block_hash().to_string())
@@ -1129,64 +1094,66 @@ mod tests {
             .build();
         store.push_to_confirmed_chain(&share_a).unwrap();
 
-        // B: confirmed at h:2, references uncle1
+        // uncle2: child of genesis at h:1, no uncles
+        let uncle2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(200)
+            .build();
+        store.store_with_valid_metadata(&uncle2);
+
+        // B: confirmed at h:2
         let share_b = TestShareBlockBuilder::new()
             .prev_share_blockhash(share_a.block_hash().to_string())
-            .uncles(vec![uncle1.block_hash()])
+            .work(2)
             .nonce(2)
             .build();
         store.push_to_confirmed_chain(&share_b).unwrap();
+
+        // uncle1: child of A at h:2, references uncle2 at h:1 as uncle
+        let uncle1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share_a.block_hash().to_string())
+            .uncles(vec![uncle2.block_hash()])
+            .nonce(100)
+            .build();
+        store.store_with_valid_metadata(&uncle1);
+
+        // C: confirmed at h:3, references uncle1 at h:2 as uncle
+        let share_c = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share_b.block_hash().to_string())
+            .uncles(vec![uncle1.block_hash()])
+            .work(2)
+            .nonce(3)
+            .build();
+        store.push_to_confirmed_chain(&share_c).unwrap();
 
         let descendants = store
             .get_descendant_blockhashes(&genesis.block_hash(), &BlockHash::all_zeros(), 10)
             .unwrap();
 
-        assert!(
-            descendants.contains(&share_a.block_hash()),
-            "confirmed A should be included"
-        );
-        assert!(
-            descendants.contains(&uncle1.block_hash()),
-            "uncle1 should be included (referenced by B)"
-        );
-        assert!(
-            descendants.contains(&uncle2.block_hash()),
-            "uncle2 should be included (uncle-of-uncle, referenced by uncle1)"
-        );
-        assert!(
-            descendants.contains(&share_b.block_hash()),
-            "confirmed B should be included"
-        );
-
-        // uncle2 must appear before share_b (transitive dependency)
-        let uncle2_pos = descendants
-            .iter()
-            .position(|h| *h == uncle2.block_hash())
-            .unwrap();
-        let share_b_pos = descendants
-            .iter()
-            .position(|h| *h == share_b.block_hash())
-            .unwrap();
-        assert!(
-            uncle2_pos < share_b_pos,
-            "uncle2 must appear before share_b"
-        );
+        // h:1 has share_a, uncle2; h:2 has share_b, uncle1; h:3 has share_c
+        let mut expected: Vec<BlockHash> = Vec::new();
+        let mut height_1 = vec![share_a.block_hash(), uncle2.block_hash()];
+        height_1.sort();
+        expected.extend(height_1);
+        let mut height_2 = vec![share_b.block_hash(), uncle1.block_hash()];
+        height_2.sort();
+        expected.extend(height_2);
+        expected.push(share_c.block_hash());
+        assert_eq!(descendants, expected);
     }
 
-    /// Long chain test: when the anchor is deep in the chain, the
-    /// confirmed walk starts from anchor - MAX_UNCLES_DEPTH so that
-    /// uncle references near the anchor are served. Blocks before the
-    /// uncle depth window are excluded.
+    /// Long chain test: locator match deep in the chain. Height-based
+    /// walk starts at locator_height+1 and includes all blocks at each
+    /// height up to top confirmed. Blocks at or below the locator
+    /// height are not included (receiver already has them from a
+    /// previous batch).
     ///
     /// Chain:
     ///   genesis(h:0) -> h:1 -> ... -> h:5 -> h:6 -> ... -> h:8 -> h:9(uncles=[uncle]) -> h:10
     ///                                      \-> uncle(h:6, parent=h:5)
     ///
-    /// Anchor at h:8. Walk starts at h:8 - 3 + 1 = h:6.
-    /// Confirmed blocks h:6..h:10 and the uncle at h:6 (referenced
-    /// by h:9) should be included. Blocks at h:1 through h:5 must NOT.
-    /// The uncle's parent is at h:5, which is MAX_UNCLES_DEPTH below
-    /// the anchor -- the deepest allowed uncle ancestor, because h:8 has to be confirmed anchor.
+    /// Locator at h:8. Walk starts at h:9. Uncle at h:6 is below
+    /// locator height so it is NOT in this batch (was in previous batch).
     #[test]
     fn test_get_descendant_blockhashes_long_chain_starts_at_uncle_depth() {
         let temp_dir = tempdir().unwrap();
@@ -1238,50 +1205,609 @@ mod tests {
         store.push_to_confirmed_chain(&block_h10).unwrap();
         chain.push(block_h10);
 
-        // Anchor at h:8 (chain[7]). Walk starts at h:8 - 3 + 1 = h:6.
-        let anchor = &chain[7];
+        // Locator at h:8 (chain[7]). Walk starts at h:9.
+        let locator_block = &chain[7];
         let descendants = store
-            .get_descendant_blockhashes(&anchor.block_hash(), &BlockHash::all_zeros(), 100)
+            .get_descendant_blockhashes(&locator_block.block_hash(), &BlockHash::all_zeros(), 100)
             .unwrap();
 
-        // h:6 (chain[5]), h:7 (chain[6]), h:8 (chain[7]) from early
-        // walk, then uncle (referenced by h:9) + h:9 + h:10
+        // h:9 has confirmed + uncle (both at h:9... wait, uncle is at h:6)
+        // Actually uncle is at h:6, below locator. Only h:9 and h:10.
+        let expected = vec![chain[8].block_hash(), chain[9].block_hash()];
+        assert_eq!(descendants, expected);
+    }
+
+    /// A parallel fork chain runs alongside the confirmed chain.
+    /// Height-based walking includes all blocks at each height, so
+    /// fork blocks appear naturally without chasing uncle references.
+    ///
+    /// DAG structure:
+    ///
+    /// Confirmed: genesis -> C1(h:1) -> C2(h:2) -> C3(h:3) -> C4(h:4) -> C5(h:5)
+    /// Fork:                 C1(h:1) -> F2(h:2) -> F3(h:3) -> F4(h:4) -> F5(h:5)
+    /// Fork2:                                       F3(h:3) -> G4(h:4) -> G5(h:5)
+    ///
+    /// All blocks at each height are included: confirmed, fork, and
+    /// fork2 blocks all appear in the response sorted lexicographically
+    /// within each height.
+    #[test]
+    fn test_get_descendant_blockhashes_includes_fork_chain_ancestry() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Confirmed chain: genesis -> C1 -> C2 -> C3 -> C4 -> C5
+        let confirmed_1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .work(2)
+            .nonce(10)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_1).unwrap();
+
+        let confirmed_2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_1.block_hash().to_string())
+            .work(2)
+            .nonce(20)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_2).unwrap();
+
+        let confirmed_3 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_2.block_hash().to_string())
+            .work(2)
+            .nonce(30)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_3).unwrap();
+
+        let confirmed_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_3.block_hash().to_string())
+            .work(2)
+            .nonce(40)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_4).unwrap();
+
+        // Fork chain: C1 -> F2 -> F3 -> F4 -> F5
+        let fork_2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_1.block_hash().to_string())
+            .nonce(200)
+            .build();
+        store.store_with_valid_metadata(&fork_2);
+
+        let fork_3 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_2.block_hash().to_string())
+            .uncles(vec![confirmed_2.block_hash()])
+            .nonce(300)
+            .build();
+        store.store_with_valid_metadata(&fork_3);
+
+        let fork_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_3.block_hash().to_string())
+            .nonce(400)
+            .build();
+        store.store_with_valid_metadata(&fork_4);
+
+        let fork_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_4.block_hash().to_string())
+            .uncles(vec![confirmed_4.block_hash()])
+            .nonce(500)
+            .build();
+        store.store_with_valid_metadata(&fork_5);
+
+        // Second fork chain from F3: F3 -> G4 -> G5 (unreferenced)
+        let fork2_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_3.block_hash().to_string())
+            .nonce(410)
+            .build();
+        store.store_with_valid_metadata(&fork2_4);
+
+        let fork2_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork2_4.block_hash().to_string())
+            .nonce(510)
+            .build();
+        store.store_with_valid_metadata(&fork2_5);
+
+        // C5 references F2 as uncle, pulling the fork into the DAG
+        let confirmed_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_4.block_hash().to_string())
+            .uncles(vec![fork_2.block_hash()])
+            .work(2)
+            .nonce(50)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_5).unwrap();
+
+        let descendants = store
+            .get_descendant_blockhashes(&genesis.block_hash(), &BlockHash::all_zeros(), 100)
+            .unwrap();
+
+        // Build expected: all blocks per height, lex sorted within height
+        let mut expected: Vec<BlockHash> = Vec::new();
+        // h:1
+        let mut height_1 = vec![confirmed_1.block_hash()];
+        height_1.sort();
+        expected.extend(height_1);
+        // h:2
+        let mut height_2 = vec![confirmed_2.block_hash(), fork_2.block_hash()];
+        height_2.sort();
+        expected.extend(height_2);
+        // h:3
+        let mut height_3 = vec![confirmed_3.block_hash(), fork_3.block_hash()];
+        height_3.sort();
+        expected.extend(height_3);
+        // h:4
+        let mut height_4 = vec![
+            confirmed_4.block_hash(),
+            fork_4.block_hash(),
+            fork2_4.block_hash(),
+        ];
+        height_4.sort();
+        expected.extend(height_4);
+        // h:5
+        let mut height_5 = vec![
+            confirmed_5.block_hash(),
+            fork_5.block_hash(),
+            fork2_5.block_hash(),
+        ];
+        height_5.sort();
+        expected.extend(height_5);
+
+        assert_eq!(descendants, expected);
+    }
+
+    /// Same DAG as the previous test but F5 also references G4 as
+    /// uncle. With height-based walking all blocks appear regardless
+    /// of uncle references.
+    ///
+    /// Confirmed: genesis -> C1(h:1) -> C2(h:2) -> C3(h:3) -> C4(h:4) -> C5(h:5)
+    /// Fork:                 C1(h:1) -> F2(h:2) -> F3(h:3) -> F4(h:4) -> F5(h:5)
+    /// Fork2:                                       F3(h:3) -> G4(h:4) -> G5(h:5)
+    #[test]
+    fn test_get_descendant_blockhashes_includes_fork_uncle_of_fork() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Confirmed chain: genesis -> C1 -> C2 -> C3 -> C4 -> C5
+        let confirmed_1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .work(2)
+            .nonce(10)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_1).unwrap();
+
+        let confirmed_2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_1.block_hash().to_string())
+            .work(2)
+            .nonce(20)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_2).unwrap();
+
+        let confirmed_3 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_2.block_hash().to_string())
+            .work(2)
+            .nonce(30)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_3).unwrap();
+
+        let confirmed_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_3.block_hash().to_string())
+            .work(2)
+            .nonce(40)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_4).unwrap();
+
+        // Fork chain: C1 -> F2 -> F3 -> F4 -> F5
+        let fork_2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_1.block_hash().to_string())
+            .nonce(200)
+            .build();
+        store.store_with_valid_metadata(&fork_2);
+
+        let fork_3 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_2.block_hash().to_string())
+            .uncles(vec![confirmed_2.block_hash()])
+            .nonce(300)
+            .build();
+        store.store_with_valid_metadata(&fork_3);
+
+        let fork_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_3.block_hash().to_string())
+            .nonce(400)
+            .build();
+        store.store_with_valid_metadata(&fork_4);
+
+        // Second fork from F3: F3 -> G4 -> G5
+        let fork2_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_3.block_hash().to_string())
+            .nonce(410)
+            .build();
+        store.store_with_valid_metadata(&fork2_4);
+
+        let fork2_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork2_4.block_hash().to_string())
+            .nonce(510)
+            .build();
+        store.store_with_valid_metadata(&fork2_5);
+
+        // F5 references both C4 and G4 as uncles
+        let fork_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_4.block_hash().to_string())
+            .uncles(vec![confirmed_4.block_hash(), fork2_4.block_hash()])
+            .nonce(500)
+            .build();
+        store.store_with_valid_metadata(&fork_5);
+
+        // C5 references F2 as uncle
+        let confirmed_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_4.block_hash().to_string())
+            .uncles(vec![fork_2.block_hash()])
+            .work(2)
+            .nonce(50)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_5).unwrap();
+
+        let descendants = store
+            .get_descendant_blockhashes(&genesis.block_hash(), &BlockHash::all_zeros(), 100)
+            .unwrap();
+
+        // Confirmed chain
         assert!(
-            descendants.contains(&chain[5].block_hash()),
-            "h:6 should be included (walk starts at h:6)"
+            descendants.contains(&confirmed_1.block_hash()),
+            "C1 missing"
         );
         assert!(
-            descendants.contains(&chain[6].block_hash()),
-            "h:7 should be included"
+            descendants.contains(&confirmed_2.block_hash()),
+            "C2 missing"
         );
         assert!(
-            descendants.contains(&chain[7].block_hash()),
-            "h:8 should be included"
+            descendants.contains(&confirmed_3.block_hash()),
+            "C3 missing"
         );
         assert!(
-            descendants.contains(&uncle.block_hash()),
-            "uncle at h:6 should be included (referenced by h:9)"
+            descendants.contains(&confirmed_4.block_hash()),
+            "C4 missing"
         );
         assert!(
-            descendants.contains(&chain[8].block_hash()),
-            "h:9 should be included"
-        );
-        assert!(
-            descendants.contains(&chain[9].block_hash()),
-            "h:10 should be included"
+            descendants.contains(&confirmed_5.block_hash()),
+            "C5 missing"
         );
 
-        // Blocks before uncle depth window should NOT be included
+        // All fork blocks included via height-based walk
+        assert!(descendants.contains(&fork_2.block_hash()), "F2 missing");
+        assert!(descendants.contains(&fork_3.block_hash()), "F3 missing");
+        assert!(descendants.contains(&fork_4.block_hash()), "F4 missing");
+        assert!(descendants.contains(&fork_5.block_hash()), "F5 missing");
+        assert!(descendants.contains(&fork2_4.block_hash()), "G4 missing");
         assert!(
-            !descendants.contains(&genesis.block_hash()),
-            "genesis should not be included"
+            descendants.contains(&fork2_5.block_hash()),
+            "G5 should appear (height-based walk includes all blocks at each height)"
         );
-        for early_block in &chain[..5] {
-            assert!(
-                !descendants.contains(&early_block.block_hash()),
-                "block before uncle depth window should not be included"
-            );
-        }
+    }
+
+    /// Height-based walking includes all blocks at each height,
+    /// covering fork blocks that the old reference-chasing approach
+    /// missed.
+    ///
+    /// Confirmed: genesis -> C1(h:1) -> C2(h:2) -> C3(h:3) -> C4(h:4) -> C5(h:5) -> C6(h:6) -> C7(h:7)
+    /// Fork:                 C1(h:1) -> F2(h:2) -> F3(h:3) -> F4(h:4) -> F5(h:5)
+    /// Fork2:                                       F3(h:3) -> G4(h:4) -> G5(h:5)
+    /// Uncle:                                                              U6(h:6)
+    #[test]
+    fn test_get_descendant_blockhashes_chases_uncle_parent_chain() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Confirmed chain: genesis -> C1 -> C2 -> C3 -> C4 -> C5 -> C6
+        let confirmed_1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .work(2)
+            .nonce(10)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_1).unwrap();
+
+        let confirmed_2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_1.block_hash().to_string())
+            .work(2)
+            .nonce(20)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_2).unwrap();
+
+        let confirmed_3 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_2.block_hash().to_string())
+            .work(2)
+            .nonce(30)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_3).unwrap();
+
+        let confirmed_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_3.block_hash().to_string())
+            .work(2)
+            .nonce(40)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_4).unwrap();
+
+        // Fork chain: C1 -> F2 -> F3 -> F4 -> F5
+        let fork_2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_1.block_hash().to_string())
+            .nonce(200)
+            .build();
+        store.store_with_valid_metadata(&fork_2);
+
+        let fork_3 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_2.block_hash().to_string())
+            .nonce(300)
+            .build();
+        store.store_with_valid_metadata(&fork_3);
+
+        let fork_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_3.block_hash().to_string())
+            .nonce(400)
+            .build();
+        store.store_with_valid_metadata(&fork_4);
+
+        let fork_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_4.block_hash().to_string())
+            .nonce(500)
+            .build();
+        store.store_with_valid_metadata(&fork_5);
+
+        // Second fork from F3: F3 -> G4 -> G5 (unreferenced)
+        let fork2_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_3.block_hash().to_string())
+            .nonce(410)
+            .build();
+        store.store_with_valid_metadata(&fork2_4);
+
+        let fork2_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork2_4.block_hash().to_string())
+            .nonce(510)
+            .build();
+        store.store_with_valid_metadata(&fork2_5);
+
+        // C5 references F2 (fork base) as uncle
+        let confirmed_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_4.block_hash().to_string())
+            .uncles(vec![fork_2.block_hash()])
+            .work(2)
+            .nonce(50)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_5).unwrap();
+
+        let confirmed_6 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_5.block_hash().to_string())
+            .work(2)
+            .nonce(60)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_6).unwrap();
+
+        // U6: uncle at h:6 that references F5 (fork tip) as its uncle
+        let uncle_6 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_5.block_hash().to_string())
+            .uncles(vec![fork_5.block_hash()])
+            .nonce(600)
+            .build();
+        store.store_with_valid_metadata(&uncle_6);
+
+        // C7 references U6 as uncle
+        let confirmed_7 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_6.block_hash().to_string())
+            .uncles(vec![uncle_6.block_hash()])
+            .work(2)
+            .nonce(70)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_7).unwrap();
+
+        let descendants = store
+            .get_descendant_blockhashes(&genesis.block_hash(), &BlockHash::all_zeros(), 100)
+            .unwrap();
+
+        let mut expected: Vec<BlockHash> = Vec::new();
+        // h:1
+        expected.push(confirmed_1.block_hash());
+        // h:2
+        let mut height_2 = vec![confirmed_2.block_hash(), fork_2.block_hash()];
+        height_2.sort();
+        expected.extend(height_2);
+        // h:3
+        let mut height_3 = vec![confirmed_3.block_hash(), fork_3.block_hash()];
+        height_3.sort();
+        expected.extend(height_3);
+        // h:4
+        let mut height_4 = vec![
+            confirmed_4.block_hash(),
+            fork_4.block_hash(),
+            fork2_4.block_hash(),
+        ];
+        height_4.sort();
+        expected.extend(height_4);
+        // h:5
+        let mut height_5 = vec![
+            confirmed_5.block_hash(),
+            fork_5.block_hash(),
+            fork2_5.block_hash(),
+        ];
+        height_5.sort();
+        expected.extend(height_5);
+        // h:6
+        let mut height_6 = vec![confirmed_6.block_hash(), uncle_6.block_hash()];
+        height_6.sort();
+        expected.extend(height_6);
+        // h:7
+        expected.push(confirmed_7.block_hash());
+
+        assert_eq!(descendants, expected);
+    }
+
+    /// Same DAG as above but F5 also references G4 as uncle. With
+    /// height-based walking all blocks appear regardless of uncle
+    /// references.
+    ///
+    /// Confirmed: genesis -> C1 -> C2 -> C3 -> C4 -> C5 -> C6 -> C7
+    /// Fork:                 C1 -> F2 -> F3 -> F4 -> F5
+    /// Fork2:                            F3 -> G4 -> G5
+    /// Uncle:                                          U6
+    #[test]
+    fn test_get_descendant_blockhashes_chases_uncle_parent_chain_with_fork_uncle() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Confirmed chain: genesis -> C1 -> C2 -> C3 -> C4
+        let confirmed_1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .work(2)
+            .nonce(10)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_1).unwrap();
+
+        let confirmed_2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_1.block_hash().to_string())
+            .work(2)
+            .nonce(20)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_2).unwrap();
+
+        let confirmed_3 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_2.block_hash().to_string())
+            .work(2)
+            .nonce(30)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_3).unwrap();
+
+        let confirmed_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_3.block_hash().to_string())
+            .work(2)
+            .nonce(40)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_4).unwrap();
+
+        // Fork chain: C1 -> F2 -> F3 -> F4
+        let fork_2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_1.block_hash().to_string())
+            .nonce(200)
+            .build();
+        store.store_with_valid_metadata(&fork_2);
+
+        let fork_3 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_2.block_hash().to_string())
+            .nonce(300)
+            .build();
+        store.store_with_valid_metadata(&fork_3);
+
+        let fork_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_3.block_hash().to_string())
+            .nonce(400)
+            .build();
+        store.store_with_valid_metadata(&fork_4);
+
+        // Second fork from F3: F3 -> G4 -> G5
+        let fork2_4 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_3.block_hash().to_string())
+            .nonce(410)
+            .build();
+        store.store_with_valid_metadata(&fork2_4);
+
+        let fork2_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork2_4.block_hash().to_string())
+            .nonce(510)
+            .build();
+        store.store_with_valid_metadata(&fork2_5);
+
+        // F5 references G4 as uncle
+        let fork_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_4.block_hash().to_string())
+            .uncles(vec![fork2_4.block_hash()])
+            .nonce(500)
+            .build();
+        store.store_with_valid_metadata(&fork_5);
+
+        // C5 references F2 as uncle
+        let confirmed_5 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_4.block_hash().to_string())
+            .uncles(vec![fork_2.block_hash()])
+            .work(2)
+            .nonce(50)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_5).unwrap();
+
+        let confirmed_6 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_5.block_hash().to_string())
+            .work(2)
+            .nonce(60)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_6).unwrap();
+
+        // U6 references F5 as uncle
+        let uncle_6 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_5.block_hash().to_string())
+            .uncles(vec![fork_5.block_hash()])
+            .nonce(600)
+            .build();
+        store.store_with_valid_metadata(&uncle_6);
+
+        // C7 references U6 as uncle
+        let confirmed_7 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed_6.block_hash().to_string())
+            .uncles(vec![uncle_6.block_hash()])
+            .work(2)
+            .nonce(70)
+            .build();
+        store.push_to_confirmed_chain(&confirmed_7).unwrap();
+
+        let descendants = store
+            .get_descendant_blockhashes(&genesis.block_hash(), &BlockHash::all_zeros(), 100)
+            .unwrap();
+
+        let mut expected: Vec<BlockHash> = Vec::new();
+        // h:1
+        expected.push(confirmed_1.block_hash());
+        // h:2
+        let mut height_2 = vec![confirmed_2.block_hash(), fork_2.block_hash()];
+        height_2.sort();
+        expected.extend(height_2);
+        // h:3
+        let mut height_3 = vec![confirmed_3.block_hash(), fork_3.block_hash()];
+        height_3.sort();
+        expected.extend(height_3);
+        // h:4
+        let mut height_4 = vec![
+            confirmed_4.block_hash(),
+            fork_4.block_hash(),
+            fork2_4.block_hash(),
+        ];
+        height_4.sort();
+        expected.extend(height_4);
+        // h:5
+        let mut height_5 = vec![
+            confirmed_5.block_hash(),
+            fork_5.block_hash(),
+            fork2_5.block_hash(),
+        ];
+        height_5.sort();
+        expected.extend(height_5);
+        // h:6
+        let mut height_6 = vec![confirmed_6.block_hash(), uncle_6.block_hash()];
+        height_6.sort();
+        expected.extend(height_6);
+        // h:7
+        expected.push(confirmed_7.block_hash());
+
+        assert_eq!(descendants, expected);
     }
 
     #[test]
@@ -2957,73 +3483,6 @@ mod tests {
         // requester can restart sync from the beginning.
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], genesis.block_hash());
-    }
-
-    /// When the locator contains a non-confirmed block at a different
-    /// height than its confirmed counterpart
-    ///
-    /// Chain:
-    ///   genesis(h:0) -> share_a(h:1) -> share_b(h:2) -> share_c(h:3)
-    ///
-    /// Unconfirmed block stored at height 2:
-    ///   uncle(h:2, parent=share_a, not confirmed)
-    ///
-    /// Locator: [uncle_hash, genesis_hash]
-    ///
-    /// Required behavior: skips uncle (not confirmed), matches genesis,
-    ///   returns [share_a, share_b, share_c] -- a complete chain.
-    #[test]
-    fn test_get_blockhashes_for_locator_skips_uncle_at_different_height() {
-        let temp_dir = tempdir().unwrap();
-        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
-
-        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
-        let mut batch = Store::get_write_batch();
-        store.setup_genesis(&genesis, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
-
-        let share_a = TestShareBlockBuilder::new()
-            .prev_share_blockhash(genesis.block_hash().to_string())
-            .work(2)
-            .nonce(1)
-            .build();
-        store.push_to_confirmed_chain(&share_a).unwrap();
-
-        let share_b = TestShareBlockBuilder::new()
-            .prev_share_blockhash(share_a.block_hash().to_string())
-            .work(2)
-            .nonce(2)
-            .build();
-        store.push_to_confirmed_chain(&share_b).unwrap();
-
-        let share_c = TestShareBlockBuilder::new()
-            .prev_share_blockhash(share_b.block_hash().to_string())
-            .work(2)
-            .nonce(3)
-            .build();
-        store.push_to_confirmed_chain(&share_c).unwrap();
-
-        // Uncle at height 2: stored but not on the confirmed chain.
-        // Its parent is share_a, so it competes with share_b for h:2.
-        let uncle = TestShareBlockBuilder::new()
-            .prev_share_blockhash(share_a.block_hash().to_string())
-            .nonce(100)
-            .build();
-        store.store_with_valid_metadata(&uncle);
-
-        // Locator: uncle first (exists at h:2 but not confirmed),
-        // then genesis (confirmed at h:0).
-        let locator = vec![uncle.block_hash(), genesis.block_hash()];
-        let result = store
-            .get_blockhashes_for_locator(&locator, &BlockHash::all_zeros(), 10)
-            .unwrap();
-
-        // Should skip uncle, match genesis, return all confirmed
-        // descendants: share_a, share_b, share_c.
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0], share_a.block_hash());
-        assert_eq!(result[1], share_b.block_hash());
-        assert_eq!(result[2], share_c.block_hash());
     }
 
     /// first_confirmed_locator_match returns the first confirmed hash

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -2846,14 +2846,14 @@ mod tests {
             .nonce(5)
             .build();
 
-        // Store uncle shares with Valid metadata so find_uncles can read their metadata
+        // Confirm main chain up to each uncle's parent before storing uncles
+        store.push_to_confirmed_chain(&share1).unwrap();
         store.store_with_valid_metadata(&uncle_deep);
+        store.push_to_confirmed_chain(&share2).unwrap();
+        store.push_to_confirmed_chain(&share3).unwrap();
         store.store_with_valid_metadata(&uncle_within);
-
-        // Confirm main chain (share1 through share5) using push_to_confirmed_chain
-        for share in [&share1, &share2, &share3, &share4, &share5] {
-            store.push_to_confirmed_chain(share).unwrap();
-        }
+        store.push_to_confirmed_chain(&share4).unwrap();
+        store.push_to_confirmed_chain(&share5).unwrap();
 
         // find_uncles from share5 (height 5)
         // Should only find uncle_within (at height 3, within depth 3: heights 2,3,4)
@@ -2901,12 +2901,12 @@ mod tests {
             .nonce(101)
             .build();
 
-        // Store uncle shares with Valid metadata so find_uncles can read their metadata
+        // Confirm share1 first so uncle1 and uncle2 can find their parents
+        store.push_to_confirmed_chain(&share1).unwrap();
         store.store_with_valid_metadata(&uncle1);
         store.store_with_valid_metadata(&uncle2);
 
-        // Confirm main chain using push_to_confirmed_chain
-        store.push_to_confirmed_chain(&share1).unwrap();
+        // Confirm share2
         store.push_to_confirmed_chain(&share2).unwrap();
 
         // Mark uncle1 as already used as uncle

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -269,14 +269,15 @@ impl Store {
         };
 
         for height in start_height..=top_confirmed_height {
-            let mut hashes_at_height = self.get_blockhashes_for_height(height);
-            hashes_at_height.retain(|hash| {
-                self.get_block_metadata(hash)
-                    .map(|metadata| {
-                        metadata.status != Status::Pending && metadata.status != Status::Invalid
-                    })
-                    .unwrap_or(false)
-            });
+            let raw_hashes = self.get_blockhashes_for_height(height);
+            let mut hashes_at_height: Vec<BlockHash> = self
+                .get_block_metadata_batch(&raw_hashes)
+                .into_iter()
+                .filter(|(_, metadata)| {
+                    metadata.status != Status::Pending && metadata.status != Status::Invalid
+                })
+                .map(|(hash, _)| hash)
+                .collect();
             hashes_at_height.sort();
 
             let found_stop = hashes_at_height.contains(stop_blockhash);

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -383,23 +383,26 @@ impl Store {
 
     /// Store a share block and create Valid metadata for it.
     ///
-    /// Used for shares that arrive out of order and need to be
-    /// discoverable by forward walks and uncle lookups. The metadata
-    /// height and chain_work are computed from the parent if available,
-    /// or default to height 1 with just the share's own work.
+    /// Used in tests for shares that need to be discoverable by
+    /// forward walks and uncle lookups. The metadata height and
+    /// chain_work are computed from the parent. Panics if the parent
+    /// is not in the store -- missing parent in test setup is a bug.
     /// Does NOT go through organise_header, so it avoids candidate
     /// chain side effects.
     pub fn store_with_valid_metadata(&self, share: &ShareBlock) {
         let blockhash = share.block_hash();
         let share_work = share.header.get_work();
-        let (height, chain_work) = match self.get_block_metadata(&share.header.prev_share_blockhash)
-        {
-            Ok(parent_metadata) => {
-                let parent_height = parent_metadata.expected_height.unwrap_or_default();
-                (parent_height + 1, parent_metadata.chain_work + share_work)
-            }
-            Err(_) => (1, share_work),
-        };
+        let parent_metadata = self
+            .get_block_metadata(&share.header.prev_share_blockhash)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Parent {} not found for block {blockhash} in test setup",
+                    share.header.prev_share_blockhash
+                )
+            });
+        let parent_height = parent_metadata.expected_height.unwrap_or_default();
+        let height = parent_height + 1;
+        let chain_work = parent_metadata.chain_work + share_work;
         let mut batch = Store::get_write_batch();
         self.add_share_block(share, &mut batch).unwrap();
         self.set_height_to_blockhash(&blockhash, height, &mut batch)
@@ -417,22 +420,23 @@ impl Store {
     /// Create Valid metadata for a share without storing its block data.
     ///
     /// Also stores the header in the Header CF so that downstream
-    /// children can look up parent timestamps and heights. Used to set
-    /// up metadata for intermediate shares so that downstream children
-    /// can compute their cumulative height and work correctly, even
-    /// when the intermediate share has not arrived yet in the test
-    /// scenario.
+    /// children can look up parent timestamps and heights. Panics if
+    /// the parent is not in the store -- missing parent in test setup
+    /// is a bug.
     pub fn create_valid_metadata_only(&self, share: &ShareBlock) {
         let blockhash = share.block_hash();
         let share_work = share.header.get_work();
-        let (height, chain_work) = match self.get_block_metadata(&share.header.prev_share_blockhash)
-        {
-            Ok(parent_metadata) => {
-                let parent_height = parent_metadata.expected_height.unwrap_or_default();
-                (parent_height + 1, parent_metadata.chain_work + share_work)
-            }
-            Err(_) => (1, share_work),
-        };
+        let parent_metadata = self
+            .get_block_metadata(&share.header.prev_share_blockhash)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Parent {} not found for block {blockhash} in test setup",
+                    share.header.prev_share_blockhash
+                )
+            });
+        let parent_height = parent_metadata.expected_height.unwrap_or_default();
+        let height = parent_height + 1;
+        let chain_work = parent_metadata.chain_work + share_work;
         let mut batch = Store::get_write_batch();
         self.add_share_header(&share.header, &mut batch).unwrap();
         self.set_height_to_blockhash(&blockhash, height, &mut batch)

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -17,6 +17,7 @@
 use crate::shares::share_block::ShareBlock;
 use crate::store::block_tx_metadata::{BlockMetadata, Status};
 use crate::store::column_families::ColumnFamily;
+use crate::store::dag_store::MAX_UNCLES_DEPTH;
 use bitcoin::consensus::{Encodable, encode};
 use bitcoin::{BlockHash, Work};
 use rocksdb::{ColumnFamilyDescriptor, DB, Options as RocksDbOptions};
@@ -228,8 +229,8 @@ impl Store {
         self.db.write(batch)
     }
 
-    /// Get all blockhashes from blockhash' height+1 up to top
-    /// confirmed height.
+    /// Get all blockhashes from locator height up to top confirmed
+    /// height.
     ///
     /// Walks the height index and collects all valid blocks at each
     /// height (confirmed, candidate, header-valid, block-valid).
@@ -237,6 +238,13 @@ impl Store {
     /// blocks are sorted lexicographically by blockhash for
     /// deterministic ordering. Heights are never split across batches
     /// -- all blocks at a height are included atomically.
+    ///
+    /// Starts MAX_UNCLES_DEPTH heights before the locator match so
+    /// that fork blocks near the boundary have their parents included
+    /// in the batch. The overlap is small and duplicate headers are
+    /// handled as no-ops by organise_header on the receiver. This
+    /// prevents in the common case starting to fetch from a locator
+    /// much deeper down.
     ///
     /// This produces a topologically sorted DAG subgraph because every
     /// block's parent is at height H-1, which is either in this batch
@@ -249,10 +257,11 @@ impl Store {
     ) -> Result<Vec<BlockHash>, StoreError> {
         let mut blockhashes = Vec::with_capacity(limit);
 
-        let start_height = match self.get_block_metadata(blockhash) {
-            Ok(metadata) => metadata.expected_height.unwrap_or(0) + 1,
-            Err(_) => 1,
+        let locator_height = match self.get_block_metadata(blockhash) {
+            Ok(metadata) => metadata.expected_height.unwrap_or(0),
+            Err(_) => 0,
         };
+        let start_height = locator_height.saturating_sub(MAX_UNCLES_DEPTH as u32) + 1;
 
         let top_confirmed_height = match self.get_top_confirmed_height() {
             Ok(height) => height,

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -17,11 +17,9 @@
 use crate::shares::share_block::ShareBlock;
 use crate::store::block_tx_metadata::{BlockMetadata, Status};
 use crate::store::column_families::ColumnFamily;
-use crate::store::dag_store::MAX_UNCLES_DEPTH;
 use bitcoin::consensus::{Encodable, encode};
 use bitcoin::{BlockHash, Work};
 use rocksdb::{ColumnFamilyDescriptor, DB, Options as RocksDbOptions};
-use std::collections::{HashSet, VecDeque};
 use std::sync::{Arc, RwLock};
 use tracing::debug;
 use writer::StoreError;
@@ -230,16 +228,19 @@ impl Store {
         self.db.write(batch)
     }
 
-    /// Get confirmed chain blockhashes descending from a given blockhash,
-    /// including uncle blockhashes referenced by each confirmed block.
+    /// Get all blockhashes from blockhash' height+1 up to top
+    /// confirmed height.
     ///
-    /// Walks the confirmed chain from anchor_height - MAX_UNCLES_DEPTH + 1
-    /// up to the top confirmed height. Starting earlier than the anchor
-    /// ensures that uncle blocks referenced by shares near the anchor
-    /// are included in the response. For each confirmed block, its
-    /// uncle blockhashes are inserted before the confirmed blockhash so
-    /// that a peer receives uncle data before the share that depends on
-    /// it.
+    /// Walks the height index and collects all valid blocks at each
+    /// height (confirmed, candidate, header-valid, block-valid).
+    /// Pending and invalid blocks are excluded. Within each height,
+    /// blocks are sorted lexicographically by blockhash for
+    /// deterministic ordering. Heights are never split across batches
+    /// -- all blocks at a height are included atomically.
+    ///
+    /// This produces a topologically sorted DAG subgraph because every
+    /// block's parent is at height H-1, which is either in this batch
+    /// or was sent in a previous batch.
     fn get_descendant_blockhashes(
         &self,
         blockhash: &BlockHash,
@@ -247,11 +248,10 @@ impl Store {
         limit: usize,
     ) -> Result<Vec<BlockHash>, StoreError> {
         let mut blockhashes = Vec::with_capacity(limit);
-        let mut seen = HashSet::with_capacity(limit);
 
         let start_height = match self.get_block_metadata(blockhash) {
-            Ok(metadata) => metadata.expected_height.unwrap_or(0),
-            Err(_) => 0,
+            Ok(metadata) => metadata.expected_height.unwrap_or(0) + 1,
+            Err(_) => 1,
         };
 
         let top_confirmed_height = match self.get_top_confirmed_height() {
@@ -259,53 +259,26 @@ impl Store {
             Err(_) => return Ok(blockhashes),
         };
 
-        let mut height = start_height.saturating_sub(MAX_UNCLES_DEPTH as u32) + 1;
-        while height <= top_confirmed_height && blockhashes.len() < limit {
-            let confirmed_hash = self.get_confirmed_at_height(height)?;
+        for height in start_height..=top_confirmed_height {
+            let mut hashes_at_height = self.get_blockhashes_for_height(height);
+            hashes_at_height.retain(|hash| {
+                self.get_block_metadata(hash)
+                    .map(|metadata| {
+                        metadata.status != Status::Pending && metadata.status != Status::Invalid
+                    })
+                    .unwrap_or(false)
+            });
+            hashes_at_height.sort();
 
-            self.collect_uncle_chain(&confirmed_hash, &mut seen, &mut blockhashes);
+            let found_stop = hashes_at_height.contains(stop_blockhash);
+            blockhashes.extend(hashes_at_height);
 
-            if seen.insert(confirmed_hash) {
-                blockhashes.push(confirmed_hash);
-            }
-
-            if confirmed_hash == *stop_blockhash {
+            if found_stop || blockhashes.len() >= limit {
                 return Ok(blockhashes);
             }
-
-            height += 1;
         }
 
         Ok(blockhashes)
-    }
-
-    /// Collect uncle blockhashes for a block, chasing transitive
-    /// uncle references (uncle-of-uncle) so the receiver has all
-    /// declared uncles available. The DAG is finite and acyclic, and
-    /// the seen set prevents revisits, so this always terminates.
-    fn collect_uncle_chain(
-        &self,
-        blockhash: &BlockHash,
-        seen: &mut HashSet<BlockHash>,
-        blockhashes: &mut Vec<BlockHash>,
-    ) {
-        let header = match self.get_share_header(blockhash) {
-            Ok(Some(header)) => header,
-            _ => return,
-        };
-        let mut uncle_queue: VecDeque<BlockHash> = header.uncles.iter().copied().collect();
-        while let Some(uncle_hash) = uncle_queue.pop_front() {
-            if seen.insert(uncle_hash) {
-                blockhashes.push(uncle_hash);
-                if let Ok(Some(uncle_header)) = self.get_share_header(&uncle_hash) {
-                    for nested_uncle in &uncle_header.uncles {
-                        if !seen.contains(nested_uncle) {
-                            uncle_queue.push_back(*nested_uncle);
-                        }
-                    }
-                }
-            }
-        }
     }
 
     /// Get genesis block hash from chain state

--- a/p2poolv2_lib/src/store/organise/candidate.rs
+++ b/p2poolv2_lib/src/store/organise/candidate.rs
@@ -804,14 +804,13 @@ mod tests {
 
         assert_eq!(store.get_top_candidate_height().unwrap(), 2);
 
-        // orphan_share has an unknown parent (not on the chain) so
-        // push_to_candidate_chain computes height 1 with only its own work,
-        // which is not enough to extend or reorg.
+        // orphan_share has an unknown parent (not in store), so
+        // organise_header returns an error for missing parent.
         let orphan_share = TestShareBlockBuilder::new().nonce(0xe9695793).build();
-        let result = store.push_to_candidate_chain(&orphan_share).unwrap();
+        let result = store.push_to_candidate_chain(&orphan_share);
 
-        // Should not change the candidate chain
-        assert!(result.is_none());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
         assert_eq!(store.get_top_candidate_height().unwrap(), 2);
     }
 

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -267,14 +267,13 @@ mod tests {
         assert_eq!(top_before.hash, share2.block_hash());
         assert_eq!(top_before.height, 2);
 
-        // orphan_share has an unknown parent so organise_header computes
-        // height 1 with only its own work. That work is less than the
-        // top candidate cumulative work, so neither extend nor reorg fires.
+        // orphan_share has an unknown parent so organise_header
+        // returns an error for missing parent.
         let orphan_share = TestShareBlockBuilder::new().nonce(0xe9695794).build();
-        let result = store.push_to_candidate_chain(&orphan_share).unwrap();
+        let result = store.push_to_candidate_chain(&orphan_share);
 
-        // Candidate chain unchanged
-        assert!(result.is_none());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
         let top_after = store.get_top_candidate().unwrap();
         assert_eq!(top_after.hash, share2.block_hash());
         assert_eq!(top_after.height, 2);

--- a/p2poolv2_lib/src/store/organise/organise_header.rs
+++ b/p2poolv2_lib/src/store/organise/organise_header.rs
@@ -181,15 +181,22 @@ impl Store {
 
         let share_work = header.get_work();
 
-        let (new_height, new_chain_work) =
-            match self.get_block_metadata(&header.prev_share_blockhash) {
-                Ok(prev_metadata) => {
-                    let prev_height = prev_metadata.expected_height.unwrap_or_default();
-                    let new_chain_work = prev_metadata.chain_work + share_work;
-                    (prev_height + 1, new_chain_work)
-                }
-                Err(_) => (1, share_work),
-            };
+        let prev_metadata = self
+            .get_block_metadata(&header.prev_share_blockhash)
+            .map_err(|_| {
+                StoreError::NotFound(format!(
+                    "Parent {} not found for block {}",
+                    header.prev_share_blockhash, blockhash
+                ))
+            })?;
+        let prev_height = prev_metadata.expected_height.ok_or_else(|| {
+            StoreError::Database(format!(
+                "Parent {} has no expected height for block {}",
+                header.prev_share_blockhash, blockhash
+            ))
+        })?;
+        let new_height = prev_height + 1;
+        let new_chain_work = prev_metadata.chain_work + share_work;
 
         for uncle_blockhash in &header.uncles {
             self.update_block_index(uncle_blockhash, blockhash, batch)?;
@@ -292,17 +299,14 @@ mod tests {
         assert_eq!(top_before.hash, share2.block_hash());
         assert_eq!(top_before.height, 2);
 
-        // orphan_share has an unknown parent so organise_header computes
-        // height 1 with only its own work. That work is less than the
-        // top candidate cumulative work, so neither extend nor reorg fires.
+        // orphan_share has an unknown parent so organise_header
+        // returns an error for missing parent.
         let orphan_share = TestShareBlockBuilder::new().nonce(0xe9695794).build();
         let mut batch = Store::get_write_batch();
-        let result = store
-            .organise_header(&orphan_share.header, &mut batch)
-            .unwrap();
+        let result = store.organise_header(&orphan_share.header, &mut batch);
 
-        // Candidate chain unchanged
-        assert!(result.is_none());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
         let top_after = store.get_top_candidate().unwrap();
         assert_eq!(top_after.hash, share2.block_hash());
         assert_eq!(top_after.height, 2);


### PR DESCRIPTION
We use a height based traversal to return a cut of the DAG in response to getheaders.

Walking a DAG was fraught with error, sending cuts is cleaner and easier to reason about. 

Now we send all fork branches when traversing the DAG, so the receiver doesn't have to chase the sender with requests for ancestors (and descendants).

This works smoothly in initial sync. During steady state, instead of again chasing missing parents/uncles, we shift the window of locator requests back by 100 depth and request again.

Supporting changes like error enum types to identify retryable errors.