### PR TITLE
Fix unwraps in stratum message handlers

### DIFF
--- a/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
@@ -63,7 +63,7 @@ pub(crate) async fn handle_authorize<'a, D: DifficultyAdjusterTrait>(
             "Already authorized".to_string(),
         ));
     }
-    let username = match message.params[0].clone() {
+    let username = match message.params.first().and_then(|p| p.clone()) {
         Some(name) => name,
         None => {
             return Ok(vec![Message::Response(
@@ -90,11 +90,11 @@ pub(crate) async fn handle_authorize<'a, D: DifficultyAdjusterTrait>(
             }
         };
 
-    session.username = Some(message.params[0].clone().unwrap());
+    session.username = Some(username.clone());
     session.btcaddress = Some(parsed_username.address_str.to_string());
     session.parsed_address = parsed_username.parsed_address;
     session.workername = parsed_username.worker_name.map(|s| s.to_string());
-    session.password = message.params[1].clone();
+    session.password = message.params.get(1).and_then(|p| p.clone());
 
     // Register user in the store
     register_user(session, parsed_username.address_str, ctx.chain_store_handle).await?;
@@ -670,5 +670,55 @@ mod tests {
             session.btcaddress.is_none(),
             "BTC address should not be set for invalid address"
         );
+    }
+
+    #[tokio::test]
+    async fn test_handle_authorize_empty_params_returns_error_not_panic() {
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        let request = SimpleRequest {
+            id: Some(Id::Number(1)),
+            method: std::borrow::Cow::Owned("mining.authorize".to_string()),
+            params: std::borrow::Cow::Owned(vec![]),
+        };
+        let (notify_tx, _) = mpsc::channel(1);
+        let (emissions_tx, _) = mpsc::channel(10);
+        let (_mock_rpc_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+        let tracker_handle = start_tracker_actor();
+        let stats_dir = tempfile::tempdir().unwrap();
+        let metrics_handle = metrics::start_metrics(stats_dir.path().to_str().unwrap().to_string())
+            .await
+            .unwrap();
+        let (chain_store_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+
+        let ctx = StratumContext {
+            notify_tx,
+            tracker_handle,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
+            start_difficulty: 1000,
+            minimum_difficulty: 1,
+            maximum_difficulty: None,
+            ignore_difficulty: false,
+            validate_addresses: true,
+            emissions_tx,
+            network: bitcoin::network::Network::Testnet,
+            metrics: metrics_handle,
+            chain_store_handle,
+        };
+
+        let result = handle_authorize(request, &mut session, ctx).await;
+        assert!(result.is_ok());
+        let messages = result.unwrap();
+        let response = match &messages[..] {
+            [Message::Response(r)] => r,
+            _ => panic!("expected Response"),
+        };
+        let err = response.error.as_ref().unwrap();
+        assert_eq!(err.code, 24, "should be UnauthorizedWorker (code 24)");
+        assert_eq!(err.message, "Empty username");
     }
 }

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -1235,4 +1235,81 @@ mod handle_submit_tests {
             err.message
         );
     }
+
+    #[tokio::test]
+    async fn test_handle_submit_bad_nonce_returns_error_not_panic() {
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
+        let tracker_handle = start_tracker_actor();
+
+        let (template, notify, _submit, authorize_response) =
+            load_valid_stratum_work_components("../p2poolv2_tests/test_data/validation/stratum/b/");
+
+        let enonce1 = authorize_response.result.unwrap()[1].clone();
+        let enonce1: &str = enonce1.as_str().unwrap();
+        session.enonce1 =
+            u32::from_le_bytes(hex::decode(enonce1).unwrap().as_slice().try_into().unwrap());
+        session.enonce1_hex = enonce1.to_string();
+        session.btcaddress = Some("tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string());
+        session.user_id = Some(1);
+
+        let job_id = JobId(u64::from_str_radix(&notify.params.job_id, 16).unwrap());
+        let _ = tracker_handle.insert_job(
+            Arc::new(template),
+            notify.params.coinbase1.to_string(),
+            notify.params.coinbase2.to_string(),
+            None,
+            TEST_COINBASE_NSECS,
+            vec![],
+            job_id,
+        );
+
+        let submit = SimpleRequest::new_submit(
+            4,
+            "worker".to_string(),
+            notify.params.job_id.clone(),
+            "0000000000000000".to_string(),
+            "504e86ed".to_string(),
+            "ZZZZZZZZ".to_string(),
+        );
+
+        let (_mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+        let (emissions_tx, _) = mpsc::channel(10);
+        let (notify_tx, _) = mpsc::channel(10);
+        let (chain_store_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+        let stats_dir = tempfile::tempdir().unwrap();
+        let metrics_handle = metrics::start_metrics(stats_dir.path().to_str().unwrap().to_string())
+            .await
+            .unwrap();
+
+        let ctx = StratumContext {
+            notify_tx,
+            tracker_handle: tracker_handle.clone(),
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
+            start_difficulty: 1,
+            minimum_difficulty: 1,
+            maximum_difficulty: None,
+            ignore_difficulty: false,
+            validate_addresses: true,
+            emissions_tx,
+            network: bitcoin::network::Network::Regtest,
+            metrics: metrics_handle,
+            chain_store_handle,
+        };
+
+        let messages = handle_submit(submit, &mut session, ctx).await.unwrap();
+        let response = match &messages[..] {
+            [Message::Response(r)] => r,
+            _ => panic!("expected Response"),
+        };
+        assert_eq!(response.result, None);
+        let err = response.error.as_ref().unwrap();
+        assert_eq!(err.code, 20, "should be OtherUnknown (code 20)");
+        assert_eq!(err.message, "Invalid parameters provided: Bad nonce");
+    }
 }

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -1312,4 +1312,89 @@ mod handle_submit_tests {
         assert_eq!(err.code, 20, "should be OtherUnknown (code 20)");
         assert_eq!(err.message, "Invalid parameters provided: Bad nonce");
     }
+
+    #[tokio::test]
+    async fn test_handle_submit_none_version_bits_returns_error_not_panic() {
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
+        let tracker_handle = start_tracker_actor();
+
+        let (template, notify, _submit, authorize_response) =
+            load_valid_stratum_work_components("../p2poolv2_tests/test_data/validation/stratum/b/");
+
+        let enonce1 = authorize_response.result.unwrap()[1].clone();
+        let enonce1: &str = enonce1.as_str().unwrap();
+        session.enonce1 =
+            u32::from_le_bytes(hex::decode(enonce1).unwrap().as_slice().try_into().unwrap());
+        session.enonce1_hex = enonce1.to_string();
+        session.btcaddress = Some("tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string());
+        session.user_id = Some(1);
+
+        let job_id = JobId(u64::from_str_radix(&notify.params.job_id, 16).unwrap());
+        let _ = tracker_handle.insert_job(
+            Arc::new(template),
+            notify.params.coinbase1.to_string(),
+            notify.params.coinbase2.to_string(),
+            None,
+            TEST_COINBASE_NSECS,
+            vec![],
+            job_id,
+        );
+
+        // Build a submit with 6 params where the 6th (version bits) is None
+        let submit = SimpleRequest {
+            id: Some(Id::Number(4)),
+            method: std::borrow::Cow::Owned("mining.submit".to_string()),
+            params: std::borrow::Cow::Owned(vec![
+                Some("worker".to_string()),
+                Some(notify.params.job_id.clone()),
+                Some("0000000000000000".to_string()),
+                Some("504e86ed".to_string()),
+                Some("e9695791".to_string()),
+                None, // version bits is None
+            ]),
+        };
+
+        let (_mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+        let (emissions_tx, _) = mpsc::channel(10);
+        let (notify_tx, _) = mpsc::channel(10);
+        let (chain_store_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+        let stats_dir = tempfile::tempdir().unwrap();
+        let metrics_handle = metrics::start_metrics(stats_dir.path().to_str().unwrap().to_string())
+            .await
+            .unwrap();
+
+        let ctx = StratumContext {
+            notify_tx,
+            tracker_handle: tracker_handle.clone(),
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
+            start_difficulty: 1,
+            minimum_difficulty: 1,
+            maximum_difficulty: None,
+            ignore_difficulty: false,
+            validate_addresses: true,
+            emissions_tx,
+            network: bitcoin::network::Network::Regtest,
+            metrics: metrics_handle,
+            chain_store_handle,
+        };
+
+        let messages = handle_submit(submit, &mut session, ctx).await.unwrap();
+        let response = match &messages[..] {
+            [Message::Response(r)] => r,
+            _ => panic!("expected Response"),
+        };
+        assert_eq!(response.result, None);
+        let err = response.error.as_ref().unwrap();
+        assert_eq!(err.code, 20, "should be OtherUnknown (code 20)");
+        assert_eq!(
+            err.message,
+            "Invalid parameters provided: Missing version bits"
+        );
+    }
 }

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -61,11 +61,13 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
             StratumErrorCode::NotSubscribed,
         ))]);
     }
-    if message.params.len() < 4 {
+    if message.params.len() < 5 {
         return Err(Error::InvalidParams("Missing parameters".into()));
     }
 
-    let id = message.params[1].as_ref().unwrap();
+    let id = message.params[1]
+        .as_ref()
+        .ok_or_else(|| Error::InvalidParams("Missing job_id".into()))?;
 
     let job_id =
         u64::from_str_radix(id, 16).map_err(|_| Error::InvalidParams("Invalid job_id".into()))?;

--- a/p2poolv2_lib/src/stratum/work/difficulty/validate.rs
+++ b/p2poolv2_lib/src/stratum/work/difficulty/validate.rs
@@ -61,7 +61,8 @@ pub fn build_coinbase_from_components(
     let complete_tx = format!("{coinbase1}{enonce1}{enonce2}{coinbase2}");
     debug!("Complete coinbase tx hex: {}", complete_tx);
 
-    let tx_bytes = Vec::from_hex(&complete_tx).unwrap();
+    let tx_bytes = Vec::from_hex(&complete_tx)
+        .map_err(|_| Error::InvalidParams("Invalid coinbase hex".into()))?;
     bitcoin::Transaction::consensus_decode(&mut std::io::Cursor::new(tx_bytes))
         .map_err(|_e| Error::InvalidParams("Failed to decode coinbase transaction".into()))
 }

--- a/p2poolv2_lib/src/stratum/work/difficulty/validate.rs
+++ b/p2poolv2_lib/src/stratum/work/difficulty/validate.rs
@@ -105,7 +105,10 @@ pub fn validate_bitcoin_difficulty(
         .map_err(|_| Error::InvalidParams("Failed to parse compact target".into()))?;
     let target = bitcoin::Target::from_compact(compact_target);
 
-    let enonce2 = submission.params[2].as_ref().unwrap().as_str();
+    let enonce2 = submission.params[2]
+        .as_ref()
+        .ok_or_else(|| Error::InvalidParams("Missing enonce2".into()))?
+        .as_str();
 
     debug!(
         "Coinbase components coinbase1: {} enonce1: {}, enonce2: {}, coinbase2: {}",
@@ -133,8 +136,11 @@ pub fn validate_bitcoin_difficulty(
 
     debug!("Merkle root: {}", merkle_root);
 
-    let n_time = u32::from_str_radix(submission.params[3].as_ref().unwrap(), 16)
-        .map_err(|_| Error::InvalidParams("Bad nTime".into()))?;
+    let ntime_str = submission.params[3]
+        .as_ref()
+        .ok_or_else(|| Error::InvalidParams("Missing ntime".into()))?;
+    let n_time =
+        u32::from_str_radix(ntime_str, 16).map_err(|_| Error::InvalidParams("Bad nTime".into()))?;
 
     let version = apply_version_mask(job.blocktemplate.version, version_mask, &submission.params)?;
 
@@ -145,7 +151,13 @@ pub fn validate_bitcoin_difficulty(
         merkle_root,
         time: n_time,
         bits: compact_target,
-        nonce: u32::from_str_radix(submission.params[4].as_ref().unwrap(), 16).unwrap(),
+        nonce: u32::from_str_radix(
+            submission.params[4]
+                .as_ref()
+                .ok_or_else(|| Error::InvalidParams("Missing nonce".into()))?,
+            16,
+        )
+        .map_err(|_| Error::InvalidParams("Bad nonce".into()))?,
     };
 
     debug!(

--- a/p2poolv2_lib/src/stratum/work/difficulty/validate.rs
+++ b/p2poolv2_lib/src/stratum/work/difficulty/validate.rs
@@ -75,13 +75,16 @@ fn apply_version_mask(
     params: &[Option<String>],
 ) -> Result<i32, Error> {
     if params.len() > 5 {
-        debug!("Applying version mask from params: {:?}", params[5]);
+        let version_bits_hex = params[5]
+            .as_ref()
+            .ok_or_else(|| Error::InvalidParams("Missing version bits".into()))?;
+        debug!("Applying version mask from params: {:?}", version_bits_hex);
         let bits = i32::from_be_bytes(
-            hex::decode(params[5].as_ref().unwrap())
-                .map_err(|_| Error::InvalidParams("Failed to decode hex".into()))?
+            hex::decode(version_bits_hex)
+                .map_err(|_| Error::InvalidParams("Failed to decode version bits hex".into()))?
                 .as_slice()
                 .try_into()
-                .map_err(|_| Error::InvalidParams("Failed to decode hex".into()))?,
+                .map_err(|_| Error::InvalidParams("Invalid version bits length".into()))?,
         );
         Ok((header_version & !version_mask) | (bits & version_mask))
     } else {


### PR DESCRIPTION
Stratum server was directly accessing params array elements and also unwrapping on a few data access and parsing calls. This PR tightens that up to avoid a malicious client crashing the node.