### PR TITLE
Limit number of concurrent connections from config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,9 +2318,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -3336,6 +3336,7 @@ dependencies = [
  "mockall_double",
  "p2poolv2_config",
  "rand 0.8.5",
+ "rlimit",
  "rocksdb",
  "rust_decimal",
  "rust_decimal_macros",
@@ -4095,6 +4096,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -47,6 +47,8 @@ difficulty_multiplier = 1.0
 # how large your pool is, if you are running private, there is no need
 # to add a pool signature. Maximum length 16 bytes.
 pool_signature = "P2Poolv2"
+# Maximum concurrent stratum connections (default: 90% of OS file descriptor limit)
+# max_connections = 1000
 
 [bitcoinrpc]
 # RPC credentials are loaded from env vars

--- a/p2poolv2_config/src/lib.rs
+++ b/p2poolv2_config/src/lib.rs
@@ -98,6 +98,8 @@ pub struct StratumConfig<State = Raw> {
     pub ignore_difficulty: Option<bool>,
     /// Optional pool signature to include in coinbase
     pub pool_signature: Option<String>,
+    /// Maximum concurrent stratum connections. Default: 90% of OS fd limit.
+    pub max_connections: Option<u32>,
 
     // Parsed addresses - only available when State = Parsed
     #[serde(skip)]
@@ -166,6 +168,7 @@ impl StratumConfig<Raw> {
             difficulty_multiplier: self.difficulty_multiplier,
             ignore_difficulty: self.ignore_difficulty,
             pool_signature: self.pool_signature,
+            max_connections: self.max_connections,
             bootstrap_address_parsed: Some(bootstrap_address_parsed),
             donation_address_parsed,
             fee_address_parsed,
@@ -216,6 +219,7 @@ impl StratumConfig<Raw> {
             difficulty_multiplier: 1.0,
             ignore_difficulty: None,
             pool_signature: None,
+            max_connections: None,
             bootstrap_address_parsed: None,
             donation_address_parsed: None,
             fee_address_parsed: None,

--- a/p2poolv2_lib/Cargo.toml
+++ b/p2poolv2_lib/Cargo.toml
@@ -49,6 +49,7 @@ p2poolv2_config = { path = "../p2poolv2_config" }
 chrono = { workspace = true }
 dashmap = { workspace = true }
 uint = { workspace = true }
+rlimit = "0.11.0"
 
 [dev-dependencies]
 bitcoindrpc = { path = "../bitcoindrpc", features = ["test-utils"] }

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -1884,4 +1884,105 @@ mod stratum_server_tests {
             "Should not send mining.notify before authorization"
         );
     }
+
+    #[tokio::test]
+    async fn test_max_connections_rejects_when_at_capacity() {
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (_mock_rpc_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+
+        let (shares_tx, _shares_rx) = mpsc::channel(10);
+        let stats_dir = tempfile::tempdir().unwrap();
+        let metrics_handle = metrics::start_metrics(stats_dir.path().to_str().unwrap().to_string())
+            .await
+            .unwrap();
+        let tracker_handle = start_tracker_actor();
+        let (chain_store_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+
+        // Keep shutdown_tx alive so the connection task does not exit immediately
+        let (keep_alive_tx, _keep_alive_rx) = mpsc::channel::<oneshot::Sender<()>>(10);
+        let mut connections_handle = ClientConnectionsHandle::default();
+        connections_handle
+            .expect_add()
+            .times(1)
+            .returning(move |_addr| {
+                let (_message_tx, message_rx) = mpsc::channel(10);
+                let (shutdown_tx, shutdown_rx) = oneshot::channel();
+                // Park the shutdown_tx so it stays alive, keeping the connection open
+                let _ = keep_alive_tx.try_send(shutdown_tx);
+                (message_rx, shutdown_rx)
+            });
+
+        let mut server = StratumServerBuilder::default()
+            .hostname("127.0.0.1".to_string())
+            .port(12399)
+            .start_difficulty(1)
+            .minimum_difficulty(1)
+            .maximum_difficulty(Some(2))
+            .network(bitcoin::network::Network::Regtest)
+            .version_mask(0x1fffe000)
+            .max_connections(Some(1))
+            .shutdown_rx(shutdown_rx)
+            .connections_handle(connections_handle)
+            .emissions_tx(shares_tx)
+            .chain_store_handle(chain_store_handle)
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(server.max_connections, Some(1));
+
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let (notify_tx, _notify_rx) = mpsc::channel(10);
+        let (_template_tx, template_rx) = watch::channel(None);
+
+        let server_handle = tokio::spawn(async move {
+            let _ = server
+                .start(
+                    Some(ready_tx),
+                    notify_tx,
+                    tracker_handle.clone(),
+                    bitcoinrpc_config,
+                    metrics_handle,
+                    template_rx,
+                )
+                .await;
+        });
+
+        ready_rx.await.expect("Server should signal readiness");
+
+        // First connection should succeed (consumes the single permit)
+        let first_connection = tokio::net::TcpStream::connect("127.0.0.1:12399").await;
+        assert!(first_connection.is_ok(), "First connection should succeed");
+
+        // Give the server time to accept and register the connection
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        // Second connection: the TCP handshake may succeed at the OS level,
+        // but the server should drop it immediately. We detect this by trying
+        // to read -- a dropped connection returns EOF or an error.
+        let second_result = tokio::net::TcpStream::connect("127.0.0.1:12399").await;
+
+        if let Ok(mut second_stream) = second_result {
+            let mut buffer = [0u8; 1];
+            let read_result = tokio::time::timeout(
+                tokio::time::Duration::from_millis(500),
+                tokio::io::AsyncReadExt::read(&mut second_stream, &mut buffer),
+            )
+            .await;
+
+            match read_result {
+                _ => {
+                    // was not serviced
+                }
+                Ok(Ok(_)) => {
+                    panic!("Second connection should not receive data when at max capacity");
+                }
+            }
+        }
+        // If connect itself failed, that also means rejection -- acceptable
+
+        drop(first_connection);
+        shutdown_tx.send(()).expect("Failed to send shutdown");
+        let _ = server_handle.await;
+    }
 }

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -37,8 +37,8 @@ use bitcoindrpc::{BitcoinRpcConfig, BitcoindRpcClient};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::TcpListener;
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot, watch};
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
 use tracing::{debug, error, info};
@@ -55,6 +55,7 @@ pub struct StratumServer {
     pub validate_addresses: bool,
     pub network: bitcoin::Network,
     pub version_mask: i32,
+    pub max_connections: Option<u32>,
     shutdown_rx: oneshot::Receiver<()>,
     connections_handle: ClientConnectionsHandle,
     emissions_tx: EmissionSender,
@@ -73,6 +74,7 @@ pub struct StratumServerBuilder {
     validate_addresses: Option<bool>,
     network: Option<bitcoin::Network>,
     version_mask: Option<i32>,
+    max_connections: Option<Option<u32>>,
     shutdown_rx: Option<oneshot::Receiver<()>>,
     connections_handle: Option<ClientConnectionsHandle>,
     emissions_tx: Option<EmissionSender>,
@@ -126,6 +128,11 @@ impl StratumServerBuilder {
         self
     }
 
+    pub fn max_connections(mut self, max_connections: Option<u32>) -> Self {
+        self.max_connections = Some(max_connections);
+        self
+    }
+
     pub fn shutdown_rx(mut self, shutdown_rx: oneshot::Receiver<()>) -> Self {
         self.shutdown_rx = Some(shutdown_rx);
         self
@@ -173,6 +180,7 @@ impl StratumServerBuilder {
                 .connections_handle
                 .ok_or("connections_handle is required")?,
             emissions_tx: self.emissions_tx.ok_or("shares_tx is required")?,
+            max_connections: self.max_connections.unwrap_or(None),
             chain_store_handle: self
                 .chain_store_handle
                 .ok_or("chain store handle is required")?,
@@ -214,8 +222,11 @@ impl StratumServer {
             }
         };
 
+        let max_connections = self.max_connections.unwrap_or_else(default_max_connections);
+        info!("Stratum server max connections: {}", max_connections);
+        let connection_semaphore = Arc::new(Semaphore::new(max_connections as usize));
+
         if let Some(ready_tx) = ready_tx {
-            // Notify that the server is ready to accept connections
             info!(
                 "Stratum server is ready to accept connections on {}",
                 bind_address
@@ -224,66 +235,47 @@ impl StratumServer {
         }
         loop {
             tokio::select! {
-                // Check for shutdown signal
                 _ = &mut self.shutdown_rx => {
                     info!("Shutdown signal received");
                     break;
                 }
                 connection = listener.accept() => {
                     match connection {
-                        Ok(connection) => {
-                            let (stream, addr) = connection;
-                            // Disable Nagle's algorithm for lower latency
-                            if let Err(e) = stream.set_nodelay(true) {
-                                error!("Failed to set TCP_NODELAY for {}: {}", addr, e);
-                            }
-                            debug!("New connection from: {}", addr);
-                            let (message_rx, shutdown_rx) = self.connections_handle.add(addr).await;
-                            let (reader, writer) = stream.into_split();
-                            let buf_reader = BufReader::new(reader);
-
-                            let ctx = StratumContext {
-                                notify_tx: notify_tx.clone(),
-                                tracker_handle: tracker_handle.clone(),
-                                bitcoindrpc_client: bitcoindrpc_client.clone(),
-                                start_difficulty: self.start_difficulty,
-                                minimum_difficulty: self.minimum_difficulty,
-                                maximum_difficulty: self.maximum_difficulty,
-                                ignore_difficulty: self.ignore_difficulty,
-                                validate_addresses: self.validate_addresses,
-                                emissions_tx: self.emissions_tx.clone(),
-                                network: self.network,
-                                metrics: metrics.clone(),
-                                chain_store_handle: self.chain_store_handle.clone(),
-                            };
-                            let version_mask = self.version_mask;
-                            let connection_template_rx = template_rx.clone();
-                            // Spawn a new task for each connection
-                            tokio::spawn(async move {
-                                // Handle the connection with graceful shutdown support
-                                if handle_connection(
-                                    buf_reader,
-                                    writer,
-                                    addr,
-                                    message_rx,
-                                    shutdown_rx,
-                                    version_mask,
-                                    ctx,
-                                    &SystemTimeProvider {},
-                                    connection_template_rx,
-                                )
-                                .await
-                                .is_err()
-                                {
-                                    error!(
-                                        "Error occurred while handling connection {addr}. Closing connection."
-                                    );
+                        Ok((stream, addr)) => {
+                            match connection_semaphore.clone().try_acquire_owned() {
+                                Ok(permit) => {
+                                    let ctx = StratumContext {
+                                        notify_tx: notify_tx.clone(),
+                                        tracker_handle: tracker_handle.clone(),
+                                        bitcoindrpc_client: bitcoindrpc_client.clone(),
+                                        start_difficulty: self.start_difficulty,
+                                        minimum_difficulty: self.minimum_difficulty,
+                                        maximum_difficulty: self.maximum_difficulty,
+                                        ignore_difficulty: self.ignore_difficulty,
+                                        validate_addresses: self.validate_addresses,
+                                        emissions_tx: self.emissions_tx.clone(),
+                                        network: self.network,
+                                        metrics: metrics.clone(),
+                                        chain_store_handle: self.chain_store_handle.clone(),
+                                    };
+                                    accept_connection(
+                                        stream,
+                                        addr,
+                                        &self.connections_handle,
+                                        ctx,
+                                        self.version_mask,
+                                        template_rx.clone(),
+                                        permit,
+                                    ).await;
                                 }
-                            });
+                                Err(_) => {
+                                    info!("Max connections ({}) reached, rejecting {}", max_connections, addr);
+                                    drop(stream);
+                                }
+                            }
                         }
                         Err(e) => {
                             error!("Connection failed: {}", e);
-                            continue;
                         }
                     }
                 }
@@ -291,6 +283,75 @@ impl StratumServer {
         }
         Ok(())
     }
+}
+
+/// Returns a default max connections value based on the OS soft file descriptor limit.
+///
+/// Computes 90% of the soft NOFILE limit. Falls back to 1024 if the limit
+/// cannot be queried.
+fn default_max_connections() -> u32 {
+    match rlimit::getrlimit(rlimit::Resource::NOFILE) {
+        Ok((soft_limit, _hard_limit)) => {
+            let limit = (soft_limit as f64 * 0.9) as u32;
+            info!(
+                "Default max_connections: {} (90% of OS fd limit {})",
+                limit, soft_limit
+            );
+            limit
+        }
+        Err(_) => {
+            let fallback = 1024;
+            info!(
+                "Could not query OS fd limit, default max_connections: {}",
+                fallback
+            );
+            fallback
+        }
+    }
+}
+
+/// Accepts a new stratum connection, spawning a handler task.
+///
+/// Sets TCP_NODELAY, registers the connection, and spawns a tokio task that
+/// runs `handle_connection`. The semaphore permit is moved into the spawned
+/// task so it is released when the connection closes.
+async fn accept_connection(
+    stream: TcpStream,
+    addr: SocketAddr,
+    connections_handle: &ClientConnectionsHandle,
+    ctx: StratumContext,
+    version_mask: i32,
+    template_rx: watch::Receiver<Option<Arc<PreparedNotifyParams>>>,
+    connection_permit: OwnedSemaphorePermit,
+) {
+    if let Err(e) = stream.set_nodelay(true) {
+        error!("Failed to set TCP_NODELAY for {}: {}", addr, e);
+    }
+    debug!("New connection from: {}", addr);
+
+    let (message_rx, shutdown_rx) = connections_handle.add(addr).await;
+    let (reader, writer) = stream.into_split();
+    let buf_reader = BufReader::new(reader);
+
+    tokio::spawn(async move {
+        let _permit = connection_permit;
+        if handle_connection(
+            buf_reader,
+            writer,
+            addr,
+            message_rx,
+            shutdown_rx,
+            version_mask,
+            ctx,
+            &SystemTimeProvider {},
+            template_rx,
+        )
+        .await
+        .is_err()
+        {
+            error!("Error occurred while handling connection {addr}. Closing connection.");
+        }
+    });
 }
 
 /// A context for the Stratum server easing the number of parameters passed around.

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -269,7 +269,7 @@ impl StratumServer {
                                     ).await;
                                 }
                                 Err(_) => {
-                                    info!("Max connections ({}) reached, rejecting {}", max_connections, addr);
+                                    debug!("Max connections ({}) reached, rejecting {}", max_connections, addr);
                                     drop(stream);
                                 }
                             }

--- a/p2poolv2_node/src/main.rs
+++ b/p2poolv2_node/src/main.rs
@@ -257,6 +257,7 @@ async fn main() -> ExitCode {
             ))
             .network(stratum_config.network)
             .version_mask(stratum_config.version_mask)
+            .max_connections(stratum_config.max_connections)
             .chain_store_handle(chain_store_handle_for_stratum)
             .build()
             .await


### PR DESCRIPTION
Admins can provision a stratum server to limit a max number of connections.

This limits the number of connection handling tokio tasks we spawn and thus helps protect the server from more connections than it can handle. 