### PR TITLE
feat(ci): Add docker image build for tags and main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,168 @@
+name: Docker
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag (e.g. v0.10.0)"
+        required: true
+        type: string
+
+env:
+  IMAGE_NAME: p2poolv2
+  REGISTRY: ghcr.io
+  IMAGE_TAG: ${{ github.sha }}
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build and verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        id: build
+        with:
+          context: .
+          file: docker/p2poolv2/Dockerfile
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            docker.io/${{ github.repository }}:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description="P2Poolv2 is a peer-to-peer Bitcoin mining pool where miners coordinate directly and verify their rewards without centralized operators."
+            org.opencontainers.image.licenses=GPL-3.0
+          cache-from: type=gha,scope=build-docker-amd64
+          cache-to: type=gha,scope=build-docker-amd64,mode=max
+          load: true
+
+      - name: Verify binaries
+        run: |
+          docker run --rm --entrypoint /bin/sh ${{ env.IMAGE_NAME }}:${IMAGE_TAG} -c \
+            'test -f /usr/local/bin/p2poolv2 && test -f /usr/local/bin/p2poolv2_cli && echo "Binaries OK" && sha256sum /usr/local/bin/p2poolv2 /usr/local/bin/p2poolv2_cli'
+
+      - name: Run CLI
+        run: |
+          docker run --rm ${{ env.IMAGE_NAME }}:${IMAGE_TAG} --help
+
+  multi-arch-push:
+    name: Build ${{ matrix.platform }}
+    needs: [build]
+    if: github.event_name != 'pull_request'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+            qemu: false
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+            qemu: false
+          - platform: linux/arm/v7
+            runner: ubuntu-24.04-arm
+            arch: armv7
+            qemu: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        if: matrix.qemu
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          file: docker/p2poolv2/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description="P2Poolv2 is a peer-to-peer Bitcoin mining pool where miners coordinate directly and verify their rewards without centralized operators."
+            org.opencontainers.image.licenses=GPL-3.0
+          cache-from: type=gha,scope=build-docker-${{ matrix.arch }}
+          cache-to: type=gha,scope=build-docker-${{ matrix.arch }},mode=max
+
+  merge:
+    name: Merge multi-arch manifest
+    needs: [multi-arch-push]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine tags
+        id: tags
+        run: .github/workflows/docker/determine-tags.sh
+        env:
+          IMAGE_SHA: ${{ env.IMAGE_TAG }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          GITHUB_REF_TYPE: ${{ github.ref_type }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+
+      - name: Create and push multi-arch manifests
+        run: .github/workflows/docker/create-manifests.sh
+        env:
+          TAGS_GHCR: ${{ steps.tags.outputs.tags_ghcr }}
+          TAGS_DH: ${{ steps.tags.outputs.tags_dh }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          IMAGE_SHA: ${{ env.IMAGE_TAG }}
+
+      - name: Cleanup temp tags
+        if: success() || failure()
+        run: .github/workflows/docker/cleanup-temp-tags.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          IMAGE_SHA: ${{ env.IMAGE_TAG }}
+          CLEANUP_TEMP_TAGS: ${{ vars.CLEANUP_TEMP_TAGS || 'true' }}

--- a/.github/workflows/docker/cleanup-temp-tags.sh
+++ b/.github/workflows/docker/cleanup-temp-tags.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${CLEANUP_TEMP_TAGS:-true}" == "false" || "${CLEANUP_TEMP_TAGS:-true}" == "0" ]]; then
+  echo "CLEANUP_TEMP_TAGS=${CLEANUP_TEMP_TAGS}, skipping cleanup"
+  exit 0
+fi
+
+OWNER="${GITHUB_REPOSITORY_OWNER}"
+PKG="p2poolv2"
+
+if gh api "/orgs/${OWNER}" --silent 2>/dev/null; then
+  BASE="/orgs/${OWNER}/packages/container/${PKG}"
+else
+  BASE="/users/${OWNER}/packages/container/${PKG}"
+fi
+
+for ARCH in amd64 arm64 armv7; do
+  TAG="${IMAGE_SHA}-${ARCH}"
+  VID=$(gh api "${BASE}/versions" \
+    --jq ".[] | select(.metadata.container.tags | index(\"${TAG}\")) | .id" \
+    2>/dev/null || true)
+  if [[ -n "${VID}" ]]; then
+    gh api --method DELETE "${BASE}/versions/${VID}" --silent 2>/dev/null || true
+    echo "Deleted ${TAG} (version ${VID})"
+  else
+    echo "Tag ${TAG} not found, skipping"
+  fi
+done

--- a/.github/workflows/docker/create-manifests.sh
+++ b/.github/workflows/docker/create-manifests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SRC_TAG="ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_SHA}"
+ANN_SOURCE="org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}"
+ANN_DESC="org.opencontainers.image.description=P2Poolv2 is a peer-to-peer Bitcoin mining pool where miners coordinate directly and verify their rewards without centralized operators."
+
+docker buildx imagetools create \
+  $(echo "${TAGS_GHCR}" | xargs -I{} echo -t {}) \
+  --annotation "${ANN_SOURCE}" \
+  --annotation "${ANN_DESC}" \
+  "${SRC_TAG}-amd64" \
+  "${SRC_TAG}-arm64" \
+  "${SRC_TAG}-armv7"
+
+docker buildx imagetools create \
+  $(echo "${TAGS_DH}" | xargs -I{} echo -t {}) \
+  --annotation "${ANN_SOURCE}" \
+  --annotation "${ANN_DESC}" \
+  "${SRC_TAG}"

--- a/.github/workflows/docker/determine-tags.sh
+++ b/.github/workflows/docker/determine-tags.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_GHCR="ghcr.io/${GITHUB_REPOSITORY}"
+REPO_DH="docker.io/${GITHUB_REPOSITORY}"
+
+TAGS_GHCR="${REPO_GHCR}:${IMAGE_SHA}"
+TAGS_DH="${REPO_DH}:${IMAGE_SHA}"
+
+if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+  TAGS_GHCR="${TAGS_GHCR} ${REPO_GHCR}:${DISPATCH_TAG} ${REPO_GHCR}:latest"
+  TAGS_DH="${TAGS_DH} ${REPO_DH}:${DISPATCH_TAG} ${REPO_DH}:latest"
+elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+  TAGS_GHCR="${TAGS_GHCR} ${REPO_GHCR}:${GITHUB_REF_NAME} ${REPO_GHCR}:latest"
+  TAGS_DH="${TAGS_DH} ${REPO_DH}:${GITHUB_REF_NAME} ${REPO_DH}:latest"
+else
+  TAGS_GHCR="${TAGS_GHCR} ${REPO_GHCR}:main"
+  TAGS_DH="${TAGS_DH} ${REPO_DH}:main"
+fi
+
+echo "tags_ghcr=${TAGS_GHCR}" >> "${GITHUB_OUTPUT}"
+echo "tags_dh=${TAGS_DH}" >> "${GITHUB_OUTPUT}"

--- a/docker/p2poolv2/Dockerfile
+++ b/docker/p2poolv2/Dockerfile
@@ -42,7 +42,6 @@ COPY --parents p2poolv2_lib/ .
 COPY --parents p2poolv2_api/ .
 
 ENV RUST_LOG=info
-ENV RUSTFLAGS='-C target-cpu=native'
 
 # Build and install
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -76,6 +75,10 @@ COPY config-docker.sample.toml /etc/p2poolv2/config.toml
 # Set up dashboard
 COPY p2poolv2_api/static /var/www/dashboard
 ENV P2POOL_STATIC_DIR=/var/www/dashboard
+
+LABEL org.opencontainers.image.source=https://github.com/p2poolv2/p2poolv2
+LABEL org.opencontainers.image.description="P2Poolv2 is a peer-to-peer Bitcoin mining pool where miners coordinate directly and verify their rewards without centralized operators."
+LABEL org.opencontainers.image.licenses=GPL-3.0
 
 # TODO: add non-root user
 

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-set unstable := true
+set unstable
 
 dev_config := "." / "config-dev.toml"
 default_config := "." / "config.toml"
@@ -55,7 +55,7 @@ build package="":
 
 # Build a release version of all packages and binaries in the workspace
 build-release:
-    RUSTFLAGS='-C target-cpu=native' cargo build --workspace --release
+    cargo build --workspace --release
 
 run-release config=target_config:
     cargo run --release --package p2poolv2_node -- --config={{ config }}

--- a/load-tests/jmeter-testing/README.adoc
+++ b/load-tests/jmeter-testing/README.adoc
@@ -179,23 +179,15 @@ node server.js
 
 We test two build variants to measure the impact of CPU-specific optimizations.
 
-===== Default build (portable):
+===== Default build:
 
 [,shell]
 ----
 cargo build --workspace --release
+# or
+just build-release
 ./target/release/p2poolv2 --config=config-load-test.toml
 ----
-
-===== Native build (CPU-optimized):
-
-[,shell]
-----
-RUSTFLAGS='-C target-cpu=native' cargo build --workspace --release
-./target/release/p2poolv2 --config=config-load-test.toml
-----
-
-This can also be built using `just build-release` which sets the native flag automatically.
 
 ==== CKPool Stratum Server
 


### PR DESCRIPTION
Provides pre-built multi-architecture Docker images for convenient deployments, pushed to both GHCR and Docker Hub.

Removed RUSTFLAGS='-C target-cpu=native' from the Dockerfile because it tunes the binary for the build host's specific CPU, making images incompatible across architectures. Under QEMU emulation it produces unpredictable results. The --release profile already enables LTO and aggressive optimization, making target-cpu=native redundant.

The build matrix covers linux/amd64 (native ubuntu-latest), linux/arm64 (native ubuntu-24.04-arm), and linux/arm/v7 (QEMU on ubuntu-latest). Each platform gets its own scoped GHA cache so cache entries persist across commits without clobbering each other.

OCI labels were added as recommended by GHCR docs.

The using arm native for the arm/v7 QEMU build (observed 2h42m on x64 host).

Runs:
- https://github.com/johnnyasantoss/p2poolv2/actions/runs/25866966050 (with x64 host for QEMU arm/v7 took almost 3h)
- https://github.com/johnnyasantoss/p2poolv2/actions/runs/25879822250 (with arm host ~15min)

The image on DockerHub: https://hub.docker.com/r/johnnyasantoss/p2poolv2 (latest multi arch)