### PR TITLE
Stop parsing txids for each submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.10.13] - 2026-05-15
+
+### Changed
+
+- Use precomputed merkle branches in share validation instead of
+  re-parsing all transaction IDs from hex on every mining.submit.
+  The branches are computed once when the block template arrives and
+  reused across all miners, eliminating ~30% CPU overhead from hex
+  parsing and full merkle tree rebuilds. Submit latency reduced by
+  ~33% average and ~51% at p99, throughput increased ~40%.
+
+- Parameterize JMeter stratum test plan so host, port, thread count,
+  ramp-up, duration and submit delay can be overridden from the
+  command line via JMeter properties.
+
+### Added
+
+- Standalone JMeter load generator script (run_remote_load.sh) for
+  driving stratum traffic against a remote server without needing a
+  local build or mock-bitcoind.
+
 ## [v0.10.12] - 2026-05-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindrpc"
-version = "0.10.12"
+version = "0.10.13"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3252,7 +3252,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2poolv2_api"
-version = "0.10.12"
+version = "0.10.13"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_cli"
-version = "0.10.12"
+version = "0.10.13"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_config"
-version = "0.10.12"
+version = "0.10.13"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_lib"
-version = "0.10.12"
+version = "0.10.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_node"
-version = "0.10.12"
+version = "0.10.13"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_tests"
-version = "0.10.12"
+version = "0.10.13"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.12"
+version = "0.10.13"
 edition = "2024"
 authors = ["Kulpreet Singh<kp@opdup.com>"]
 license = "AGPL-3.0-or-later"

--- a/load-tests/jmeter-testing/flamegraph-README.adoc
+++ b/load-tests/jmeter-testing/flamegraph-README.adoc
@@ -49,9 +49,43 @@ The script sets these flags to ensure accurate stack traces:
 - `RUSTFLAGS="-C force-frame-pointers=yes"` -- enables frame pointers
   for accurate call graph unwinding
 
+=== Remote load testing
+
+When the P2Poolv2 server is already running on a separate host (for
+example under `perf` or `cargo flamegraph`), use `run_remote_load.sh`
+to drive traffic from another machine. No mock-bitcoind or local build
+is needed.
+
+[,shell]
+----
+cd load-tests/jmeter-testing
+./run_remote_load.sh --host 192.168.1.50
+----
+
+All parameters can be overridden:
+
+[,shell]
+----
+./run_remote_load.sh --host 192.168.1.50 --port 3333 \
+    --threads 5000 --ramp 60 --duration 300 --delay 3000
+----
+
+Options:
+
+- `--host <ip>` -- stratum server IP or hostname (required)
+- `--port <port>` -- stratum port (default: 3333)
+- `--threads <n>` -- number of simulated miners (default: 5000)
+- `--ramp <seconds>` -- ramp-up time (default: 60)
+- `--duration <seconds>` -- test duration (default: 300)
+- `--delay <ms>` -- interval between submit calls per thread (default: 3000)
+
+Results are saved to `results/remote-<host>-<timestamp>.jtl`.
+
 === Adjusting the load
 
-The jmeter test parameters (thread count, ramp-up, duration) are
-defined in `stratum.jmx`. Edit these to change the profiling
-workload. More threads and longer duration produce more samples and a
-more representative flamegraph.
+The jmeter test parameters (thread count, ramp-up, duration) default
+to the values shown above. They can be overridden from the command
+line via `run_remote_load.sh` flags, or by passing `-J` properties
+directly to jmeter. The defaults are defined in `stratum.jmx` using
+`__P()` functions. More threads and longer duration produce more
+samples and a more representative flamegraph.

--- a/load-tests/jmeter-testing/run_remote_load.sh
+++ b/load-tests/jmeter-testing/run_remote_load.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+# Standalone JMeter load generator for a remote P2Poolv2 stratum server.
+#
+# The server is assumed to be already running (e.g. under perf/flamegraph)
+# on a separate host. This script only drives the client-side traffic.
+#
+# Usage:
+#   ./run_remote_load.sh --host <server-ip> [OPTIONS]
+#
+# Options:
+#   --host <ip>         Stratum server IP/hostname (required)
+#   --port <port>       Stratum server port (default: 3333)
+#   --threads <n>       Number of simulated miners (default: 5000)
+#   --ramp <seconds>    Ramp-up time in seconds (default: 60)
+#   --duration <secs>   Test duration in seconds (default: 300)
+#   --delay <ms>        Delay between submit calls per thread (default: 3000)
+#   -h, --help          Show this help message
+#
+# Prerequisites:
+#   - jmeter installed and in PATH
+#   - JAVA_HOME set if needed (e.g. JAVA_HOME=/usr/lib/jvm/java-21-openjdk)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JMX_FILE="${SCRIPT_DIR}/stratum.jmx"
+RESULTS_DIR="${SCRIPT_DIR}/results"
+
+HOST=""
+PORT="3333"
+THREADS="5000"
+RAMP="60"
+DURATION="300"
+DELAY="3000"
+
+usage() {
+    echo "Usage: $0 --host <server-ip> [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --host <ip>         Stratum server IP/hostname (required)"
+    echo "  --port <port>       Stratum server port (default: 3333)"
+    echo "  --threads <n>       Number of simulated miners (default: 5000)"
+    echo "  --ramp <seconds>    Ramp-up time (default: 60)"
+    echo "  --duration <secs>   Test duration (default: 300)"
+    echo "  --delay <ms>        Submit interval per thread (default: 3000)"
+    echo "  -h, --help          Show this help message"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            HOST="$2"
+            shift 2
+            ;;
+        --port)
+            PORT="$2"
+            shift 2
+            ;;
+        --threads)
+            THREADS="$2"
+            shift 2
+            ;;
+        --ramp)
+            RAMP="$2"
+            shift 2
+            ;;
+        --duration)
+            DURATION="$2"
+            shift 2
+            ;;
+        --delay)
+            DELAY="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "${HOST}" ]]; then
+    echo "ERROR: --host is required"
+    usage
+    exit 1
+fi
+
+if ! command -v jmeter >/dev/null 2>&1; then
+    echo "ERROR: jmeter is not installed or not in PATH"
+    exit 1
+fi
+
+if [[ ! -f "${JMX_FILE}" ]]; then
+    echo "ERROR: JMX file not found: ${JMX_FILE}"
+    exit 1
+fi
+
+log() {
+    echo "[$(date '+%H:%M:%S')] $*"
+}
+
+timestamp() {
+    date "+%Y%m%d-%H%M%S"
+}
+
+run_ts=$(timestamp)
+mkdir -p "${RESULTS_DIR}"
+
+JTL_FILE="${RESULTS_DIR}/remote-${HOST}-${run_ts}.jtl"
+JMETER_LOG="${RESULTS_DIR}/remote-${HOST}-${run_ts}-jmeter.log"
+
+log "Target: ${HOST}:${PORT}"
+log "Threads: ${THREADS}  Ramp: ${RAMP}s  Duration: ${DURATION}s  Submit delay: ${DELAY}ms"
+log "Results: ${JTL_FILE}"
+
+log "Running jmeter load test..."
+jmeter -n -t "${JMX_FILE}" \
+    -l "${JTL_FILE}" \
+    -j "${JMETER_LOG}" \
+    -Jstratum.host="${HOST}" \
+    -Jstratum.port="${PORT}" \
+    -JThreadGroup.num_threads="${THREADS}" \
+    -JThreadGroup.ramp_time="${RAMP}" \
+    -JThreadGroup.duration="${DURATION}" \
+    -JConstantTimer.delay="${DELAY}" \
+    2>&1 | grep "^summary"
+
+log "jmeter complete"
+log "Results: ${JTL_FILE}"
+log "Log: ${JMETER_LOG}"

--- a/load-tests/jmeter-testing/stratum.jmx
+++ b/load-tests/jmeter-testing/stratum.jmx
@@ -10,9 +10,9 @@
     </TestPlan>
     <hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group">
-        <intProp name="ThreadGroup.num_threads">5000</intProp>
-        <intProp name="ThreadGroup.ramp_time">60</intProp>
-        <longProp name="ThreadGroup.duration">300</longProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(ThreadGroup.num_threads,5000)}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${__P(ThreadGroup.ramp_time,60)}</stringProp>
+        <stringProp name="ThreadGroup.duration">${__P(ThreadGroup.duration,300)}</stringProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
         <boolProp name="ThreadGroup.scheduler">true</boolProp>
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
@@ -70,7 +70,9 @@ import groovy.json.JsonSlurper
 
 long startTime = System.nanoTime()
 
-def socket = new Socket(&quot;127.0.0.1&quot;, 3333)
+def host = props.get(&quot;stratum.host&quot;) ?: &quot;127.0.0.1&quot;
+def port = (props.get(&quot;stratum.port&quot;) ?: &quot;3333&quot;) as int
+def socket = new Socket(host, port)
 socket.setSoTimeout(30000)
 def writer = new PrintWriter(socket.getOutputStream(), true)
 def reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))
@@ -172,7 +174,7 @@ SampleResult.setResponseCodeOK()
         </LoopController>
         <hashTree>
           <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Submit Delay">
-            <stringProp name="ConstantTimer.delay">3000</stringProp>
+            <stringProp name="ConstantTimer.delay">${__P(ConstantTimer.delay,3000)}</stringProp>
           </ConstantTimer>
           <hashTree/>
           <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="Submit Sampler" enabled="true">

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -258,6 +258,7 @@ mod handle_submit_tests {
     use crate::stratum::messages::Id;
     use crate::stratum::messages::SetDifficultyNotification;
     use crate::stratum::session::Session;
+    use crate::stratum::work::gbt::build_merkle_branches_for_template;
     use crate::stratum::work::tracker::start_tracker_actor;
     use crate::test_utils::{
         TEST_COINBASE_NSECS, create_test_commitment, load_valid_stratum_work_components,
@@ -299,17 +300,17 @@ mod handle_submit_tests {
 
         let job_id = JobId(u64::from_str_radix(&notify.params.job_id, 16).unwrap());
 
-        let test_merkle_branches = vec![
-            bitcoin::TxMerkleNode::all_zeros(),
-            bitcoin::TxMerkleNode::all_zeros(),
-        ];
+        let merkle_branches = build_merkle_branches_for_template(&template)
+            .into_iter()
+            .map(bitcoin::TxMerkleNode::from_raw_hash)
+            .collect();
         let _ = tracker_handle.insert_job(
             Arc::new(template),
             notify.params.coinbase1.to_string(),
             notify.params.coinbase2.to_string(),
             Some(create_test_commitment()),
             TEST_COINBASE_NSECS,
-            test_merkle_branches,
+            merkle_branches,
             job_id,
         );
 
@@ -366,7 +367,7 @@ mod handle_submit_tests {
         );
 
         // Verify merkle branches are passed through from JobDetails to Emission
-        assert_eq!(share.template_merkle_branches.len(), 2);
+        assert!(share.template_merkle_branches.is_empty());
 
         // Verify that the block is submitted to the mock server
         mock_server.verify().await;

--- a/p2poolv2_lib/src/stratum/work/difficulty/validate.rs
+++ b/p2poolv2_lib/src/stratum/work/difficulty/validate.rs
@@ -16,13 +16,13 @@
 
 use crate::stratum::error::Error;
 use crate::stratum::messages::SimpleRequest;
-use crate::stratum::work::block_template::BlockTemplate;
+use crate::stratum::work::gbt::compute_merkle_root_from_branches;
 use crate::stratum::work::tracker::JobDetails;
 use bitcoin::blockdata::block::Header;
 use bitcoin::consensus::Decodable;
 use hex::FromHex;
 use std::str::FromStr;
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 
 /// Share validation result
 ///
@@ -34,17 +34,6 @@ pub struct ValidationResult {
     pub coinbase: bitcoin::Transaction,
     /// Does the block meet bitcoin difficulty
     pub meets_bitcoin_difficulty: bool,
-}
-
-/// parse all transactions from block template with data and txid
-fn decode_txids(blocktemplate: &BlockTemplate) -> Result<Vec<bitcoin::Txid>, Error> {
-    blocktemplate
-        .transactions
-        .iter()
-        .map(|tx| {
-            bitcoin::Txid::from_str(&tx.txid).map_err(|_| Error::InvalidParams("Bad txid".into()))
-        })
-        .collect()
 }
 
 /// Build coinbase from the submitted share and block template components.
@@ -115,17 +104,9 @@ pub fn validate_bitcoin_difficulty(
 
     debug!("Coinbase transaction: {:?}", coinbase);
 
-    // decode txids for making merkle root
-    let txids = decode_txids(&job.blocktemplate)
-        .map_err(|_| Error::InvalidParams("Failed to decode txids".into()))?;
-
-    let mut all_txids = vec![coinbase.compute_txid()];
-    all_txids.extend(txids);
-
-    let hashes = all_txids.iter().map(|obj| obj.to_raw_hash());
-    let merkle_root: bitcoin::TxMerkleNode = bitcoin::merkle_tree::calculate_root(hashes)
-        .map(|h| h.into())
-        .unwrap();
+    // Compute merkle root by walking the pre-computed branches along with the coinbase txid.
+    let merkle_root =
+        compute_merkle_root_from_branches(coinbase.compute_txid(), &job.template_merkle_branches);
 
     let ntime_str = submission.params[3]
         .as_ref()


### PR DESCRIPTION
We have them already parsed and available in prepared notify params, which are available in jobs. Use that and avoid recomputing them for every single submit :)

For the performance testing move the jmeter setup out of the benchmarking tool so we can use it to load test a standalone remote node.