### PR TITLE
Fix prometheus counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix user and worker shares_valid_total Prometheus counter overflow.
+  The TWO32 multiplication used saturating_mul on u64, capping at
+  u64::MAX for users with accumulated difficulty above ~4.29 billion.
+  Switched to f64 arithmetic which handles the full range correctly.
+
 ## [v0.10.13] - 2026-05-15
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindrpc"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3252,7 +3252,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2poolv2_api"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_cli"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_config"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_lib"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_node"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_tests"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.13"
+version = "0.10.14"
 edition = "2024"
 authors = ["Kulpreet Singh<kp@opdup.com>"]
 license = "AGPL-3.0-or-later"

--- a/p2poolv2_lib/src/accounting/stats/prom.rs
+++ b/p2poolv2_lib/src/accounting/stats/prom.rs
@@ -15,7 +15,7 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::accounting::stats::metrics::PoolMetrics;
-const TWO32: u64 = 1u64 << 32;
+const TWO32: f64 = (1u64 << 32) as f64;
 
 impl PoolMetrics {
     pub fn get_exposition(&self) -> String {
@@ -94,9 +94,9 @@ impl PoolMetrics {
         output.push_str("# TYPE user_shares_valid_total counter\n");
         for (btcaddress, user) in &some_shares_users {
             output.push_str(&format!(
-                "user_shares_valid_total{{btcaddress=\"{}\"}} {}\n",
+                "user_shares_valid_total{{btcaddress=\"{}\"}} {:.0}\n",
                 btcaddress,
-                user.shares_valid_total.saturating_mul(TWO32)
+                (user.shares_valid_total as f64) * TWO32
             ));
         }
         output.push('\n');
@@ -113,10 +113,10 @@ impl PoolMetrics {
                     workername
                 };
                 output.push_str(&format!(
-                    "worker_shares_valid_total{{btcaddress=\"{}\",workername=\"{}\"}} {}\n",
+                    "worker_shares_valid_total{{btcaddress=\"{}\",workername=\"{}\"}} {:.0}\n",
                     btcaddress,
                     display_name,
-                    worker.shares_valid_total.saturating_mul(TWO32)
+                    (worker.shares_valid_total as f64) * TWO32
                 ));
             }
         }
@@ -263,21 +263,21 @@ mod tests {
         assert!(exposition.contains("# HELP user_shares_valid_total"));
         assert!(exposition.contains("# TYPE user_shares_valid_total counter"));
         assert!(exposition.contains(&format!(
-            r#"user_shares_valid_total{{btcaddress="bc1quser1"}} {}"#,
-            42 * TWO32
+            r#"user_shares_valid_total{{btcaddress="bc1quser1"}} {:.0}"#,
+            42.0 * TWO32
         )));
 
         // Check worker metrics are present for active worker1
         assert!(exposition.contains("# HELP worker_shares_valid"));
         assert!(exposition.contains("# TYPE worker_shares_valid_total counter"));
         assert!(exposition.contains(&format!(
-            r#"worker_shares_valid_total{{btcaddress="bc1quser1",workername="worker1"}} {}"#,
-            20 * TWO32
+            r#"worker_shares_valid_total{{btcaddress="bc1quser1",workername="worker1"}} {:.0}"#,
+            20.0 * TWO32
         )));
         // Inactive worker2 should NOT be present
         assert!(!exposition.contains(&format!(
-            r#"worker_shares_valid_total{{btcaddress="bc1quser1",workername="worker2"}} {}"#,
-            22 * TWO32
+            r#"worker_shares_valid_total{{btcaddress="bc1quser1",workername="worker2"}} {:.0}"#,
+            22.0 * TWO32
         )));
 
         assert!(exposition.contains("# HELP worker_best_share"));
@@ -352,15 +352,15 @@ mod tests {
 
         // Check user-level metric
         assert!(exposition.contains(&format!(
-            r#"user_shares_valid_total{{btcaddress="bc1qtest"}} {}"#,
-            10 * TWO32
+            r#"user_shares_valid_total{{btcaddress="bc1qtest"}} {:.0}"#,
+            10.0 * TWO32
         )));
 
         // Verify that empty workername is replaced with "unnamed"
         assert!(exposition.contains(r#"workername="unnamed""#));
         assert!(exposition.contains(&format!(
-            r#"worker_shares_valid_total{{btcaddress="bc1qtest",workername="unnamed"}} {}"#,
-            10 * TWO32
+            r#"worker_shares_valid_total{{btcaddress="bc1qtest",workername="unnamed"}} {:.0}"#,
+            10.0 * TWO32
         )));
         assert!(
             exposition


### PR DESCRIPTION
We were using saturating mul and u64, when tracking total hashes contributed this overflowed.

Use f64 when generating prom hash counting metrics.