### PR TITLE
Sync improvements

### DIFF
--- a/p2poolv2_api/src/api/endpoints/mod.rs
+++ b/p2poolv2_api/src/api/endpoints/mod.rs
@@ -20,6 +20,7 @@ pub mod dag;
 pub mod share;
 pub mod share_headers;
 pub mod shares;
+pub mod transaction;
 
 /// Maximum number of candidates and shares that can be requested in a single query.
 pub(crate) const MAX_NUM_SHARES_IN_RESPONSE: u32 = 100;

--- a/p2poolv2_api/src/api/endpoints/transaction.rs
+++ b/p2poolv2_api/src/api/endpoints/transaction.rs
@@ -78,7 +78,10 @@ pub async fn transaction(
             txid: txid.to_string(),
             hex,
         };
-        Ok(Json(serde_json::to_value(output).unwrap()))
+        let value = serde_json::to_value(output).map_err(|error| {
+            ApiError::ServerError(format!("Failed to serialize response: {error}"))
+        })?;
+        Ok(Json(value))
     } else {
         let inputs: Vec<InputOutput> = tx
             .input
@@ -109,7 +112,10 @@ pub async fn transaction(
             inputs,
             outputs,
         };
-        Ok(Json(serde_json::to_value(output).unwrap()))
+        let value = serde_json::to_value(output).map_err(|error| {
+            ApiError::ServerError(format!("Failed to serialize response: {error}"))
+        })?;
+        Ok(Json(value))
     }
 }
 

--- a/p2poolv2_api/src/api/endpoints/transaction.rs
+++ b/p2poolv2_api/src/api/endpoints/transaction.rs
@@ -1,0 +1,232 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::api::error::ApiError;
+use crate::api::server::AppState;
+use axum::{
+    Json,
+    extract::{Query, State},
+};
+use bitcoin::consensus::encode;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use std::sync::Arc;
+
+#[derive(Deserialize)]
+pub struct TransactionQuery {
+    pub txid: String,
+    pub raw: Option<bool>,
+}
+
+#[derive(Serialize)]
+pub struct TransactionOutput {
+    pub txid: String,
+    pub version: i32,
+    pub lock_time: String,
+    pub inputs: Vec<InputOutput>,
+    pub outputs: Vec<OutputOutput>,
+}
+
+#[derive(Serialize)]
+pub struct InputOutput {
+    pub previous_output: String,
+    pub script_sig: String,
+    pub sequence: u32,
+}
+
+#[derive(Serialize)]
+pub struct OutputOutput {
+    pub value: u64,
+    pub script_pubkey: String,
+}
+
+#[derive(Serialize)]
+pub struct RawTransactionOutput {
+    pub txid: String,
+    pub hex: String,
+}
+
+pub async fn transaction(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<TransactionQuery>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let txid = bitcoin::Txid::from_str(&query.txid)
+        .map_err(|error| ApiError::BadRequest(format!("Invalid txid: {error}")))?;
+
+    let store = state.chain_store_handle.store_handle().store();
+    let tx = store
+        .get_tx(&txid)
+        .map_err(|error| ApiError::NotFound(format!("Transaction not found: {error}")))?;
+
+    if query.raw.unwrap_or(false) {
+        let raw_bytes = encode::serialize(&tx);
+        let hex = hex::encode(raw_bytes);
+        let output = RawTransactionOutput {
+            txid: txid.to_string(),
+            hex,
+        };
+        Ok(Json(serde_json::to_value(output).unwrap()))
+    } else {
+        let inputs: Vec<InputOutput> = tx
+            .input
+            .iter()
+            .map(|input| InputOutput {
+                previous_output: format!(
+                    "{}:{}",
+                    input.previous_output.txid, input.previous_output.vout
+                ),
+                script_sig: input.script_sig.to_hex_string(),
+                sequence: input.sequence.0,
+            })
+            .collect();
+
+        let outputs: Vec<OutputOutput> = tx
+            .output
+            .iter()
+            .map(|output| OutputOutput {
+                value: output.value.to_sat(),
+                script_pubkey: output.script_pubkey.to_hex_string(),
+            })
+            .collect();
+
+        let output = TransactionOutput {
+            txid: txid.to_string(),
+            version: tx.version.0,
+            lock_time: format!("{}", tx.lock_time),
+            inputs,
+            outputs,
+        };
+        Ok(Json(serde_json::to_value(output).unwrap()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::server::{AppConfig, AppState};
+    use axum::extract::{Query, State};
+    use p2poolv2_lib::accounting::stats::metrics;
+    use p2poolv2_lib::monitoring_events::create_monitoring_event_channel;
+    use p2poolv2_lib::node::actor::NodeHandle;
+    use p2poolv2_lib::stratum::work::tracker::start_tracker_actor;
+    use p2poolv2_lib::test_utils::{
+        TestShareBlockBuilder, genesis_for_tests, setup_test_chain_store_handle,
+    };
+
+    async fn build_test_state() -> (Arc<AppState>, tempfile::TempDir) {
+        let (chain_store_handle, temp_dir) = setup_test_chain_store_handle(true).await;
+        let genesis = genesis_for_tests();
+        chain_store_handle
+            .init_or_setup_genesis(genesis)
+            .await
+            .unwrap();
+
+        let share = TestShareBlockBuilder::new()
+            .prev_share_blockhash(chain_store_handle.get_chain_tip().unwrap().to_string())
+            .nonce(1)
+            .work(2)
+            .build();
+        chain_store_handle.add_share_block(share).await.unwrap();
+
+        let metrics_temp = tempfile::tempdir().unwrap();
+        let metrics_handle =
+            metrics::start_metrics(metrics_temp.path().to_str().unwrap().to_string())
+                .await
+                .unwrap();
+        let tracker_handle = start_tracker_actor();
+        let node_handle = NodeHandle::new_for_test();
+        let state = Arc::new(AppState {
+            app_config: AppConfig {
+                pool_signature_length: 0,
+                network: bitcoin::Network::Signet,
+                cors_allowed: false,
+            },
+            chain_store_handle,
+            metrics_handle,
+            tracker_handle,
+            node_handle,
+            monitoring_event_sender: create_monitoring_event_channel().0,
+            auth_user: None,
+            auth_token: None,
+        });
+        (state, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn test_transaction_invalid_txid() {
+        let (state, _temp_dir) = build_test_state().await;
+        let query = Query(TransactionQuery {
+            txid: "not_a_valid_txid".to_string(),
+            raw: None,
+        });
+        let result = transaction(State(state), query).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_transaction_not_found() {
+        let (state, _temp_dir) = build_test_state().await;
+        let query = Query(TransactionQuery {
+            txid: "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+            raw: None,
+        });
+        let result = transaction(State(state), query).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_transaction_json_output() {
+        let (state, _temp_dir) = build_test_state().await;
+        let store = state.chain_store_handle.store_handle().store();
+        let genesis_hash = state.chain_store_handle.get_chain_tip().unwrap();
+        let txids = store.get_txids_for_blockhash(&genesis_hash);
+        let txid = txids.0[0];
+
+        let query = Query(TransactionQuery {
+            txid: txid.to_string(),
+            raw: None,
+        });
+        let result = transaction(State(state), query).await;
+        assert!(result.is_ok());
+        let json = result.unwrap().0;
+        assert_eq!(json["txid"], txid.to_string());
+        assert!(json["version"].is_number());
+        assert!(json["inputs"].is_array());
+        assert!(json["outputs"].is_array());
+    }
+
+    #[tokio::test]
+    async fn test_transaction_raw_output() {
+        let (state, _temp_dir) = build_test_state().await;
+        let store = state.chain_store_handle.store_handle().store();
+        let genesis_hash = state.chain_store_handle.get_chain_tip().unwrap();
+        let txids = store.get_txids_for_blockhash(&genesis_hash);
+        let txid = txids.0[0];
+
+        let query = Query(TransactionQuery {
+            txid: txid.to_string(),
+            raw: Some(true),
+        });
+        let result = transaction(State(state), query).await;
+        assert!(result.is_ok());
+        let json = result.unwrap().0;
+        assert_eq!(json["txid"], txid.to_string());
+        assert!(json["hex"].is_string());
+        let hex_str = json["hex"].as_str().unwrap();
+        assert!(hex_str.len() > 0);
+        assert!(hex::decode(hex_str).is_ok());
+    }
+}

--- a/p2poolv2_api/src/api/server.rs
+++ b/p2poolv2_api/src/api/server.rs
@@ -23,7 +23,7 @@ use axum::{
     http::StatusCode,
     middleware::{self, Next},
     response::Response,
-    routing::get,
+    routing::{delete, get, post},
 };
 use chrono::DateTime;
 use p2poolv2_lib::monitoring_events::MonitoringEventSender;
@@ -116,6 +116,9 @@ fn build_router(app_state: Arc<AppState>, app_config: AppConfig) -> Router {
             "/share_headers",
             get(endpoints::share_headers::share_headers),
         )
+        .route("/blocked_ips", get(get_blocked_ips))
+        .route("/blocked_ips", post(block_ip))
+        .route("/blocked_ips", delete(unblock_ip))
         .layer(middleware::from_fn_with_state(
             app_state.clone(),
             auth_middleware,
@@ -234,28 +237,71 @@ async fn metrics(State(state): State<Arc<AppState>>) -> String {
 
 /// Response type for the /peers endpoint.
 ///
-/// Reuses the shared PeerResponse from the lib crate but with a
-/// default Connected status since the REST endpoint only lists
-/// currently connected peers.
-use p2poolv2_lib::monitoring_events::{PeerResponse, PeerStatus};
+use p2poolv2_lib::node::connection_tracker::PeerInfoResponse;
 
-/// Returns the list of currently connected peers.
-async fn peers(State(state): State<Arc<AppState>>) -> Result<Json<Vec<PeerResponse>>, ApiError> {
-    let peer_ids = state
+/// Returns enriched info for all connected peers including IP, direction,
+/// and connection duration.
+async fn peers(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<PeerInfoResponse>>, ApiError> {
+    let peer_infos = state
         .node_handle
-        .get_peers()
+        .get_peer_infos()
         .await
-        .map_err(|error| ApiError::ServerError(format!("Failed to get peers: {error}")))?;
+        .map_err(|error| ApiError::ServerError(format!("Failed to get peer infos: {error}")))?;
+    Ok(Json(peer_infos))
+}
 
-    let peers: Vec<PeerResponse> = peer_ids
-        .into_iter()
-        .map(|peer_id| PeerResponse {
-            peer_id: peer_id.to_string(),
-            status: PeerStatus::Connected,
-        })
-        .collect();
+/// Request body for block/unblock IP endpoints.
+#[derive(Deserialize)]
+struct BlockIpRequest {
+    ip: String,
+}
 
-    Ok(Json(peers))
+/// List all blocked IPs.
+async fn get_blocked_ips(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<String>>, ApiError> {
+    let ips =
+        state.node_handle.get_blocked_ips().await.map_err(|error| {
+            ApiError::ServerError(format!("Failed to get blocked IPs: {error}"))
+        })?;
+    let ip_strings: Vec<String> = ips.iter().map(|ip| ip.to_string()).collect();
+    Ok(Json(ip_strings))
+}
+
+/// Add an IP to the runtime blocklist.
+async fn block_ip(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<BlockIpRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let ip: std::net::IpAddr = body
+        .ip
+        .parse()
+        .map_err(|error| ApiError::BadRequest(format!("Invalid IP address: {error}")))?;
+    state
+        .node_handle
+        .block_ip(ip)
+        .await
+        .map_err(|error| ApiError::ServerError(format!("Failed to block IP: {error}")))?;
+    Ok(Json(serde_json::json!({"blocked": body.ip})))
+}
+
+/// Remove an IP from the runtime blocklist.
+async fn unblock_ip(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<BlockIpRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let ip: std::net::IpAddr = body
+        .ip
+        .parse()
+        .map_err(|error| ApiError::BadRequest(format!("Invalid IP address: {error}")))?;
+    state
+        .node_handle
+        .unblock_ip(ip)
+        .await
+        .map_err(|error| ApiError::ServerError(format!("Failed to unblock IP: {error}")))?;
+    Ok(Json(serde_json::json!({"unblocked": body.ip})))
 }
 
 /// Returns PPLNS shares with optional time filtering and limit.

--- a/p2poolv2_api/src/api/server.rs
+++ b/p2poolv2_api/src/api/server.rs
@@ -112,6 +112,7 @@ fn build_router(app_state: Arc<AppState>, app_config: AppConfig) -> Router {
         .route("/candidates", get(endpoints::candidates::candidates))
         .route("/share", get(endpoints::share::share))
         .route("/dag", get(endpoints::dag::dag))
+        .route("/transaction", get(endpoints::transaction::transaction))
         .route(
             "/share_headers",
             get(endpoints::share_headers::share_headers),

--- a/p2poolv2_cli/README.md
+++ b/p2poolv2_cli/README.md
@@ -29,7 +29,7 @@ Query the RocksDB database directly without a running node. Pass
 p2poolv2_cli --db-path /path/to/store.db <command>
 ```
 
-All commands except `peers-info` work in this mode.
+All commands except `peers` work in this mode.
 
 ## Commands
 
@@ -93,13 +93,32 @@ p2poolv2_cli pplns-shares --limit 50
 p2poolv2_cli pplns-shares --limit 100 --start-time 1700000000 --end-time 1700100000
 ```
 
-### peers-info
+### peers
 
-List connected peers.
+Peer management commands. Requires a running node (`--config`).
 
 ```sh
-p2poolv2_cli peers-info
+p2poolv2_cli peers info              # list connected peers
+p2poolv2_cli peers blocked           # list blocked IPs
+p2poolv2_cli peers block 1.2.3.4     # block an IP address
+p2poolv2_cli peers unblock 1.2.3.4   # unblock an IP address
 ```
+
+### db
+
+Database maintenance commands. Requires `--db-path` and the node must
+be stopped (RocksDB does not support concurrent access).
+
+```sh
+p2poolv2_cli --db-path /path/to/store.db db cleanup-dense-heights
+```
+
+#### cleanup-dense-heights
+
+Walk the height index and invalidate excess HeaderValid blocks at
+heights with more than 20 blocks. Retains Confirmed, Candidate, and
+BlockValid blocks, plus HeaderValid blocks that are referenced as
+uncles by other blocks.
 
 ### gen-auth
 
@@ -181,6 +200,6 @@ p2poolv2_cli candidates --num 20 \
 ### Peer IDs as a plain list
 
 ```sh
-p2poolv2_cli peers-info \
+p2poolv2_cli peers info \
   | jq -r '.[].peer_id'
 ```

--- a/p2poolv2_cli/src/commands/api_client.rs
+++ b/p2poolv2_cli/src/commands/api_client.rs
@@ -69,7 +69,6 @@ impl ApiClient {
         Ok(response.text().await?)
     }
 
-    /// Wrapper around get returning parsed JSON respons.
     /// Perform an authenticated GET request and deserialize the JSON response.
     pub async fn get_json<T: serde::de::DeserializeOwned>(
         &self,
@@ -78,6 +77,58 @@ impl ApiClient {
         let body = self.get(path).await?;
         let parsed: T = serde_json::from_str(&body)?;
         Ok(parsed)
+    }
+
+    /// Perform an authenticated POST request with a JSON body and
+    /// return the parsed JSON response.
+    pub async fn post_json(
+        &self,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self.send_json(reqwest::Method::POST, path, body).await?;
+        Ok(serde_json::from_str(&response)?)
+    }
+
+    /// Perform an authenticated DELETE request with a JSON body and
+    /// return the parsed JSON response.
+    pub async fn delete_json(
+        &self,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> Result<serde_json::Value, Box<dyn Error>> {
+        let response = self.send_json(reqwest::Method::DELETE, path, body).await?;
+        Ok(serde_json::from_str(&response)?)
+    }
+
+    /// Send a request with a JSON body using the given HTTP method.
+    async fn send_json(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> Result<String, Box<dyn Error>> {
+        let url = format!("{}{}", self.base_url, path);
+        let mut request = self.client.request(method, &url).json(body);
+
+        if let Some(header_value) = &self.auth_header {
+            request = request.header("Authorization", header_value.clone());
+        }
+
+        let response = request.send().await.map_err(|error| {
+            format!("Failed to connect to API at {url}: {error}. Is the node running?")
+        })?;
+
+        if !response.status().is_success() {
+            return Err(format!(
+                "API returned status {}: {}",
+                response.status(),
+                response.text().await.unwrap_or_default()
+            )
+            .into());
+        }
+
+        Ok(response.text().await?)
     }
 }
 

--- a/p2poolv2_cli/src/commands/blocked_ips.rs
+++ b/p2poolv2_cli/src/commands/blocked_ips.rs
@@ -1,0 +1,45 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::commands::api_client::ApiClient;
+use p2poolv2_lib::config::ApiConfig;
+use std::error::Error;
+
+/// List all blocked IPs.
+pub async fn list(api_config: &ApiConfig) -> Result<(), Box<dyn Error>> {
+    let api_client = ApiClient::new(api_config);
+    let response: serde_json::Value = api_client.get_json("/blocked_ips").await?;
+    println!("{}", serde_json::to_string_pretty(&response)?);
+    Ok(())
+}
+
+/// Add an IP to the blocklist.
+pub async fn block(api_config: &ApiConfig, ip: &str) -> Result<(), Box<dyn Error>> {
+    let api_client = ApiClient::new(api_config);
+    let body = serde_json::json!({"ip": ip});
+    let response = api_client.post_json("/blocked_ips", &body).await?;
+    println!("{}", serde_json::to_string_pretty(&response)?);
+    Ok(())
+}
+
+/// Remove an IP from the blocklist.
+pub async fn unblock(api_config: &ApiConfig, ip: &str) -> Result<(), Box<dyn Error>> {
+    let api_client = ApiClient::new(api_config);
+    let body = serde_json::json!({"ip": ip});
+    let response = api_client.delete_json("/blocked_ips", &body).await?;
+    println!("{}", serde_json::to_string_pretty(&response)?);
+    Ok(())
+}

--- a/p2poolv2_cli/src/commands/db.rs
+++ b/p2poolv2_cli/src/commands/db.rs
@@ -1,0 +1,212 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+//! Database maintenance commands that operate directly on the RocksDB store.
+//!
+//! These commands require `--db-path` and open the store in read-write mode.
+//! The node must be stopped before running these commands.
+
+use super::DbCommands;
+use bitcoin::BlockHash;
+use p2poolv2_lib::store::Store;
+use p2poolv2_lib::store::block_tx_metadata::Status;
+use p2poolv2_lib::store::dag_store::MAX_BLOCKS_PER_HEIGHT;
+use p2poolv2_lib::store::writer::StoreError;
+use std::error::Error;
+
+/// Open a RocksDB store in read-write mode for maintenance operations.
+fn open_store_readwrite(db_path: &str) -> Result<Store, Box<dyn Error>> {
+    Store::new(db_path.to_string(), false)
+        .map_err(|error| format!("Failed to open database at {db_path}: {error}").into())
+}
+
+/// Dispatch a db subcommand.
+pub fn execute(command: &DbCommands, db_path: &str) -> Result<(), Box<dyn Error>> {
+    let store = open_store_readwrite(db_path)?;
+    match command {
+        DbCommands::CleanupDenseHeights => cleanup_dense_heights(&store),
+    }
+}
+
+/// Clean up dense heights by marking excess HeaderValid blocks as Invalid.
+///
+/// Walks the height index and for each height with more than
+/// MAX_BLOCKS_PER_HEIGHT blocks, keeps Confirmed, Candidate, and
+/// BlockValid blocks plus HeaderValid blocks that are referenced as
+/// uncles. Marks remaining HeaderValid blocks as Invalid.
+fn cleanup_dense_heights(store: &Store) -> Result<(), Box<dyn Error>> {
+    let top_height = match store.get_top_confirmed_height() {
+        Ok(height) => height,
+        Err(StoreError::NotFound(_)) => {
+            println!("No confirmed chain found, nothing to clean up");
+            return Ok(());
+        }
+        Err(error) => return Err(format!("Failed to get top height: {error}").into()),
+    };
+
+    let mut total_invalidated = 0usize;
+    let mut dense_heights = 0usize;
+
+    let height_entries = store.get_blockhashes_for_height_range(0, top_height);
+
+    for (height, blockhashes) in height_entries {
+        if blockhashes.len() <= MAX_BLOCKS_PER_HEIGHT {
+            continue;
+        }
+
+        let metadata_results = store.get_block_metadata_batch(&blockhashes);
+
+        let header_valid_hashes: Vec<BlockHash> = metadata_results
+            .iter()
+            .filter(|(_, metadata)| metadata.status == Status::HeaderValid)
+            .map(|(hash, _)| *hash)
+            .collect();
+
+        if header_valid_hashes.len() + (blockhashes.len() - header_valid_hashes.len())
+            <= MAX_BLOCKS_PER_HEIGHT
+        {
+            continue;
+        }
+
+        dense_heights += 1;
+        let non_header_valid_count = blockhashes.len() - header_valid_hashes.len();
+        println!(
+            "Height {height}: {total} blocks ({non_hv} non-HeaderValid, {hv} HeaderValid)",
+            total = blockhashes.len(),
+            non_hv = non_header_valid_count,
+            hv = header_valid_hashes.len(),
+        );
+
+        let mut batch = Store::get_write_batch();
+        let mut height_invalidated = 0usize;
+
+        for blockhash in &header_valid_hashes {
+            let is_uncle = store.get_nephews(blockhash).is_some();
+            if is_uncle {
+                continue;
+            }
+            let mut metadata = store.get_block_metadata(blockhash)?;
+            metadata.status = Status::Invalid;
+            store.update_block_metadata(blockhash, &metadata, &mut batch)?;
+            height_invalidated += 1;
+        }
+
+        if height_invalidated > 0 {
+            store.commit_batch(batch)?;
+            println!("  Invalidated {height_invalidated} unreferenced HeaderValid blocks");
+            total_invalidated += height_invalidated;
+        }
+    }
+
+    println!(
+        "Cleanup complete: {dense_heights} dense heights found, {total_invalidated} blocks invalidated"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p2poolv2_lib::test_utils::{
+        TestShareBlockBuilder, genesis_for_tests, setup_test_chain_store_handle,
+    };
+
+    #[tokio::test]
+    async fn test_cleanup_dense_heights_invalidates_unreferenced_header_valid() {
+        let (chain_store_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+        let genesis = genesis_for_tests();
+        chain_store_handle
+            .init_or_setup_genesis(genesis.clone())
+            .await
+            .unwrap();
+
+        // Confirmed block at height 1
+        let confirmed = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(1)
+            .work(2)
+            .build();
+        chain_store_handle
+            .add_share_block(confirmed.clone())
+            .await
+            .unwrap();
+        chain_store_handle
+            .promote_block(confirmed.header.clone())
+            .await
+            .unwrap();
+
+        // Uncle at height 1 (organise header stores as HeaderValid)
+        let uncle = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(100)
+            .build();
+        chain_store_handle
+            .add_share_block(uncle.clone())
+            .await
+            .unwrap();
+        chain_store_handle
+            .organise_header(uncle.header.clone())
+            .await
+            .unwrap();
+
+        // Confirmed block at height 2 referencing uncle
+        let confirmed_with_uncle = TestShareBlockBuilder::new()
+            .prev_share_blockhash(confirmed.block_hash().to_string())
+            .uncles(vec![uncle.block_hash()])
+            .nonce(2)
+            .work(2)
+            .build();
+        chain_store_handle
+            .add_share_block(confirmed_with_uncle.clone())
+            .await
+            .unwrap();
+        chain_store_handle
+            .promote_block(confirmed_with_uncle.header.clone())
+            .await
+            .unwrap();
+
+        // 25 unreferenced HeaderValid blocks at height 1
+        for nonce in 200..225 {
+            let spam = TestShareBlockBuilder::new()
+                .prev_share_blockhash(genesis.block_hash().to_string())
+                .nonce(nonce)
+                .build();
+            chain_store_handle
+                .add_share_block(spam.clone())
+                .await
+                .unwrap();
+            chain_store_handle
+                .organise_header(spam.header.clone())
+                .await
+                .unwrap();
+        }
+
+        let store = chain_store_handle.store_handle().store();
+        let blocks_before = store.get_blockhashes_for_height(1);
+        assert_eq!(blocks_before.len(), 27);
+
+        cleanup_dense_heights(store).unwrap();
+
+        // Uncle and confirmed should survive, 25 spam blocks invalidated
+        let metadata_results = store.get_block_metadata_batch(&blocks_before);
+        let valid_count = metadata_results
+            .iter()
+            .filter(|(_, metadata)| metadata.status != Status::Invalid)
+            .count();
+        // 1 confirmed + 1 uncle-referenced HeaderValid = 2 valid
+        assert_eq!(valid_count, 2);
+    }
+}

--- a/p2poolv2_cli/src/commands/db_query.rs
+++ b/p2poolv2_cli/src/commands/db_query.rs
@@ -35,7 +35,6 @@ pub fn open_store(db_path: &str) -> Result<Store, Box<dyn Error>> {
         .map_err(|error| format!("Failed to open database at {db_path}: {error}").into())
 }
 
-
 /// Query chain info directly from the store.
 pub fn info(store: &Store) -> Result<(), Box<dyn Error>> {
     let genesis_blockhash = store.get_genesis_blockhash().map(|h| h.to_string());

--- a/p2poolv2_cli/src/commands/db_query.rs
+++ b/p2poolv2_cli/src/commands/db_query.rs
@@ -35,6 +35,7 @@ pub fn open_store(db_path: &str) -> Result<Store, Box<dyn Error>> {
         .map_err(|error| format!("Failed to open database at {db_path}: {error}").into())
 }
 
+
 /// Query chain info directly from the store.
 pub fn info(store: &Store) -> Result<(), Box<dyn Error>> {
     let genesis_blockhash = store.get_genesis_blockhash().map(|h| h.to_string());

--- a/p2poolv2_cli/src/commands/mod.rs
+++ b/p2poolv2_cli/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub mod peers_info;
 pub mod pplns_shares;
 pub mod share;
 pub mod shares;
+pub mod transactions;
 
 use crate::commands;
 use clap::{ArgGroup, Parser, Subcommand};
@@ -126,6 +127,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: PeersCommands,
     },
+    /// Transaction queries
+    Transactions {
+        #[command(subcommand)]
+        command: TransactionsCommands,
+    },
     /// Database maintenance commands (requires --db-path, node must be stopped)
     Db {
         #[command(subcommand)]
@@ -144,6 +150,18 @@ pub enum Commands {
 pub enum DbCommands {
     /// Clean up dense heights by invalidating excess HeaderValid blocks
     CleanupDenseHeights,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TransactionsCommands {
+    /// Get a transaction by txid
+    Get {
+        /// Transaction hash
+        txid: String,
+        /// Output raw hex instead of JSON
+        #[arg(long, default_value = "false")]
+        raw: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -194,7 +212,8 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
             | Commands::Shares { .. }
             | Commands::Candidates { .. }
             | Commands::Share { .. }
-            | Commands::Dag { .. },
+            | Commands::Dag { .. }
+            | Commands::Transactions { .. },
         ) => {
             if let Some(db_path) = &cli.db_path {
                 // Direct database query mode (offline, no running node required)
@@ -230,6 +249,9 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                     }
                     Some(Commands::Dag { to, num, dot }) => {
                         commands::db_query::dag(&store, *to, *num, *dot)?;
+                    }
+                    Some(Commands::Transactions { command }) => {
+                        commands::transactions::execute_db(&store, command)?;
                     }
                     _ => unreachable!(),
                 }
@@ -282,6 +304,9 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                     }
                     Some(Commands::Dag { to, num, dot: _ }) => {
                         commands::dag::execute(&config.api, *to, *num).await?;
+                    }
+                    Some(Commands::Transactions { command }) => {
+                        commands::transactions::execute_api(&config.api, command).await?;
                     }
                     _ => unreachable!(),
                 }

--- a/p2poolv2_cli/src/commands/mod.rs
+++ b/p2poolv2_cli/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub mod dag;
 pub mod db;
 pub mod db_query;
 pub mod gen_auth;
+pub mod peers;
 pub mod peers_info;
 pub mod pplns_shares;
 pub mod share;
@@ -120,19 +121,10 @@ pub enum Commands {
         #[arg(short, long, default_value = "false")]
         dot: bool,
     },
-    /// Show connected peers by querying the running node's API
-    PeersInfo,
-    /// List blocked IPs
-    BlockedIps,
-    /// Block an IP address at runtime
-    BlockIp {
-        /// IP address to block
-        ip: String,
-    },
-    /// Unblock an IP address at runtime
-    UnblockIp {
-        /// IP address to unblock
-        ip: String,
+    /// Peer management commands (requires running node with --config)
+    Peers {
+        #[command(subcommand)]
+        command: PeersCommands,
     },
     /// Database maintenance commands (requires --db-path, node must be stopped)
     Db {
@@ -154,6 +146,24 @@ pub enum DbCommands {
     CleanupDenseHeights,
 }
 
+#[derive(Subcommand, Debug)]
+pub enum PeersCommands {
+    /// Show connected peers
+    Info,
+    /// List blocked IPs
+    Blocked,
+    /// Block an IP address at runtime
+    Block {
+        /// IP address to block
+        ip: String,
+    },
+    /// Unblock an IP address at runtime
+    Unblock {
+        /// IP address to unblock
+        ip: String,
+    },
+}
+
 pub async fn run() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
 
@@ -170,12 +180,16 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                 .ok_or("--db-path required for db commands")?;
             commands::db::execute(command, db_path)?;
         }
+        Some(Commands::Peers { command }) => {
+            let config_path = cli
+                .config
+                .as_ref()
+                .ok_or("Config file required for peers commands. Use --config")?;
+            let config = Config::load(config_path)?;
+            commands::peers::execute(command, &config.api).await?;
+        }
         Some(
-            Commands::PeersInfo
-            | Commands::BlockedIps
-            | Commands::BlockIp { .. }
-            | Commands::UnblockIp { .. }
-            | Commands::Info
+            Commands::Info
             | Commands::PplnsShares { .. }
             | Commands::Shares { .. }
             | Commands::Candidates { .. }
@@ -187,17 +201,6 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                 let store = commands::db_query::open_store(db_path)?;
 
                 match &cli.command {
-                    Some(
-                        Commands::PeersInfo
-                        | Commands::BlockedIps
-                        | Commands::BlockIp { .. }
-                        | Commands::UnblockIp { .. },
-                    ) => {
-                        return Err(
-                            "This command requires a running node; cannot use with --db-path"
-                                .into(),
-                        );
-                    }
                     Some(Commands::Info) => {
                         commands::db_query::info(&store)?;
                     }
@@ -239,18 +242,6 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                 let config = Config::load(config_path)?;
 
                 match &cli.command {
-                    Some(Commands::PeersInfo) => {
-                        commands::peers_info::execute(&config.api).await?;
-                    }
-                    Some(Commands::BlockedIps) => {
-                        commands::blocked_ips::list(&config.api).await?;
-                    }
-                    Some(Commands::BlockIp { ip }) => {
-                        commands::blocked_ips::block(&config.api, ip).await?;
-                    }
-                    Some(Commands::UnblockIp { ip }) => {
-                        commands::blocked_ips::unblock(&config.api, ip).await?;
-                    }
                     Some(Commands::Info) => {
                         commands::chain_info::execute(&config.api).await?;
                     }

--- a/p2poolv2_cli/src/commands/mod.rs
+++ b/p2poolv2_cli/src/commands/mod.rs
@@ -15,6 +15,7 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 pub mod api_client;
+pub mod blocked_ips;
 pub mod candidates;
 pub mod chain_info;
 pub mod dag;
@@ -120,6 +121,18 @@ pub enum Commands {
     },
     /// Show connected peers by querying the running node's API
     PeersInfo,
+    /// List blocked IPs
+    BlockedIps,
+    /// Block an IP address at runtime
+    BlockIp {
+        /// IP address to block
+        ip: String,
+    },
+    /// Unblock an IP address at runtime
+    UnblockIp {
+        /// IP address to unblock
+        ip: String,
+    },
     /// Generate API authentication credentials (salt, password, HMAC)
     GenAuth {
         /// Username for API authentication
@@ -140,6 +153,9 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         }
         Some(
             Commands::PeersInfo
+            | Commands::BlockedIps
+            | Commands::BlockIp { .. }
+            | Commands::UnblockIp { .. }
             | Commands::Info
             | Commands::PplnsShares { .. }
             | Commands::Shares { .. }
@@ -152,9 +168,15 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                 let store = commands::db_query::open_store(db_path)?;
 
                 match &cli.command {
-                    Some(Commands::PeersInfo) => {
+                    Some(
+                        Commands::PeersInfo
+                        | Commands::BlockedIps
+                        | Commands::BlockIp { .. }
+                        | Commands::UnblockIp { .. },
+                    ) => {
                         return Err(
-                            "peers-info requires a running node; cannot use with --db-path".into(),
+                            "This command requires a running node; cannot use with --db-path"
+                                .into(),
                         );
                     }
                     Some(Commands::Info) => {
@@ -200,6 +222,15 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                 match &cli.command {
                     Some(Commands::PeersInfo) => {
                         commands::peers_info::execute(&config.api).await?;
+                    }
+                    Some(Commands::BlockedIps) => {
+                        commands::blocked_ips::list(&config.api).await?;
+                    }
+                    Some(Commands::BlockIp { ip }) => {
+                        commands::blocked_ips::block(&config.api, ip).await?;
+                    }
+                    Some(Commands::UnblockIp { ip }) => {
+                        commands::blocked_ips::unblock(&config.api, ip).await?;
                     }
                     Some(Commands::Info) => {
                         commands::chain_info::execute(&config.api).await?;

--- a/p2poolv2_cli/src/commands/mod.rs
+++ b/p2poolv2_cli/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod blocked_ips;
 pub mod candidates;
 pub mod chain_info;
 pub mod dag;
+pub mod db;
 pub mod db_query;
 pub mod gen_auth;
 pub mod peers_info;
@@ -133,6 +134,11 @@ pub enum Commands {
         /// IP address to unblock
         ip: String,
     },
+    /// Database maintenance commands (requires --db-path, node must be stopped)
+    Db {
+        #[command(subcommand)]
+        command: DbCommands,
+    },
     /// Generate API authentication credentials (salt, password, HMAC)
     GenAuth {
         /// Username for API authentication
@@ -140,6 +146,12 @@ pub enum Commands {
         /// Password (leave empty to auto-generate, or use "-" to prompt)
         password: Option<String>,
     },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum DbCommands {
+    /// Clean up dense heights by invalidating excess HeaderValid blocks
+    CleanupDenseHeights,
 }
 
 pub async fn run() -> Result<(), Box<dyn Error>> {
@@ -150,6 +162,13 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     match &cli.command {
         Some(Commands::GenAuth { username, password }) => {
             commands::gen_auth::execute(username.clone(), password.clone())?;
+        }
+        Some(Commands::Db { command }) => {
+            let db_path = cli
+                .db_path
+                .as_ref()
+                .ok_or("--db-path required for db commands")?;
+            commands::db::execute(command, db_path)?;
         }
         Some(
             Commands::PeersInfo

--- a/p2poolv2_cli/src/commands/peers.rs
+++ b/p2poolv2_cli/src/commands/peers.rs
@@ -1,0 +1,69 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+//! Peer management commands that query the running node's API.
+
+use super::PeersCommands;
+use crate::commands::api_client::ApiClient;
+use p2poolv2_lib::config::ApiConfig;
+use std::error::Error;
+
+/// Dispatch a peers subcommand.
+pub async fn execute(
+    command: &PeersCommands,
+    api_config: &ApiConfig,
+) -> Result<(), Box<dyn Error>> {
+    match command {
+        PeersCommands::Info => info(api_config).await,
+        PeersCommands::Blocked => blocked_ips(api_config).await,
+        PeersCommands::Block { ip } => block_ip(api_config, ip).await,
+        PeersCommands::Unblock { ip } => unblock_ip(api_config, ip).await,
+    }
+}
+
+/// Show connected peers.
+async fn info(api_config: &ApiConfig) -> Result<(), Box<dyn Error>> {
+    let api_client = ApiClient::new(api_config);
+    let response: serde_json::Value = api_client.get_json("/peers").await?;
+    println!("{}", serde_json::to_string_pretty(&response)?);
+    Ok(())
+}
+
+/// List all blocked IPs.
+async fn blocked_ips(api_config: &ApiConfig) -> Result<(), Box<dyn Error>> {
+    let api_client = ApiClient::new(api_config);
+    let response: serde_json::Value = api_client.get_json("/blocked_ips").await?;
+    println!("{}", serde_json::to_string_pretty(&response)?);
+    Ok(())
+}
+
+/// Add an IP to the blocklist.
+async fn block_ip(api_config: &ApiConfig, ip: &str) -> Result<(), Box<dyn Error>> {
+    let api_client = ApiClient::new(api_config);
+    let body = serde_json::json!({"ip": ip});
+    let response = api_client.post_json("/blocked_ips", &body).await?;
+    println!("{}", serde_json::to_string_pretty(&response)?);
+    Ok(())
+}
+
+/// Remove an IP from the blocklist.
+async fn unblock_ip(api_config: &ApiConfig, ip: &str) -> Result<(), Box<dyn Error>> {
+    let api_client = ApiClient::new(api_config);
+    let body = serde_json::json!({"ip": ip});
+    let response = api_client.delete_json("/blocked_ips", &body).await?;
+    println!("{}", serde_json::to_string_pretty(&response)?);
+    Ok(())
+}

--- a/p2poolv2_cli/src/commands/transactions.rs
+++ b/p2poolv2_cli/src/commands/transactions.rs
@@ -1,0 +1,128 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+//! Transaction query commands.
+
+use super::TransactionsCommands;
+use crate::commands::api_client::ApiClient;
+use bitcoin::consensus::encode;
+use p2poolv2_lib::config::ApiConfig;
+use p2poolv2_lib::store::Store;
+use serde::Serialize;
+use std::error::Error;
+use std::str::FromStr;
+
+#[derive(Serialize)]
+struct TransactionOutput {
+    txid: String,
+    version: i32,
+    lock_time: String,
+    inputs: Vec<InputOutput>,
+    outputs: Vec<OutputOutput>,
+}
+
+#[derive(Serialize)]
+struct InputOutput {
+    previous_output: String,
+    script_sig: String,
+    sequence: u32,
+}
+
+#[derive(Serialize)]
+struct OutputOutput {
+    value: u64,
+    script_pubkey: String,
+}
+
+#[derive(Serialize)]
+struct RawTransactionOutput {
+    txid: String,
+    hex: String,
+}
+
+/// Execute a transactions subcommand via API.
+pub async fn execute_api(
+    api_config: &ApiConfig,
+    command: &TransactionsCommands,
+) -> Result<(), Box<dyn Error>> {
+    match command {
+        TransactionsCommands::Get { txid, raw } => {
+            let api_client = ApiClient::new(api_config);
+            let path = if *raw {
+                format!("/transaction?txid={txid}&raw=true")
+            } else {
+                format!("/transaction?txid={txid}")
+            };
+            let response: serde_json::Value = api_client.get_json(&path).await?;
+            println!("{}", serde_json::to_string_pretty(&response)?);
+            Ok(())
+        }
+    }
+}
+
+/// Execute a transactions subcommand via direct DB access.
+pub fn execute_db(store: &Store, command: &TransactionsCommands) -> Result<(), Box<dyn Error>> {
+    match command {
+        TransactionsCommands::Get { txid, raw } => {
+            let txid =
+                bitcoin::Txid::from_str(txid).map_err(|error| format!("Invalid txid: {error}"))?;
+            let tx = store
+                .get_tx(&txid)
+                .map_err(|error| format!("Transaction not found: {error}"))?;
+
+            if *raw {
+                let raw_bytes = encode::serialize(&tx);
+                let output = RawTransactionOutput {
+                    txid: txid.to_string(),
+                    hex: hex::encode(raw_bytes),
+                };
+                println!("{}", serde_json::to_string_pretty(&output)?);
+            } else {
+                let inputs: Vec<InputOutput> = tx
+                    .input
+                    .iter()
+                    .map(|input| InputOutput {
+                        previous_output: format!(
+                            "{}:{}",
+                            input.previous_output.txid, input.previous_output.vout
+                        ),
+                        script_sig: input.script_sig.to_hex_string(),
+                        sequence: input.sequence.0,
+                    })
+                    .collect();
+
+                let outputs: Vec<OutputOutput> = tx
+                    .output
+                    .iter()
+                    .map(|output| OutputOutput {
+                        value: output.value.to_sat(),
+                        script_pubkey: output.script_pubkey.to_hex_string(),
+                    })
+                    .collect();
+
+                let output = TransactionOutput {
+                    txid: txid.to_string(),
+                    version: tx.version.0,
+                    lock_time: format!("{}", tx.lock_time),
+                    inputs,
+                    outputs,
+                };
+                println!("{}", serde_json::to_string_pretty(&output)?);
+            }
+            Ok(())
+        }
+    }
+}

--- a/p2poolv2_config/src/lib.rs
+++ b/p2poolv2_config/src/lib.rs
@@ -262,6 +262,10 @@ pub struct NetworkConfig {
     pub max_transaction_per_second: u32,
     pub max_requests_per_second: u64,
     pub dial_timeout_secs: u64,
+    /// IP addresses to block from connecting. Connections from these IPs
+    /// are immediately disconnected.
+    #[serde(default)]
+    pub blocked_ips: Vec<String>,
 }
 
 impl Default for NetworkConfig {
@@ -281,6 +285,7 @@ impl Default for NetworkConfig {
             max_transaction_per_second: 100,
             max_requests_per_second: 100,
             dial_timeout_secs: 30,
+            blocked_ips: vec![],
         }
     }
 }

--- a/p2poolv2_lib/src/command/mod.rs
+++ b/p2poolv2_lib/src/command/mod.rs
@@ -15,8 +15,10 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::accounting::payout::simple_pplns::SimplePplnsShare;
+use crate::node::connection_tracker::PeerInfoResponse;
 use crate::node::messages::Message;
 use std::error::Error;
+use std::net::IpAddr;
 use tokio::sync::oneshot;
 
 /// Struct for queruying the PPLNS shares from the node
@@ -49,4 +51,12 @@ pub enum Command {
     Shutdown(oneshot::Sender<()>),
     /// Get PPLNS shares from the node with optional filtering
     GetPplnsShares(GetPplnsShareQuery, oneshot::Sender<Vec<SimplePplnsShare>>),
+    /// Get enriched info for all connected peers
+    GetPeerInfos(oneshot::Sender<Vec<PeerInfoResponse>>),
+    /// Add an IP to the runtime blocklist
+    BlockIp(IpAddr, oneshot::Sender<()>),
+    /// Remove an IP from the runtime blocklist
+    UnblockIp(IpAddr, oneshot::Sender<()>),
+    /// List all blocked IPs
+    GetBlockedIps(oneshot::Sender<Vec<IpAddr>>),
 }

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -133,6 +133,42 @@ impl NodeHandle {
             .await;
         rx.await.unwrap_or_default()
     }
+
+    /// Get enriched info for all connected peers.
+    pub async fn get_peer_infos(
+        &self,
+    ) -> Result<Vec<crate::node::connection_tracker::PeerInfoResponse>, Box<dyn Error + Send + Sync>>
+    {
+        let (tx, rx) = oneshot::channel();
+        self.command_tx.send(Command::GetPeerInfos(tx)).await?;
+        Ok(rx.await?)
+    }
+
+    /// Add an IP to the runtime blocklist.
+    pub async fn block_ip(&self, ip: std::net::IpAddr) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let (tx, rx) = oneshot::channel();
+        self.command_tx.send(Command::BlockIp(ip, tx)).await?;
+        Ok(rx.await?)
+    }
+
+    /// Remove an IP from the runtime blocklist.
+    pub async fn unblock_ip(
+        &self,
+        ip: std::net::IpAddr,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let (tx, rx) = oneshot::channel();
+        self.command_tx.send(Command::UnblockIp(ip, tx)).await?;
+        Ok(rx.await?)
+    }
+
+    /// List all blocked IPs.
+    pub async fn get_blocked_ips(
+        &self,
+    ) -> Result<Vec<std::net::IpAddr>, Box<dyn Error + Send + Sync>> {
+        let (tx, rx) = oneshot::channel();
+        self.command_tx.send(Command::GetBlockedIps(tx)).await?;
+        Ok(rx.await?)
+    }
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -155,6 +191,18 @@ impl NodeHandle {
                     }
                     Command::SendToPeer(_, _, reply) => {
                         let _ = reply.send(Ok(()));
+                    }
+                    Command::GetPeerInfos(reply) => {
+                        let _ = reply.send(Vec::new());
+                    }
+                    Command::BlockIp(_, reply) => {
+                        let _ = reply.send(());
+                    }
+                    Command::UnblockIp(_, reply) => {
+                        let _ = reply.send(());
+                    }
+                    Command::GetBlockedIps(reply) => {
+                        let _ = reply.send(Vec::new());
                     }
                 }
             }
@@ -191,6 +239,18 @@ impl NodeHandle {
                     }
                     Command::SendToPeer(_, _, reply) => {
                         let _ = reply.send(Ok(()));
+                    }
+                    Command::GetPeerInfos(reply) => {
+                        let _ = reply.send(Vec::new());
+                    }
+                    Command::BlockIp(_, reply) => {
+                        let _ = reply.send(());
+                    }
+                    Command::UnblockIp(_, reply) => {
+                        let _ = reply.send(());
+                    }
+                    Command::GetBlockedIps(reply) => {
+                        let _ = reply.send(Vec::new());
                     }
                 }
             }
@@ -475,6 +535,28 @@ impl NodeActor {
                             let result = self.node.handle_get_pplns_shares(query);
                             if tx.send(result).is_err() {
                                 error!("Failed to send GetPplnsShares response - receiver dropped");
+                            }
+                        },
+                        Some(Command::GetPeerInfos(tx)) => {
+                            let infos = self.node.connection_tracker.get_peer_infos();
+                            if tx.send(infos).is_err() {
+                                error!("Failed to send GetPeerInfos response - receiver dropped");
+                            }
+                        },
+                        Some(Command::BlockIp(ip, tx)) => {
+                            info!("Blocking IP {ip} via runtime command");
+                            self.node.connection_tracker.block_ip(ip);
+                            let _ = tx.send(());
+                        },
+                        Some(Command::UnblockIp(ip, tx)) => {
+                            info!("Unblocking IP {ip} via runtime command");
+                            self.node.connection_tracker.unblock_ip(ip);
+                            let _ = tx.send(());
+                        },
+                        Some(Command::GetBlockedIps(tx)) => {
+                            let ips = self.node.connection_tracker.get_blocked_ips();
+                            if tx.send(ips).is_err() {
+                                error!("Failed to send GetBlockedIps response - receiver dropped");
                             }
                         },
                         None => {

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -379,7 +379,6 @@ impl NodeActor {
             chain_store_handle.clone(),
             organise_tx.clone(),
             node.swarm_tx.clone(),
-            pplns_window,
             difficulty_multiplier,
             pool_signature,
             pool_difficulty.clone(),

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -215,6 +215,8 @@ impl NodeHandle {
     /// Returns the handle and the string representations of the generated peer IDs
     /// so callers can assert on expected values without depending on libp2p directly.
     pub fn new_for_test_with_peer_count(count: usize) -> (Self, Vec<String>) {
+        use crate::node::connection_tracker::{ConnectionDirection, PeerInfoResponse};
+
         let peer_ids: Vec<libp2p::PeerId> = (0..count)
             .map(|_| {
                 libp2p::identity::Keypair::generate_ed25519()
@@ -223,6 +225,16 @@ impl NodeHandle {
             })
             .collect();
         let peer_id_strings: Vec<String> = peer_ids.iter().map(|id| id.to_string()).collect();
+        let peer_infos: Vec<PeerInfoResponse> = peer_ids
+            .iter()
+            .map(|peer_id| PeerInfoResponse {
+                peer_id: peer_id.to_string(),
+                ip: Some("127.0.0.1".to_string()),
+                address: "/ip4/127.0.0.1/tcp/46884".to_string(),
+                direction: ConnectionDirection::Outbound,
+                connected_secs: 0,
+            })
+            .collect();
         let (command_tx, mut command_rx) = mpsc::channel::<Command>(32);
         tokio::spawn(async move {
             while let Some(command) = command_rx.recv().await {
@@ -241,7 +253,7 @@ impl NodeHandle {
                         let _ = reply.send(Ok(()));
                     }
                     Command::GetPeerInfos(reply) => {
-                        let _ = reply.send(Vec::new());
+                        let _ = reply.send(peer_infos.clone());
                     }
                     Command::BlockIp(_, reply) => {
                         let _ = reply.send(());

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -27,7 +27,6 @@ use crate::monitoring_events::MonitoringEventSender;
 use crate::node::Node;
 use crate::node::SwarmSend;
 use crate::node::emission_worker::EmissionWorker;
-#[cfg(test)]
 use crate::node::messages::Message;
 use crate::node::organise_worker::{OrganiseError, OrganiseSender};
 use crate::node::organise_worker::{OrganiseWorker, create_organise_channel};
@@ -446,6 +445,9 @@ impl NodeActor {
                 buf = self.node.swarm_rx.recv() => {
                     match buf {
                         Some(SwarmSend::Request(peer_id, msg)) => {
+                            if matches!(msg, Message::GetShareHeaders(_, _)) {
+                                sync_retry_interval.reset();
+                            }
                             let msg_type = msg.message_type();
                             let request_id = self
                                 .node

--- a/p2poolv2_lib/src/node/connection_tracker.rs
+++ b/p2poolv2_lib/src/node/connection_tracker.rs
@@ -137,6 +137,21 @@ impl ConnectionTracker {
         self.connected_peers.remove(peer_id);
     }
 
+    /// Add an IP to the blocklist.
+    pub(crate) fn block_ip(&mut self, ip: IpAddr) {
+        self.blocked_ips.insert(ip);
+    }
+
+    /// Remove an IP from the blocklist.
+    pub(crate) fn unblock_ip(&mut self, ip: IpAddr) {
+        self.blocked_ips.remove(&ip);
+    }
+
+    /// Return all blocked IPs.
+    pub(crate) fn get_blocked_ips(&self) -> Vec<IpAddr> {
+        self.blocked_ips.iter().copied().collect()
+    }
+
     /// Build a list of connected peer info responses.
     pub(crate) fn get_peer_infos(&self) -> Vec<PeerInfoResponse> {
         let now = Instant::now();

--- a/p2poolv2_lib/src/node/connection_tracker.rs
+++ b/p2poolv2_lib/src/node/connection_tracker.rs
@@ -97,9 +97,6 @@ impl ConnectionTracker {
     ) -> ConnectionAction {
         let (address, direction) = match endpoint {
             ConnectedPoint::Dialer { address, .. } => {
-                if !self.connected_dial_addresses.contains(address) {
-                    self.connected_dial_addresses.push(address.clone());
-                }
                 (address.clone(), ConnectionDirection::Outbound)
             }
             ConnectedPoint::Listener { send_back_addr, .. } => {
@@ -116,6 +113,12 @@ impl ConnectionTracker {
                     peer_id, peer_ip
                 );
                 return ConnectionAction::Block;
+            }
+        }
+
+        if let ConnectedPoint::Dialer { address, .. } = endpoint {
+            if !self.connected_dial_addresses.contains(address) {
+                self.connected_dial_addresses.push(address.clone());
             }
         }
 
@@ -331,6 +334,25 @@ mod tests {
         assert_eq!(
             extract_ip_from_multiaddr(&addr),
             Some("::1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_blocked_outbound_does_not_leave_stale_dial_address() {
+        let blocked: HashSet<IpAddr> = ["1.2.3.4"]
+            .iter()
+            .filter_map(|ip| ip.parse().ok())
+            .collect();
+        let mut tracker = ConnectionTracker::new(blocked);
+        let peer_id = PeerId::random();
+        let endpoint = make_dialer_endpoint("/ip4/1.2.3.4/tcp/46884");
+
+        let action = tracker.handle_established(peer_id, &endpoint);
+        assert!(matches!(action, ConnectionAction::Block));
+        assert_eq!(
+            tracker.connected_dial_addresses.len(),
+            0,
+            "blocked outbound should not leave a stale dial address"
         );
     }
 

--- a/p2poolv2_lib/src/node/connection_tracker.rs
+++ b/p2poolv2_lib/src/node/connection_tracker.rs
@@ -1,0 +1,338 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+use libp2p::core::ConnectedPoint;
+use libp2p::{Multiaddr, PeerId};
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+use std::net::IpAddr;
+use std::time::Instant;
+use tracing::warn;
+
+/// Direction of a peer connection.
+#[derive(Debug, Clone, Serialize)]
+pub enum ConnectionDirection {
+    Inbound,
+    Outbound,
+}
+
+/// Metadata about a connected peer.
+#[derive(Debug, Clone)]
+pub struct PeerInfo {
+    pub address: Multiaddr,
+    pub ip: Option<IpAddr>,
+    pub connected_at: Instant,
+    pub direction: ConnectionDirection,
+}
+
+/// Serializable peer info returned by the API.
+#[derive(Debug, Clone, Serialize)]
+pub struct PeerInfoResponse {
+    pub peer_id: String,
+    pub ip: Option<String>,
+    pub address: String,
+    pub direction: ConnectionDirection,
+    pub connected_secs: u64,
+}
+
+/// Result of processing a new connection.
+pub(crate) enum ConnectionAction {
+    /// Connection accepted, proceed with handshake.
+    Accept(PeerInfo),
+    /// Connection blocked, disconnect the peer.
+    Block,
+}
+
+/// Extract the IP address from a Multiaddr.
+fn extract_ip_from_multiaddr(address: &Multiaddr) -> Option<IpAddr> {
+    for protocol in address.iter() {
+        match protocol {
+            libp2p::multiaddr::Protocol::Ip4(ip) => return Some(IpAddr::V4(ip)),
+            libp2p::multiaddr::Protocol::Ip6(ip) => return Some(IpAddr::V6(ip)),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Tracks connected peers, their metadata, and the IP blocklist.
+pub(crate) struct ConnectionTracker {
+    /// Metadata for currently connected peers
+    connected_peers: HashMap<PeerId, PeerInfo>,
+    /// Tracks Multiaddrs of currently connected outbound peers for reconnection logic
+    pub(crate) connected_dial_addresses: Vec<Multiaddr>,
+    /// IP addresses blocked from connecting
+    blocked_ips: HashSet<IpAddr>,
+}
+
+impl ConnectionTracker {
+    pub(crate) fn new(blocked_ips: HashSet<IpAddr>) -> Self {
+        Self {
+            connected_peers: HashMap::new(),
+            connected_dial_addresses: Vec::new(),
+            blocked_ips,
+        }
+    }
+
+    /// Process a new connection. Returns Block if the IP is blocked,
+    /// otherwise returns Accept with the peer info and records the
+    /// connection in the tracker.
+    pub(crate) fn handle_established(
+        &mut self,
+        peer_id: PeerId,
+        endpoint: &ConnectedPoint,
+    ) -> ConnectionAction {
+        let (address, direction) = match endpoint {
+            ConnectedPoint::Dialer { address, .. } => {
+                if !self.connected_dial_addresses.contains(address) {
+                    self.connected_dial_addresses.push(address.clone());
+                }
+                (address.clone(), ConnectionDirection::Outbound)
+            }
+            ConnectedPoint::Listener { send_back_addr, .. } => {
+                (send_back_addr.clone(), ConnectionDirection::Inbound)
+            }
+        };
+
+        let ip = extract_ip_from_multiaddr(&address);
+
+        if let Some(peer_ip) = ip {
+            if self.blocked_ips.contains(&peer_ip) {
+                warn!(
+                    "Blocking connection from {} (IP {}), disconnecting",
+                    peer_id, peer_ip
+                );
+                return ConnectionAction::Block;
+            }
+        }
+
+        let peer_info = PeerInfo {
+            address,
+            ip,
+            connected_at: Instant::now(),
+            direction,
+        };
+        self.connected_peers.insert(peer_id, peer_info.clone());
+        ConnectionAction::Accept(peer_info)
+    }
+
+    /// Remove a peer from the tracker when the connection closes.
+    pub(crate) fn handle_closed(&mut self, peer_id: &PeerId, endpoint: &ConnectedPoint) {
+        if let ConnectedPoint::Dialer { address, .. } = endpoint {
+            self.connected_dial_addresses.retain(|addr| addr != address);
+        }
+        self.connected_peers.remove(peer_id);
+    }
+
+    /// Build a list of connected peer info responses.
+    pub(crate) fn get_peer_infos(&self) -> Vec<PeerInfoResponse> {
+        let now = Instant::now();
+        self.connected_peers
+            .iter()
+            .map(|(peer_id, info)| PeerInfoResponse {
+                peer_id: peer_id.to_string(),
+                ip: info.ip.map(|ip| ip.to_string()),
+                address: info.address.to_string(),
+                direction: info.direction.clone(),
+                connected_secs: now.duration_since(info.connected_at).as_secs(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p::core::{ConnectedPoint, Endpoint};
+
+    fn make_dialer_endpoint(address: &str) -> ConnectedPoint {
+        let multiaddr: Multiaddr = address.parse().unwrap();
+        ConnectedPoint::Dialer {
+            address: multiaddr,
+            role_override: Endpoint::Dialer,
+        }
+    }
+
+    fn make_listener_endpoint(send_back: &str) -> ConnectedPoint {
+        let send_back_addr: Multiaddr = send_back.parse().unwrap();
+        let local_addr: Multiaddr = "/ip4/0.0.0.0/tcp/46884".parse().unwrap();
+        ConnectedPoint::Listener {
+            local_addr,
+            send_back_addr,
+        }
+    }
+
+    #[test]
+    fn test_accept_outbound_connection() {
+        let mut tracker = ConnectionTracker::new(HashSet::new());
+        let peer_id = PeerId::random();
+        let endpoint = make_dialer_endpoint("/ip4/1.2.3.4/tcp/46884");
+
+        let action = tracker.handle_established(peer_id, &endpoint);
+        assert!(matches!(action, ConnectionAction::Accept(_)));
+        assert_eq!(tracker.connected_peers.len(), 1);
+        assert_eq!(tracker.connected_dial_addresses.len(), 1);
+
+        let info = &tracker.connected_peers[&peer_id];
+        assert_eq!(info.ip, Some("1.2.3.4".parse().unwrap()));
+        assert!(matches!(info.direction, ConnectionDirection::Outbound));
+    }
+
+    #[test]
+    fn test_accept_inbound_connection() {
+        let mut tracker = ConnectionTracker::new(HashSet::new());
+        let peer_id = PeerId::random();
+        let endpoint = make_listener_endpoint("/ip4/5.6.7.8/tcp/12345");
+
+        let action = tracker.handle_established(peer_id, &endpoint);
+        assert!(matches!(action, ConnectionAction::Accept(_)));
+        assert_eq!(tracker.connected_peers.len(), 1);
+        assert_eq!(
+            tracker.connected_dial_addresses.len(),
+            0,
+            "inbound connections should not be added to dial addresses"
+        );
+
+        let info = &tracker.connected_peers[&peer_id];
+        assert_eq!(info.ip, Some("5.6.7.8".parse().unwrap()));
+        assert!(matches!(info.direction, ConnectionDirection::Inbound));
+    }
+
+    #[test]
+    fn test_block_connection_from_blocked_ip() {
+        let blocked: HashSet<IpAddr> = ["1.2.3.4"]
+            .iter()
+            .filter_map(|ip| ip.parse().ok())
+            .collect();
+        let mut tracker = ConnectionTracker::new(blocked);
+        let peer_id = PeerId::random();
+        let endpoint = make_dialer_endpoint("/ip4/1.2.3.4/tcp/46884");
+
+        let action = tracker.handle_established(peer_id, &endpoint);
+        assert!(matches!(action, ConnectionAction::Block));
+        assert_eq!(
+            tracker.connected_peers.len(),
+            0,
+            "blocked peer should not be tracked"
+        );
+    }
+
+    #[test]
+    fn test_allow_connection_from_non_blocked_ip() {
+        let blocked: HashSet<IpAddr> = ["1.2.3.4"]
+            .iter()
+            .filter_map(|ip| ip.parse().ok())
+            .collect();
+        let mut tracker = ConnectionTracker::new(blocked);
+        let peer_id = PeerId::random();
+        let endpoint = make_dialer_endpoint("/ip4/5.6.7.8/tcp/46884");
+
+        let action = tracker.handle_established(peer_id, &endpoint);
+        assert!(matches!(action, ConnectionAction::Accept(_)));
+        assert_eq!(tracker.connected_peers.len(), 1);
+    }
+
+    #[test]
+    fn test_handle_closed_removes_peer() {
+        let mut tracker = ConnectionTracker::new(HashSet::new());
+        let peer_id = PeerId::random();
+        let endpoint = make_dialer_endpoint("/ip4/1.2.3.4/tcp/46884");
+
+        tracker.handle_established(peer_id, &endpoint);
+        assert_eq!(tracker.connected_peers.len(), 1);
+        assert_eq!(tracker.connected_dial_addresses.len(), 1);
+
+        tracker.handle_closed(&peer_id, &endpoint);
+        assert_eq!(tracker.connected_peers.len(), 0);
+        assert_eq!(tracker.connected_dial_addresses.len(), 0);
+    }
+
+    #[test]
+    fn test_handle_closed_inbound_preserves_dial_addresses() {
+        let mut tracker = ConnectionTracker::new(HashSet::new());
+
+        let outbound_peer = PeerId::random();
+        let outbound_endpoint = make_dialer_endpoint("/ip4/1.2.3.4/tcp/46884");
+        tracker.handle_established(outbound_peer, &outbound_endpoint);
+
+        let inbound_peer = PeerId::random();
+        let inbound_endpoint = make_listener_endpoint("/ip4/5.6.7.8/tcp/12345");
+        tracker.handle_established(inbound_peer, &inbound_endpoint);
+
+        assert_eq!(tracker.connected_peers.len(), 2);
+        assert_eq!(tracker.connected_dial_addresses.len(), 1);
+
+        tracker.handle_closed(&inbound_peer, &inbound_endpoint);
+        assert_eq!(tracker.connected_peers.len(), 1);
+        assert_eq!(
+            tracker.connected_dial_addresses.len(),
+            1,
+            "closing inbound should not remove outbound dial address"
+        );
+    }
+
+    #[test]
+    fn test_get_peer_infos_returns_connected_peers() {
+        let mut tracker = ConnectionTracker::new(HashSet::new());
+
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+        tracker.handle_established(peer_a, &make_dialer_endpoint("/ip4/1.2.3.4/tcp/46884"));
+        tracker.handle_established(peer_b, &make_listener_endpoint("/ip4/5.6.7.8/tcp/12345"));
+
+        let infos = tracker.get_peer_infos();
+        assert_eq!(infos.len(), 2);
+
+        let ips: Vec<Option<String>> = infos.iter().map(|info| info.ip.clone()).collect();
+        assert!(ips.contains(&Some("1.2.3.4".to_string())));
+        assert!(ips.contains(&Some("5.6.7.8".to_string())));
+    }
+
+    #[test]
+    fn test_extract_ip_from_multiaddr_ipv4() {
+        let addr: Multiaddr = "/ip4/192.168.1.1/tcp/8080".parse().unwrap();
+        assert_eq!(
+            extract_ip_from_multiaddr(&addr),
+            Some("192.168.1.1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_extract_ip_from_multiaddr_ipv6() {
+        let addr: Multiaddr = "/ip6/::1/tcp/8080".parse().unwrap();
+        assert_eq!(
+            extract_ip_from_multiaddr(&addr),
+            Some("::1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_duplicate_outbound_not_added_twice() {
+        let mut tracker = ConnectionTracker::new(HashSet::new());
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+        let endpoint = make_dialer_endpoint("/ip4/1.2.3.4/tcp/46884");
+
+        tracker.handle_established(peer_a, &endpoint);
+        tracker.handle_established(peer_b, &endpoint);
+
+        assert_eq!(
+            tracker.connected_dial_addresses.len(),
+            1,
+            "same address should not be added twice"
+        );
+    }
+}

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -15,6 +15,7 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 pub mod behaviour;
+pub(crate) mod connection_tracker;
 pub mod emission_worker;
 pub mod organise_worker;
 pub mod peer_reconnector;
@@ -52,7 +53,9 @@ use libp2p::{
     kad::{Event as KademliaEvent, QueryResult},
     swarm::SwarmEvent,
 };
+use std::collections::HashSet;
 use std::error::Error;
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -90,6 +93,8 @@ pub enum SwarmSend<C> {
     Disconnect(PeerId),
 }
 
+use connection_tracker::{ConnectionAction, ConnectionTracker};
+
 /// Node is the main struct that represents the node
 struct Node {
     swarm: Swarm<P2PoolBehaviour>,
@@ -100,8 +105,7 @@ struct Node {
     config: Config,
     monitoring_event_sender: MonitoringEventSender,
     peer_reconnector: peer_reconnector::PeerReconnector,
-    /// Tracks Multiaddrs of currently connected outbound peers for reconnection logic
-    connected_dial_addresses: Vec<Multiaddr>,
+    connection_tracker: ConnectionTracker,
 }
 
 impl Node {
@@ -212,6 +216,24 @@ impl Node {
 
         let peer_reconnector = peer_reconnector::PeerReconnector::new(&config.network.dial_peers);
 
+        let blocked_ips: HashSet<IpAddr> = config
+            .network
+            .blocked_ips
+            .iter()
+            .filter_map(|ip_str| {
+                ip_str
+                    .parse::<IpAddr>()
+                    .map_err(|error| {
+                        warn!("Invalid blocked IP '{}' in config: {}", ip_str, error);
+                    })
+                    .ok()
+            })
+            .collect();
+
+        if !blocked_ips.is_empty() {
+            info!("Loaded {} blocked IPs from config", blocked_ips.len());
+        }
+
         Ok(Self {
             swarm,
             swarm_tx,
@@ -221,7 +243,7 @@ impl Node {
             config,
             monitoring_event_sender,
             peer_reconnector,
-            connected_dial_addresses: Vec::new(),
+            connection_tracker: ConnectionTracker::new(blocked_ips),
         })
     }
 
@@ -253,7 +275,7 @@ impl Node {
     fn attempt_reconnections(&mut self) {
         let addresses = self
             .peer_reconnector
-            .addresses_to_reconnect(&self.connected_dial_addresses);
+            .addresses_to_reconnect(&self.connection_tracker.connected_dial_addresses);
         for address in addresses {
             match self.swarm.dial(address.clone()) {
                 Ok(_) => {
@@ -306,31 +328,19 @@ impl Node {
             SwarmEvent::ConnectionEstablished {
                 peer_id, endpoint, ..
             } => {
-                match &endpoint {
-                    libp2p::core::ConnectedPoint::Dialer { address, .. } => {
-                        self.peer_reconnector.record_dial_success(address);
-                        if !self.connected_dial_addresses.contains(address) {
-                            self.connected_dial_addresses.push(address.clone());
-                        }
-                        if let Err(error) = send_handshake(
-                            peer_id,
-                            self.chain_store_handle.clone(),
-                            self.swarm_tx.clone(),
-                        )
-                        .await
-                        {
-                            error!(
-                                "Failed to send handshake to outbound peer {}: {}",
-                                peer_id, error
-                            );
-                        } else {
-                            debug!(
-                                "Outbound connection established, handshake sent to peer: {}",
-                                peer_id
-                            );
-                        }
+                if let libp2p::core::ConnectedPoint::Dialer { ref address, .. } = endpoint {
+                    self.peer_reconnector.record_dial_success(address);
+                }
+
+                match self
+                    .connection_tracker
+                    .handle_established(peer_id, &endpoint)
+                {
+                    ConnectionAction::Block => {
+                        let _ = self.swarm.disconnect_peer_id(peer_id);
+                        return Ok(());
                     }
-                    libp2p::core::ConnectedPoint::Listener { .. } => {
+                    ConnectionAction::Accept(ref peer_info) => {
                         if let Err(error) = send_handshake(
                             peer_id,
                             self.chain_store_handle.clone(),
@@ -338,18 +348,16 @@ impl Node {
                         )
                         .await
                         {
-                            error!(
-                                "Failed to send handshake to inbound peer {}: {}",
-                                peer_id, error
-                            );
+                            error!("Failed to send handshake to peer {}: {}", peer_id, error);
                         } else {
                             debug!(
-                                "Inbound connection established, handshake sent to peer: {}",
-                                peer_id
+                                "{:?} connection established, handshake sent to peer: {}",
+                                peer_info.direction, peer_id
                             );
                         }
                     }
                 }
+
                 self.request_response_handler.add_peer(peer_id);
                 let _ = self
                     .monitoring_event_sender
@@ -363,9 +371,7 @@ impl Node {
                 peer_id, endpoint, ..
             } => {
                 info!("Disconnected from peer: {peer_id}");
-                if let libp2p::core::ConnectedPoint::Dialer { ref address, .. } = endpoint {
-                    self.connected_dial_addresses.retain(|addr| addr != address);
-                }
+                self.connection_tracker.handle_closed(&peer_id, &endpoint);
                 self.swarm.behaviour_mut().remove_peer(&peer_id);
                 self.request_response_handler.remove_peer(&peer_id).await;
                 let _ = self
@@ -546,6 +552,7 @@ mod tests {
             max_transaction_per_second: 10,
             max_requests_per_second: 1,
             dial_timeout_secs: 2,
+            blocked_ips: vec![],
         };
         network_config.dial_peers = vec![unreachable_peer];
         network_config.dial_timeout_secs = 2;

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -15,7 +15,7 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 pub mod behaviour;
-pub(crate) mod connection_tracker;
+pub mod connection_tracker;
 pub mod emission_worker;
 pub mod organise_worker;
 pub mod peer_reconnector;

--- a/p2poolv2_lib/src/node/organise_worker.rs
+++ b/p2poolv2_lib/src/node/organise_worker.rs
@@ -202,10 +202,11 @@ impl OrganiseWorker {
         let blockhash = share_block.block_hash();
         debug!("Organising block: {blockhash:?}");
 
-        if let Err(validation_error) = self
-            .share_validator
-            .validate_with_chain_context(share_block, &self.chain_store_handle)
-        {
+        if let Err(validation_error) = self.share_validator.validate_with_chain_context(
+            share_block,
+            &self.chain_store_handle,
+            Arc::clone(&self.pplns_window),
+        ) {
             error!("Chain-context validation failed for {blockhash}: {validation_error}");
             return Ok(None);
         }
@@ -424,7 +425,7 @@ mod tests {
         let mut mock_validator = MockDefaultShareValidator::new();
         mock_validator
             .expect_validate_with_chain_context()
-            .returning(|_, _| Ok(()));
+            .returning(|_, _, _| Ok(()));
         Arc::new(mock_validator)
     }
 
@@ -541,7 +542,7 @@ mod tests {
         let mut mock_validator = MockDefaultShareValidator::new();
         mock_validator
             .expect_validate_with_chain_context()
-            .returning(|_, _| Err(ValidationError::new("rejected for test")));
+            .returning(|_, _, _| Err(ValidationError::new("rejected for test")));
         let share_validator: Arc<dyn ShareValidator + Send + Sync> = Arc::new(mock_validator);
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();

--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -719,6 +719,9 @@ mod tests {
             .expect_organise_header()
             .returning(|_| Ok(None));
         chain_store_handle
+            .expect_find_fork_point_height()
+            .returning(|_| Ok(Some(0)));
+        chain_store_handle
             .expect_get_candidate_blocks_missing_data()
             .returning(|_| Ok(Vec::new()));
         setup_header_chain_validation_mocks(&mut chain_store_handle);

--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -42,7 +42,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{debug, error, warn};
 
-const MAX_HEADERS_IN_RESPONSE: usize = 2000;
+const MAX_HEADERS_IN_RESPONSE: usize = 1500;
 
 /// The Tower service that processes inbound P2P requests.
 pub async fn handle_request<C: Send + Sync, T: TimeProvider + Send + Sync>(

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -33,6 +33,7 @@ use crate::shares::share_block::{
 };
 use crate::shares::validation::ShareValidator;
 use crate::store::block_tx_metadata::BlockMetadata;
+use crate::store::dag_store::MAX_BLOCKS_PER_HEIGHT;
 use crate::store::writer::StoreError;
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, CompactTarget, Target, Work};
@@ -71,6 +72,10 @@ enum HeaderSyncError {
         expected: u32,
     },
     InsufficientWork,
+    DenseHeight {
+        height: u32,
+        count: usize,
+    },
     Other(Box<dyn Error + Send + Sync>),
 }
 
@@ -142,6 +147,12 @@ impl fmt::Display for HeaderSyncError {
             HeaderSyncError::InsufficientWork => {
                 write!(formatter, "Cumulative chain work below minimum")
             }
+            HeaderSyncError::DenseHeight { height, count } => {
+                write!(
+                    formatter,
+                    "Height {height} has {count} blocks, exceeds MAX_BLOCKS_PER_HEIGHT"
+                )
+            }
             HeaderSyncError::Other(error) => write!(formatter, "{error}"),
         }
     }
@@ -192,6 +203,17 @@ pub async fn handle_share_headers<C: Send + Sync>(
     share_validator: &(dyn ShareValidator + Send + Sync),
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     debug!("Received {} ShareHeaders", share_headers.len());
+    if !share_headers.is_empty() {
+        let first = &share_headers[0];
+        let last = share_headers.last().unwrap();
+        debug!(
+            "ShareHeaders batch: first={} (parent={}), last={} (parent={})",
+            first.block_hash(),
+            first.prev_share_blockhash,
+            last.block_hash(),
+            last.prev_share_blockhash,
+        );
+    }
 
     // No new headers, start fetching any block data for received headers
     if share_headers.is_empty() {
@@ -215,6 +237,10 @@ pub async fn handle_share_headers<C: Send + Sync>(
             );
             send_getheaders(peer_id, chain_store_handle, swarm_tx, depth).await?;
             return Ok(());
+        }
+        if matches!(sync_error, HeaderSyncError::DenseHeight { .. }) {
+            error!("Disconnecting peer {peer_id}: {sync_error}");
+            let _ = swarm_tx.send(SwarmSend::Disconnect(peer_id)).await;
         }
         return Err(sync_error.into());
     }
@@ -334,6 +360,7 @@ fn validate_dag_connectivity_and_difficulty(
     let mut cumulative_work = Work::from_hex("0x00").unwrap();
     let mut time_height_cache: HashMap<BlockHash, (u32, u32)> =
         HashMap::with_capacity(share_headers.len() + 1);
+    let mut blocks_per_height: HashMap<u32, usize> = HashMap::with_capacity(64);
 
     for header in share_headers {
         share_validator.validate_header_minimum_difficulty(header)?;
@@ -361,13 +388,35 @@ fn validate_dag_connectivity_and_difficulty(
             });
         }
 
+        let header_height = parent_height + 1;
+        check_dense_height(&mut blocks_per_height, header_height)?;
+
         let header_hash = header.block_hash();
-        time_height_cache.insert(header_hash, (header.time, parent_height + 1));
+        time_height_cache.insert(header_hash, (header.time, header_height));
         known_hashes.insert(header_hash);
         cumulative_work = cumulative_work + header.get_work();
     }
 
     Ok((known_hashes, cumulative_work))
+}
+
+/// Reject batches where a single height has too many blocks.
+///
+/// In normal operation a height has at most a few blocks (confirmed +
+/// uncles). A dense height indicates a misbehaving or attacking peer.
+fn check_dense_height(
+    blocks_per_height: &mut HashMap<u32, usize>,
+    height: u32,
+) -> Result<(), HeaderSyncError> {
+    let count = blocks_per_height.entry(height).or_insert(0);
+    *count += 1;
+    if *count > MAX_BLOCKS_PER_HEIGHT {
+        return Err(HeaderSyncError::DenseHeight {
+            height,
+            count: *count,
+        });
+    }
+    Ok(())
 }
 
 /// Verify every uncle hash declared by any header in the batch exists
@@ -537,11 +586,13 @@ async fn request_next_headers<C: Send + Sync>(
     share_headers: &[ShareHeader],
     swarm_tx: &mpsc::Sender<SwarmSend<C>>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    debug!("Requesting more share headers");
     let stop_block_hash = BlockHash::all_zeros();
     let last_block_hash = share_headers.last().unwrap().block_hash();
+    debug!(
+        "Requesting more share headers, locator={last_block_hash}, batch_size={}",
+        share_headers.len(),
+    );
     let getheaders_request = Message::GetShareHeaders(vec![last_block_hash], stop_block_hash);
-    debug!("Sending getheaders {getheaders_request}");
     if let Err(send_error) = swarm_tx
         .send(SwarmSend::Request(peer_id, getheaders_request))
         .await

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -40,7 +40,7 @@ use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt;
 use tokio::sync::mpsc;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 /// Depth to go back when retrying getheaders after missing parents/uncles.
 const DEEP_LOCATOR_DEPTH: u32 = 100;
@@ -195,15 +195,8 @@ pub async fn handle_share_headers<C: Send + Sync>(
 
     // No new headers, start fetching any block data for received headers
     if share_headers.is_empty() {
-        return trigger_or_request(
-            peer_id,
-            &share_headers,
-            &chain_store_handle,
-            &swarm_tx,
-            &block_fetcher_handle,
-            None,
-        )
-        .await;
+        return trigger_block_fetch(peer_id, &chain_store_handle, &block_fetcher_handle, None)
+            .await;
     }
 
     // Phase 1: Validate the header chain in memory
@@ -231,23 +224,15 @@ pub async fn handle_share_headers<C: Send + Sync>(
         chain_store_handle.organise_header(header.clone()).await?;
     }
 
-    // The batch is sorted by increasing height, so the first header
-    // is the lowest. Use its height as min_scan_height so
-    // trigger_block_fetch can find fork blocks at or below the
-    // confirmed tip.
     let first_blockhash = share_headers[0].block_hash();
-    let min_organised_height = chain_store_handle
-        .get_block_metadata(&first_blockhash)
-        .ok()
-        .and_then(|metadata| metadata.expected_height);
 
     trigger_or_request(
         peer_id,
         &share_headers,
+        &first_blockhash,
         &chain_store_handle,
         &swarm_tx,
         &block_fetcher_handle,
-        min_organised_height,
     )
     .await
 }
@@ -478,17 +463,26 @@ fn validate_cumulative_work(
 async fn trigger_or_request<C: Send + Sync>(
     peer_id: libp2p::PeerId,
     share_headers: &[ShareHeader],
+    first_blockhash: &BlockHash,
     chain_store_handle: &ChainStoreHandle,
     swarm_tx: &mpsc::Sender<SwarmSend<C>>,
     block_fetcher_handle: &BlockFetcherHandle,
-    min_organised_height: Option<u32>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     if share_headers.len() < MAX_HEADERS_IN_RESPONSE {
+        let scan_start_height = chain_store_handle
+            .find_fork_point_height(first_blockhash)
+            .unwrap_or_else(|error| {
+                warn!(
+                    "Failed to find fork point for {}: {}",
+                    first_blockhash, error
+                );
+                None
+            });
         trigger_block_fetch(
             peer_id,
             chain_store_handle,
             block_fetcher_handle,
-            min_organised_height,
+            scan_start_height,
         )
         .await
     } else {
@@ -499,18 +493,18 @@ async fn trigger_or_request<C: Send + Sync>(
 /// Header sync is complete -- query for candidate blocks missing full
 /// block data and send them to the block fetcher for download.
 ///
-/// When `min_organised_height` is provided, the scan extends down to
+/// When `scan_start_height` is provided, the scan extends down to
 /// that height so fork blocks at or below the confirmed tip are
 /// included in the fetch request.
 async fn trigger_block_fetch(
     peer_id: libp2p::PeerId,
     chain_store_handle: &ChainStoreHandle,
     block_fetcher_handle: &BlockFetcherHandle,
-    min_organised_height: Option<u32>,
+    scan_start_height: Option<u32>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     debug!("Header sync complete, triggering block fetch for missing data");
     let missing_blockhashes =
-        chain_store_handle.get_candidate_blocks_missing_data(min_organised_height)?;
+        chain_store_handle.get_candidate_blocks_missing_data(scan_start_height)?;
     if !missing_blockhashes.is_empty() {
         debug!(
             "Requesting {} blocks from block fetcher",
@@ -641,6 +635,9 @@ mod tests {
             .expect_organise_header()
             .returning(|_| Ok(None));
         chain_store_handle
+            .expect_find_fork_point_height()
+            .returning(|_| Ok(Some(0)));
+        chain_store_handle
             .expect_get_candidate_blocks_missing_data()
             .returning(|_| Ok(Vec::new()));
         setup_chain_validation_mocks(&mut chain_store_handle);
@@ -759,6 +756,9 @@ mod tests {
         chain_store_handle
             .expect_organise_header()
             .returning(|_| Ok(None));
+        chain_store_handle
+            .expect_find_fork_point_height()
+            .returning(|_| Ok(Some(0)));
 
         let missing_hash = bitcoin::BlockHash::all_zeros();
         let expected_hashes = vec![missing_hash];

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -372,6 +372,9 @@ mod tests {
             let mut cloned = ChainStoreHandle::default();
             cloned.expect_organise_header().returning(|_| Ok(None));
             cloned
+                .expect_find_fork_point_height()
+                .returning(|_| Ok(Some(0)));
+            cloned
                 .expect_get_candidate_blocks_missing_data()
                 .returning(|_| Ok(Vec::new()));
             crate::test_utils::setup_header_chain_validation_mocks(&mut cloned);

--- a/p2poolv2_lib/src/node/validation_worker.rs
+++ b/p2poolv2_lib/src/node/validation_worker.rs
@@ -22,11 +22,6 @@
 //! `OrganiseEvent::Block` and `SwarmSend::Inv` events. Runs in a dedicated
 //! tokio task, decoupled from the P2P message handler hot path.
 
-#[cfg(test)]
-#[mockall_double::double]
-use crate::accounting::payout::sharechain_pplns::PplnsWindow;
-#[cfg(not(test))]
-use crate::accounting::payout::sharechain_pplns::PplnsWindow;
 use crate::node::SwarmSend;
 use crate::node::messages::Message;
 use crate::node::organise_worker::{OrganiseEvent, OrganiseSender};
@@ -45,7 +40,7 @@ use crate::utils::cpu::available_cpus;
 use bitcoin::BlockHash;
 use libp2p::request_response::ResponseChannel;
 use std::fmt;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use tokio::sync::{Semaphore, mpsc};
 use tracing::{debug, error, info};
 
@@ -100,7 +95,6 @@ pub struct ValidationWorker {
     organise_tx: OrganiseSender,
     swarm_tx: mpsc::Sender<SwarmSend<ResponseChannel<Message>>>,
     semaphore: Arc<Semaphore>,
-    pplns_window: Arc<RwLock<PplnsWindow>>,
     difficulty_multiplier: u128,
     pool_signature: Vec<u8>,
     pool_difficulty: PoolDifficulty,
@@ -113,7 +107,6 @@ impl ValidationWorker {
         chain_store_handle: ChainStoreHandle,
         organise_tx: OrganiseSender,
         swarm_tx: mpsc::Sender<SwarmSend<ResponseChannel<Message>>>,
-        pplns_window: Arc<RwLock<PplnsWindow>>,
         difficulty_multiplier: u128,
         pool_signature: Vec<u8>,
         pool_difficulty: PoolDifficulty,
@@ -124,7 +117,6 @@ impl ValidationWorker {
             organise_tx,
             swarm_tx,
             semaphore: Arc::new(Semaphore::new(available_cpus())),
-            pplns_window,
             difficulty_multiplier,
             pool_signature,
             pool_difficulty,
@@ -160,7 +152,6 @@ impl ValidationWorker {
                     let organise_tx = self.organise_tx.clone();
                     let swarm_tx = self.swarm_tx.clone();
                     let validator = Arc::clone(&share_validator);
-                    let pplns_window = Arc::clone(&self.pplns_window);
 
                     tokio::spawn(async move {
                         let _permit = permit;
@@ -170,7 +161,6 @@ impl ValidationWorker {
                             chain_store_handle,
                             organise_tx,
                             swarm_tx,
-                            pplns_window,
                         )
                         .await;
                     });
@@ -194,7 +184,6 @@ async fn validate_and_emit(
     chain_store_handle: ChainStoreHandle,
     organise_tx: OrganiseSender,
     swarm_tx: mpsc::Sender<SwarmSend<ResponseChannel<Message>>>,
-    pplns_window: Arc<RwLock<PplnsWindow>>,
 ) {
     let share_block = match chain_store_handle.get_share(&block_hash) {
         Some(share_block) => share_block,
@@ -205,7 +194,7 @@ async fn validate_and_emit(
     };
 
     if let Err(validation_error) =
-        share_validator.validate_share_block(&share_block, &chain_store_handle, pplns_window)
+        share_validator.validate_share_block(&share_block, &chain_store_handle)
     {
         error!("Share block {block_hash} validation failed: {validation_error}");
         return;
@@ -230,7 +219,7 @@ mod tests {
     use crate::node::organise_worker;
     use crate::shares::chain::chain_store_handle::MockChainStoreHandle;
     use crate::test_utils::TestShareBlockBuilder;
-    use std::collections::HashMap;
+
     use std::time::Duration;
 
     #[tokio::test]
@@ -260,16 +249,6 @@ mod tests {
             mock_chain_handle,
             organise_tx,
             swarm_tx,
-            {
-                let mut mock_window = PplnsWindow::default();
-                mock_window
-                    .expect_network()
-                    .return_const(bitcoin::Network::Signet);
-                mock_window
-                    .expect_get_distribution_from_start_hash()
-                    .returning(|_, _, _| Some(HashMap::new()));
-                Arc::new(RwLock::new(mock_window))
-            },
             1,
             b"P2Poolv2".to_vec(),
             PoolDifficulty::default(),
@@ -318,16 +297,6 @@ mod tests {
             mock_chain_handle,
             organise_tx,
             swarm_tx,
-            {
-                let mut mock_window = PplnsWindow::default();
-                mock_window
-                    .expect_network()
-                    .return_const(bitcoin::Network::Signet);
-                mock_window
-                    .expect_get_distribution_from_start_hash()
-                    .returning(|_, _, _| Some(HashMap::new()));
-                Arc::new(RwLock::new(mock_window))
-            },
             1,
             b"P2Poolv2".to_vec(),
             PoolDifficulty::default(),
@@ -352,15 +321,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_validation_worker_skips_missing_block() {
-        let _pplns_new_ctx = PplnsWindow::new_context();
-        _pplns_new_ctx.expect().returning(|_network| {
-            let mut mock = PplnsWindow::default();
-            mock.expect_network().return_const(bitcoin::Network::Signet);
-            mock.expect_get_distribution_from_start_hash()
-                .returning(|_, _, _| Some(HashMap::new()));
-            mock
-        });
-
         let (validation_tx, validation_rx) = create_validation_channel();
         let mut mock_chain_handle = MockChainStoreHandle::new();
 
@@ -380,16 +340,6 @@ mod tests {
             mock_chain_handle,
             organise_tx,
             swarm_tx,
-            {
-                let mut mock_window = PplnsWindow::default();
-                mock_window
-                    .expect_network()
-                    .return_const(bitcoin::Network::Signet);
-                mock_window
-                    .expect_get_distribution_from_start_hash()
-                    .returning(|_, _, _| Some(HashMap::new()));
-                Arc::new(RwLock::new(mock_window))
-            },
             1,
             b"P2Poolv2".to_vec(),
             PoolDifficulty::default(),
@@ -421,15 +371,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_validation_worker_skips_invalid_block() {
-        let _pplns_new_ctx = PplnsWindow::new_context();
-        _pplns_new_ctx.expect().returning(|_network| {
-            let mut mock = PplnsWindow::default();
-            mock.expect_network().return_const(bitcoin::Network::Signet);
-            mock.expect_get_distribution_from_start_hash()
-                .returning(|_, _, _| Some(HashMap::new()));
-            mock
-        });
-
         let (validation_tx, validation_rx) = create_validation_channel();
         let mut mock_chain_handle = MockChainStoreHandle::new();
 
@@ -466,16 +407,6 @@ mod tests {
             mock_chain_handle,
             organise_tx,
             swarm_tx,
-            {
-                let mut mock_window = PplnsWindow::default();
-                mock_window
-                    .expect_network()
-                    .return_const(bitcoin::Network::Signet);
-                mock_window
-                    .expect_get_distribution_from_start_hash()
-                    .returning(|_, _, _| Some(HashMap::new()));
-                Arc::new(RwLock::new(mock_window))
-            },
             1,
             b"P2Poolv2".to_vec(),
             PoolDifficulty::default(),

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -688,8 +688,13 @@ impl ChainStoreHandle {
 
     /// Promote candidates to confirmed.
     /// Returns the confirmed chain height after organising, if changed.
-    pub async fn organise_block(&self) -> Result<Option<u32>, StoreError> {
-        let height = self.store_handle.organise_block().await?;
+    /// When promoted_header is provided, the block can be confirmed
+    /// directly if it extends the confirmed tip.
+    pub async fn organise_block(
+        &self,
+        promoted_header: Option<ShareHeader>,
+    ) -> Result<Option<u32>, StoreError> {
+        let height = self.store_handle.organise_block(promoted_header).await?;
         debug!("Organised block at confirmed height {height:?}");
         Ok(height)
     }
@@ -705,8 +710,8 @@ impl ChainStoreHandle {
     /// the next promote_block call will pick up.
     pub async fn promote_block(&self, header: ShareHeader) -> Result<Option<u32>, StoreError> {
         let blockhash = header.block_hash();
-        self.organise_header(header).await?;
-        let height = self.organise_block().await?;
+        self.organise_header(header.clone()).await?;
+        let height = self.organise_block(Some(header)).await?;
         info!("Promoted block {blockhash} to confirmed height {height:?}");
         Ok(height)
     }
@@ -800,7 +805,7 @@ mockall::mock! {
         pub fn get_btcaddresses_for_user_ids(&self, user_ids: &[u64]) -> Result<Vec<(u64, String)>, StoreError>;
         pub async fn init_or_setup_genesis(&self, genesis_block: ShareBlock) -> Result<(), StoreError>;
         pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;
-        pub async fn organise_block(&self) -> Result<Option<u32>, StoreError>;
+        pub async fn organise_block(&self, promoted_header: Option<ShareHeader>) -> Result<Option<u32>, StoreError>;
         pub async fn promote_block(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;
         pub async fn add_share_block(&self, share: ShareBlock) -> Result<(), StoreError>;
         pub async fn add_share_block_and_organise_header(&self, share: ShareBlock) -> Result<Option<u32>, StoreError>;
@@ -918,7 +923,7 @@ mod tests {
                 .organise_header(share.header.clone())
                 .await
                 .unwrap();
-            chain_handle.organise_block().await.unwrap();
+            chain_handle.organise_block(None).await.unwrap();
             prev_hash = share.block_hash();
             shares.push(share);
         }
@@ -985,7 +990,7 @@ mod tests {
                 .organise_header(share.header.clone())
                 .await
                 .unwrap();
-            chain_handle.organise_block().await.unwrap();
+            chain_handle.organise_block(None).await.unwrap();
             prev_hash = share.block_hash();
             shares.push(share);
         }
@@ -1054,7 +1059,7 @@ mod tests {
                 .organise_header(share.header.clone())
                 .await
                 .unwrap();
-            chain_handle.organise_block().await.unwrap();
+            chain_handle.organise_block(None).await.unwrap();
             prev_hash = share.block_hash();
             shares.push(share);
         }
@@ -1170,7 +1175,7 @@ mod tests {
             .organise_header(share_a.header.clone())
             .await
             .unwrap();
-        chain_handle.organise_block().await.unwrap();
+        chain_handle.organise_block(None).await.unwrap();
 
         let share_b = TestShareBlockBuilder::new()
             .prev_share_blockhash(share_a.block_hash().to_string())
@@ -1182,7 +1187,7 @@ mod tests {
             .organise_header(share_b.header.clone())
             .await
             .unwrap();
-        chain_handle.organise_block().await.unwrap();
+        chain_handle.organise_block(None).await.unwrap();
 
         // Store an uncle at height 1 (same height as share_a) via the
         // underlying Store, which puts it in the BlockHeight CF without

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -528,6 +528,25 @@ impl ChainStoreHandle {
         self.store_handle.get_missing_blockhashes(blockhashes)
     }
 
+    /// Find the height where a block's ancestry meets the confirmed chain.
+    ///
+    /// Walks backwards from `blockhash` following parent links until
+    /// reaching a confirmed block. Returns that confirmed block's height.
+    /// Returns None if the ancestry does not reach the confirmed chain
+    /// (e.g. missing headers).
+    pub fn find_fork_point_height(&self, blockhash: &BlockHash) -> Result<Option<u32>, StoreError> {
+        let store = self.store_handle.store();
+        let branch = store.get_branch_to_chain(blockhash, |hash| store.is_confirmed(hash))?;
+        let Some(branch) = branch else {
+            return Ok(None);
+        };
+        let Some(confirmed_ancestor) = branch.front() else {
+            return Ok(None);
+        };
+        let metadata = store.get_block_metadata(confirmed_ancestor)?;
+        Ok(metadata.expected_height)
+    }
+
     /// Returns blockhashes on the candidate chain that do not yet have
     /// full block data (status is not BlockValid or Confirmed).
     ///
@@ -795,6 +814,7 @@ mockall::mock! {
         pub fn get_share_dag(&self, from_height: u32, to_height: u32) -> Result<ShareDag, StoreError>;
         pub fn get_missing_blockhashes(&self, blockhashes: &[BlockHash]) -> Vec<BlockHash>;
         pub fn get_candidate_blocks_missing_data(&self, min_scan_height: Option<u32>) -> Result<Vec<BlockHash>, StoreError>;
+        pub fn find_fork_point_height(&self, blockhash: &BlockHash) -> Result<Option<u32>, StoreError>;
         pub fn get_depth(&self, blockhash: &BlockHash) -> Option<usize>;
         pub fn get_pplns_shares_filtered(&self, limit: Option<usize>, start_time: Option<u64>, end_time: Option<u64>) -> Vec<SimplePplnsShare>;
         pub fn get_confirmed_at_height(&self, height: u32) -> Result<BlockHash, StoreError>;
@@ -823,6 +843,8 @@ mod tests {
     use crate::test_utils::{
         TestShareBlockBuilder, genesis_for_tests, setup_test_chain_store_handle,
     };
+    use bitcoin::BlockHash;
+    use bitcoin::hashes::Hash;
 
     #[tokio::test]
     async fn test_chain_store_handle_creation() {
@@ -1232,5 +1254,101 @@ mod tests {
         // Heights 2, 1, 0 -- all confirmed
         assert_eq!(locator.len(), 3);
         assert_eq!(locator[1], share_a.block_hash());
+    }
+
+    /// find_fork_point_height walks from a fork block back to the
+    /// confirmed chain and returns the confirmed ancestor's height.
+    ///
+    /// Chain: genesis(h:0) -> A(h:1) -> B(h:2) -> C(h:3)  [confirmed]
+    /// Fork:                  A(h:1) -> D(h:2) -> E(h:3)   [header only]
+    ///
+    /// find_fork_point_height(E) should return height 1 (A is the
+    /// confirmed ancestor where the fork meets the confirmed chain).
+    #[tokio::test]
+    async fn test_find_fork_point_height_returns_confirmed_ancestor_height() {
+        let (chain_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+        let genesis = genesis_for_tests();
+
+        chain_handle
+            .init_or_setup_genesis(genesis.clone())
+            .await
+            .unwrap();
+
+        // Build confirmed chain: genesis -> A -> B -> C
+        let mut prev_hash = genesis.block_hash();
+        let mut confirmed_shares = Vec::with_capacity(3);
+        for index in 0..3 {
+            let share = TestShareBlockBuilder::new()
+                .prev_share_blockhash(prev_hash.to_string())
+                .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
+                .nonce(index)
+                .work(2)
+                .build();
+            chain_handle.add_share_block(share.clone()).await.unwrap();
+            chain_handle
+                .organise_header(share.header.clone())
+                .await
+                .unwrap();
+            chain_handle.organise_block(None).await.unwrap();
+            prev_hash = share.block_hash();
+            confirmed_shares.push(share);
+        }
+
+        // Build fork: A(h:1) -> D(h:2) -> E(h:3), header only
+        let share_a_hash = confirmed_shares[0].block_hash();
+        let fork_d = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share_a_hash.to_string())
+            .nonce(100)
+            .work(1)
+            .build();
+        chain_handle
+            .store_handle()
+            .store()
+            .store_with_valid_metadata(&fork_d);
+
+        let fork_e = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_d.block_hash().to_string())
+            .nonce(101)
+            .work(1)
+            .build();
+        chain_handle
+            .store_handle()
+            .store()
+            .store_with_valid_metadata(&fork_e);
+
+        // Fork point for E should be A's height (1)
+        let fork_height = chain_handle
+            .find_fork_point_height(&fork_e.block_hash())
+            .unwrap();
+        assert_eq!(fork_height, Some(1));
+
+        // Fork point for D should also be A's height (1)
+        let fork_height_d = chain_handle
+            .find_fork_point_height(&fork_d.block_hash())
+            .unwrap();
+        assert_eq!(fork_height_d, Some(1));
+
+        // Fork point for a confirmed block (C) should be its own height (3)
+        let confirmed_height = chain_handle
+            .find_fork_point_height(&confirmed_shares[2].block_hash())
+            .unwrap();
+        assert_eq!(confirmed_height, Some(3));
+    }
+
+    /// find_fork_point_height returns None when the blockhash is
+    /// not in the store (ancestry cannot be walked).
+    #[tokio::test]
+    async fn test_find_fork_point_height_returns_none_for_unknown_block() {
+        let (chain_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+        let genesis = genesis_for_tests();
+
+        chain_handle
+            .init_or_setup_genesis(genesis.clone())
+            .await
+            .unwrap();
+
+        let unknown_hash = BlockHash::all_zeros();
+        let result = chain_handle.find_fork_point_height(&unknown_hash).unwrap();
+        assert_eq!(result, None);
     }
 }

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -126,7 +126,6 @@ pub trait ShareValidator {
         &self,
         share: &ShareBlock,
         chain_store_handle: &ChainStoreHandle,
-        pplns_window: Arc<RwLock<PplnsWindow>>,
     ) -> Result<(), ValidationError>;
 
     /// Validate uncles: count within MAX_UNCLES, no duplicates, each exists
@@ -160,6 +159,7 @@ pub trait ShareValidator {
         &self,
         share: &ShareBlock,
         chain_store_handle: &ChainStoreHandle,
+        pplns_window: Arc<RwLock<PplnsWindow>>,
     ) -> Result<(), ValidationError>;
 
     /// Validate a share header meets minimum pool difficulty without requiring parent.
@@ -800,7 +800,6 @@ impl ShareValidator for DefaultShareValidator {
         &self,
         share: &ShareBlock,
         chain_store_handle: &ChainStoreHandle,
-        pplns_window: Arc<RwLock<PplnsWindow>>,
     ) -> Result<(), ValidationError> {
         // When a hole in the chain is filled, schedule_dependents
         // re-schedules children that were already validated but could
@@ -818,7 +817,6 @@ impl ShareValidator for DefaultShareValidator {
         self.validate_uncles(share, chain_store_handle)?;
         self.validate_block_size(share)?;
         self.validate_share_coinbase(share)?;
-        self.validate_bitcoin_coinbase(share, chain_store_handle, pplns_window)?;
         self.validate_merkle_root(share)?;
         self.validate_share_witness_commitment(share)?;
         self.validate_transaction_count(share)?;
@@ -917,8 +915,10 @@ impl ShareValidator for DefaultShareValidator {
         &self,
         share: &ShareBlock,
         chain_store_handle: &ChainStoreHandle,
+        pplns_window: Arc<RwLock<PplnsWindow>>,
     ) -> Result<(), ValidationError> {
         self.validate_timestamp(share, chain_store_handle, self.time_provider.as_ref())?;
+        self.validate_bitcoin_coinbase(share, chain_store_handle, pplns_window)?;
         self.validate_prevouts(share, chain_store_handle)
     }
 }
@@ -1045,7 +1045,6 @@ mockall::mock! {
             &self,
             share: &ShareBlock,
             chain_store_handle: &ChainStoreHandle,
-            pplns_window: Arc<RwLock<PplnsWindow>>,
         ) -> Result<(), ValidationError>;
 
         fn validate_uncles(
@@ -1065,6 +1064,7 @@ mockall::mock! {
             &self,
             share: &ShareBlock,
             chain_store_handle: &ChainStoreHandle,
+            pplns_window: Arc<RwLock<PplnsWindow>>,
         ) -> Result<(), ValidationError>;
 
         fn validate_header_minimum_difficulty(
@@ -1457,20 +1457,9 @@ mod tests {
             .expect_setup_share_for_chain()
             .returning(Ok);
 
-        let pplns_window = {
-            let mut mock_window = PplnsWindow::default();
-            mock_window
-                .expect_network()
-                .return_const(bitcoin::Network::Regtest);
-            mock_window
-                .expect_get_distribution_from_start_hash()
-                .returning(|_, _, _| Some(HashMap::from([(make_test_address(1), 100)])));
-            Arc::new(RwLock::new(mock_window))
-        };
         let validator =
             DefaultShareValidator::new(PoolDifficulty::default(), 1, b"P2Poolv2".to_vec());
-        let result =
-            validator.validate_share_block(&share_block, &chain_store_handle, pplns_window);
+        let result = validator.validate_share_block(&share_block, &chain_store_handle);
 
         assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
     }
@@ -1486,18 +1475,7 @@ mod tests {
             .expect_has_status()
             .returning(|_, _| true);
 
-        let pplns_window = {
-            let mut mock_window = PplnsWindow::default();
-            mock_window
-                .expect_network()
-                .return_const(bitcoin::Network::Regtest);
-            mock_window
-                .expect_get_distribution_from_start_hash()
-                .returning(|_, _, _| Some(HashMap::new()));
-            Arc::new(RwLock::new(mock_window))
-        };
-        let result =
-            validator().validate_share_block(&share_block, &chain_store_handle, pplns_window);
+        let result = validator().validate_share_block(&share_block, &chain_store_handle);
         assert!(
             result.is_ok(),
             "Expected Ok for BlockValid status, got: {:?}",

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -29,6 +29,13 @@ use tracing::debug;
 /// Max depth to look for uncles when building new share blocks
 pub const MAX_UNCLES_DEPTH: u8 = 3;
 
+/// Maximum number of blocks included per height in getheaders responses.
+///
+/// In normal operation a height has at most 3-5 blocks. Even during
+/// network partitions, each side extends its own chain at different
+/// heights. Exceeding this cap indicates either a bug or an attack.
+pub const MAX_BLOCKS_PER_HEIGHT: usize = 20;
+
 /// Single confirmed share and its uncles.
 #[derive(Clone, Debug, Serialize)]
 pub struct ShareInfo {

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -268,8 +268,10 @@ impl Store {
             Err(_) => return Ok(blockhashes),
         };
 
-        for height in start_height..=top_confirmed_height {
-            let raw_hashes = self.get_blockhashes_for_height(height);
+        let height_entries =
+            self.get_blockhashes_for_height_range(start_height, top_confirmed_height);
+
+        for (_height, raw_hashes) in height_entries {
             let mut hashes_at_height: Vec<BlockHash> = self
                 .get_block_metadata_batch(&raw_hashes)
                 .into_iter()

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -17,7 +17,7 @@
 use crate::shares::share_block::ShareBlock;
 use crate::store::block_tx_metadata::{BlockMetadata, Status};
 use crate::store::column_families::ColumnFamily;
-use crate::store::dag_store::MAX_UNCLES_DEPTH;
+use crate::store::dag_store::{MAX_BLOCKS_PER_HEIGHT, MAX_UNCLES_DEPTH};
 use bitcoin::consensus::{Encodable, encode};
 use bitcoin::{BlockHash, Work};
 use rocksdb::{ColumnFamilyDescriptor, DB, Options as RocksDbOptions};
@@ -268,10 +268,13 @@ impl Store {
             Err(_) => return Ok(blockhashes),
         };
 
-        let height_entries =
-            self.get_blockhashes_for_height_range(start_height, top_confirmed_height);
+        let end_height = std::cmp::min(
+            start_height.saturating_add(limit as u32),
+            top_confirmed_height,
+        );
+        let height_entries = self.get_blockhashes_for_height_range(start_height, end_height);
 
-        for (_height, raw_hashes) in height_entries {
+        for (height, raw_hashes) in height_entries {
             let mut hashes_at_height: Vec<BlockHash> = self
                 .get_block_metadata_batch(&raw_hashes)
                 .into_iter()
@@ -281,6 +284,7 @@ impl Store {
                 .map(|(hash, _)| hash)
                 .collect();
             hashes_at_height.sort();
+            hashes_at_height.truncate(MAX_BLOCKS_PER_HEIGHT);
 
             let found_stop = hashes_at_height.contains(stop_blockhash);
             blockhashes.extend(hashes_at_height);

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -386,7 +386,7 @@ impl Store {
         self.add_share_block(share, &mut batch)?;
         self.commit_batch(batch)?;
         let mut batch = Store::get_write_batch();
-        let result = self.organise_block(&mut batch)?;
+        let result = self.organise_block(None, &mut batch)?;
         self.commit_batch(batch)?;
         Ok(result)
     }

--- a/p2poolv2_lib/src/store/organise/candidate.rs
+++ b/p2poolv2_lib/src/store/organise/candidate.rs
@@ -28,7 +28,7 @@ use bitcoin::{
 };
 use tracing::debug;
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 
 use super::{Chain, Height, TopResult, height_to_key_with_suffix};
 
@@ -282,23 +282,29 @@ impl Store {
         scan_start: u32,
         candidate_height: u32,
     ) -> (Vec<BlockHash>, Vec<BlockHash>) {
-        let height_range = (candidate_height - scan_start + 1) as usize;
-        let mut all_blockhashes = Vec::with_capacity(height_range);
-        let mut missing = Vec::with_capacity(height_range);
+        let height_entries = self.get_blockhashes_for_height_range(scan_start, candidate_height);
 
-        let mut height = scan_start;
-        while height <= candidate_height {
-            let blockhashes = self.get_blockhashes_for_height(height);
-            for blockhash in blockhashes {
-                all_blockhashes.push(blockhash);
-                if !self.share_block_exists(&blockhash)
-                    && !self.is_block_valid_or_confirmed(&blockhash)
-                {
-                    missing.push(blockhash);
-                }
-            }
-            height += 1;
+        let total_blocks: usize = height_entries.iter().map(|(_, hashes)| hashes.len()).sum();
+        let mut all_blockhashes = Vec::with_capacity(total_blocks);
+        for (_, blockhashes) in &height_entries {
+            all_blockhashes.extend(blockhashes);
         }
+
+        let metadata_results = self.get_block_metadata_batch(&all_blockhashes);
+        let already_valid: HashSet<BlockHash> = metadata_results
+            .into_iter()
+            .filter(|(_, metadata)| {
+                metadata.status == Status::BlockValid || metadata.status == Status::Confirmed
+            })
+            .map(|(blockhash, _)| blockhash)
+            .collect();
+
+        let candidates_to_check: Vec<BlockHash> = all_blockhashes
+            .iter()
+            .filter(|hash| !already_valid.contains(*hash))
+            .copied()
+            .collect();
+        let missing = self.missing_share_blocks(&candidates_to_check);
 
         (all_blockhashes, missing)
     }

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -14,45 +14,48 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
-use super::{Chain, Height, Store};
+use super::{Chain, Height, Store, TopResult};
+use crate::shares::share_block::ShareHeader;
 use crate::store::writer::StoreError;
 use tracing::debug;
 
 impl Store {
     /// Promote candidates to confirmed if conditions are met.
     ///
-    /// Reads the candidate and confirmed chain state from committed RocksDB
-    /// state and checks whether the candidate chain should extend or reorg
-    /// the confirmed chain. Does not touch the candidate chain.
+    /// When `promoted_header` is provided and it directly extends the
+    /// confirmed tip, the block is confirmed immediately without
+    /// consulting the candidate chain. This prevents the node from
+    /// getting stuck when the candidate chain is on a fork whose blocks
+    /// lack block data.
     ///
-    /// Only candidates whose full block data has been downloaded are
-    /// eligible for promotion. The candidate list is truncated at the
-    /// first block missing block data so the confirmed chain never
-    /// advances past an incomplete block.
+    /// Otherwise falls back to the candidate chain: reads candidate and
+    /// confirmed state, then extends or reorgs the confirmed chain from
+    /// candidates whose block data is available.
     ///
     /// Returns the new confirmed height if it changed, or None if unchanged.
     pub(crate) fn organise_block(
         &self,
+        promoted_header: Option<&ShareHeader>,
         batch: &mut rocksdb::WriteBatch,
     ) -> Result<Option<Height>, StoreError> {
         let top_confirmed = self.get_top_confirmed().map_err(|_| {
             StoreError::Database("organise_block called without a genesis block".into())
         })?;
 
-        let Ok(top_candidate) = self.get_top_candidate() else {
-            return Ok(None); // no new blocks organised
+        let candidates = if let Some(header) = promoted_header {
+            self.build_direct_candidates(header, &top_confirmed)
+        } else {
+            Vec::new()
         };
 
-        debug!(
-            "Organise block with top_confirmed {:?}, top_candidate {:?}",
-            top_confirmed, top_candidate
-        );
-
-        let all_candidates = self.get_candidates(top_confirmed.height + 1, top_candidate.height)?;
-        let candidates = self.contiguous_candidates_with_block_data(&all_candidates);
+        let candidates = if candidates.is_empty() {
+            self.find_promotable_candidates(&top_confirmed)?
+        } else {
+            candidates
+        };
 
         if candidates.is_empty() {
-            return Ok(None); // no new blocks organised
+            return Ok(None);
         }
 
         let promotable_height = candidates.last().unwrap().0;
@@ -66,6 +69,59 @@ impl Store {
         }
 
         Ok(None)
+    }
+
+    /// Find the contiguous prefix of candidates with block data that
+    /// are eligible for promotion to confirmed.
+    ///
+    /// Returns an empty vec when no candidate chain exists or when the
+    /// first candidate lacks block data.
+    fn find_promotable_candidates(&self, top_confirmed: &TopResult) -> Result<Chain, StoreError> {
+        let Ok(top_candidate) = self.get_top_candidate() else {
+            return Ok(Vec::new());
+        };
+
+        debug!(
+            "Finding promotable candidates: top_confirmed {:?}, top_candidate {:?}",
+            top_confirmed, top_candidate
+        );
+
+        let all_candidates = self.get_candidates(top_confirmed.height + 1, top_candidate.height)?;
+        Ok(self.contiguous_candidates_with_block_data(&all_candidates))
+    }
+
+    /// Build a single-element candidates vec from the promoted block
+    /// if it directly extends the confirmed tip.
+    ///
+    /// Returns an empty vec when the promoted block is not a child of
+    /// the confirmed tip or its metadata is not ready. This allows the
+    /// caller to fall through to the normal candidate search.
+    fn build_direct_candidates(
+        &self,
+        promoted_header: &ShareHeader,
+        top_confirmed: &TopResult,
+    ) -> Chain {
+        if promoted_header.prev_share_blockhash != top_confirmed.hash {
+            return Vec::new();
+        }
+
+        let blockhash = promoted_header.block_hash();
+        let Ok(metadata) = self.get_block_metadata(&blockhash) else {
+            return Vec::new();
+        };
+        let Some(expected_height) = metadata.expected_height else {
+            return Vec::new();
+        };
+
+        if expected_height != top_confirmed.height + 1 {
+            return Vec::new();
+        }
+
+        debug!(
+            "Direct confirmed extension: block {blockhash} at height {expected_height} \
+             extends confirmed tip"
+        );
+        vec![(expected_height, blockhash)]
     }
 
     /// Return the contiguous prefix of candidates that have full block
@@ -119,7 +175,7 @@ mod tests {
         // Now confirmed == candidate tip. Calling organise_block again
         // must return None since there is nothing new to promote.
         let mut batch = Store::get_write_batch();
-        let result = store.organise_block(&mut batch).unwrap();
+        let result = store.organise_block(None, &mut batch).unwrap();
         assert_eq!(
             result, None,
             "organise_block should return None when confirmed has caught up to candidates"
@@ -142,7 +198,7 @@ mod tests {
         assert!(store.get_top_candidate().is_err());
 
         let mut batch = Store::get_write_batch();
-        let result = store.organise_block(&mut batch).unwrap();
+        let result = store.organise_block(None, &mut batch).unwrap();
         assert_eq!(
             result, None,
             "organise_block should return None when no candidate chain exists"
@@ -883,7 +939,7 @@ mod tests {
 
         // organise_block should not promote since first candidate has no block data
         let mut batch = Store::get_write_batch();
-        let result = store.organise_block(&mut batch).unwrap();
+        let result = store.organise_block(None, &mut batch).unwrap();
         assert_eq!(
             result, None,
             "organise_block should not promote candidates without block data"
@@ -937,7 +993,7 @@ mod tests {
 
         // organise_block should promote only share1 and share2
         let mut batch = Store::get_write_batch();
-        let result = store.organise_block(&mut batch).unwrap();
+        let result = store.organise_block(None, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         assert_eq!(result, Some(2));
@@ -999,5 +1055,92 @@ mod tests {
         );
         assert_eq!(store.get_top_confirmed_height().unwrap(), 2);
         assert!(store.get_confirmed_at_height(3).is_err());
+    }
+
+    /// Direct confirmed extension bypasses a stuck candidate chain.
+    ///
+    /// Scenario
+    /// - genesis -> share1(h:1) confirmed
+    /// - Candidate chain on a different fork (header-only, no block data)
+    /// - Local block at h:2 with parent = share1 (confirmed tip), with block data
+    /// - organise_block with promoted_header = local block
+    /// - Confirmed extends to h:2 with the local block
+    #[test]
+    fn test_direct_confirmed_extension_bypasses_stuck_candidates() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // share1: confirmed at h:1
+        let share1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695792)
+            .build();
+        store.push_to_confirmed_chain(&share1).unwrap();
+        assert_eq!(store.get_top_confirmed_height().unwrap(), 1);
+
+        // fork_share: different child of genesis, candidate at h:1 on a
+        // different fork. Push header only (no block data) to simulate
+        // a peer's fork with headers but no bodies.
+        let fork_share = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695799)
+            .build();
+        store.push_to_candidate_chain(&fork_share).unwrap();
+
+        // fork_share2: extends the fork to h:2 (header only, no block data)
+        let fork_share2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_share.block_hash().to_string())
+            .nonce(0xe9695800)
+            .build();
+        store.push_to_candidate_chain(&fork_share2).unwrap();
+
+        // Candidate tip is now on the fork at h:2 with no block data
+        assert_eq!(store.get_top_candidate_height().ok(), Some(2));
+        assert!(!store.share_block_exists(&fork_share.block_hash()));
+
+        // local_block: child of share1 (confirmed tip), WITH block data.
+        // This simulates a locally mined block.
+        let local_block = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share1.block_hash().to_string())
+            .nonce(0xe9695801)
+            .build();
+        // Store block data
+        let mut batch = Store::get_write_batch();
+        store.add_share_block(&local_block, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+        // Initialise metadata via organise_header
+        let mut batch = Store::get_write_batch();
+        store
+            .organise_header(&local_block.header, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // organise_block without promoted_header returns None (candidates
+        // stuck on fork with no block data)
+        let mut batch = Store::get_write_batch();
+        let result = store.organise_block(None, &mut batch).unwrap();
+        assert_eq!(
+            result, None,
+            "Without promoted_header, candidates are stuck"
+        );
+
+        // organise_block WITH promoted_header should directly extend confirmed
+        let mut batch = Store::get_write_batch();
+        let result = store
+            .organise_block(Some(&local_block.header), &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        assert_eq!(result, Some(2));
+        assert_eq!(store.get_top_confirmed_height().unwrap(), 2);
+        assert_eq!(
+            store.get_confirmed_at_height(2).unwrap(),
+            local_block.block_hash()
+        );
     }
 }

--- a/p2poolv2_lib/src/store/share_store.rs
+++ b/p2poolv2_lib/src/store/share_store.rs
@@ -419,7 +419,7 @@ impl Store {
     /// Batch-fetch block metadata for the given blockhashes.
     ///
     /// Deduplicates the input so each blockhash is looked up at most once.
-    pub(crate) fn get_block_metadata_batch(
+    pub fn get_block_metadata_batch(
         &self,
         blockhashes: &[BlockHash],
     ) -> Vec<(BlockHash, BlockMetadata)> {
@@ -459,7 +459,7 @@ impl Store {
     }
 
     /// Update block metadata for a blockhash
-    pub(crate) fn update_block_metadata(
+    pub fn update_block_metadata(
         &self,
         blockhash: &BlockHash,
         metadata: &BlockMetadata,

--- a/p2poolv2_lib/src/store/share_store.rs
+++ b/p2poolv2_lib/src/store/share_store.rs
@@ -358,7 +358,7 @@ impl Store {
         lower_key.extend_from_slice(&from_height.to_be_bytes());
 
         let mut upper_key = b"h:".to_vec();
-        upper_key.extend_from_slice(&(to_height + 1).to_be_bytes());
+        upper_key.extend_from_slice(&to_height.saturating_add(1).to_be_bytes());
 
         let mut read_opts = rocksdb::ReadOptions::default();
         read_opts.set_iterate_lower_bound(lower_key.clone());

--- a/p2poolv2_lib/src/store/share_store.rs
+++ b/p2poolv2_lib/src/store/share_store.rs
@@ -167,6 +167,8 @@ impl Store {
     /// Checks the BlockTxids CF for the txids key, since txids are
     /// written as part of add_share_block and their presence indicates
     /// the full block data has been stored.
+    ///
+    /// TODO: Replace this with a has_block field in metadata. Will require migration, so pending till we add migration support. See `missing_share_blocks`.
     pub fn share_block_exists(&self, blockhash: &BlockHash) -> bool {
         let block_txids_cf = self.db.cf_handle(&ColumnFamily::BlockTxids).unwrap();
         let mut key = consensus::serialize(blockhash);
@@ -176,6 +178,31 @@ impl Store {
             .ok()
             .flatten()
             .is_some()
+    }
+
+    /// Return blockhashes from the input that do NOT have block data in
+    /// the store. Uses a single `multi_get_cf` on the BlockTxids CF.
+    ///
+    /// TODO: Replace this with a has_block field in metadata. Will require migration, so pending till we add migration support. See `share_block_exists`.
+    pub fn missing_share_blocks(&self, blockhashes: &[BlockHash]) -> Vec<BlockHash> {
+        let block_txids_cf = self.db.cf_handle(&ColumnFamily::BlockTxids).unwrap();
+        let keys: Vec<_> = blockhashes
+            .iter()
+            .map(|hash| {
+                let mut key = consensus::serialize(hash);
+                key.extend_from_slice(b"_txids");
+                (&block_txids_cf, key)
+            })
+            .collect();
+        let results = self.db.multi_get_cf(keys);
+
+        let mut missing = Vec::new();
+        for (blockhash, result) in blockhashes.iter().zip(results.into_iter()) {
+            if !matches!(result, Ok(Some(_))) {
+                missing.push(*blockhash);
+            }
+        }
+        missing
     }
 
     /// Get a share from the store by reconstructing it from the Header CF
@@ -309,6 +336,53 @@ impl Store {
             Ok(Some(blockhashes)) => encode::deserialize(&blockhashes).unwrap_or_default(),
             Ok(None) | Err(_) => vec![],
         }
+    }
+
+    /// Get all blockhashes for a range of heights in a single iterator pass.
+    ///
+    /// Uses a RocksDB range iterator on the BlockHeight CF instead of
+    /// per-height point reads. Returns (height, blockhashes) pairs sorted
+    /// by height. Heights with no entries are omitted.
+    pub fn get_blockhashes_for_height_range(
+        &self,
+        from_height: u32,
+        to_height: u32,
+    ) -> Vec<(u32, Vec<BlockHash>)> {
+        if from_height > to_height {
+            return Vec::new();
+        }
+
+        let block_height_cf = self.db.cf_handle(&ColumnFamily::BlockHeight).unwrap();
+
+        let mut lower_key = b"h:".to_vec();
+        lower_key.extend_from_slice(&from_height.to_be_bytes());
+
+        let mut upper_key = b"h:".to_vec();
+        upper_key.extend_from_slice(&(to_height + 1).to_be_bytes());
+
+        let mut read_opts = rocksdb::ReadOptions::default();
+        read_opts.set_iterate_lower_bound(lower_key.clone());
+        read_opts.set_iterate_upper_bound(upper_key);
+
+        let iter = self.db.iterator_cf_opt(
+            &block_height_cf,
+            read_opts,
+            rocksdb::IteratorMode::From(&lower_key, rocksdb::Direction::Forward),
+        );
+
+        let capacity = (to_height - from_height + 1) as usize;
+        let mut results = Vec::with_capacity(capacity);
+
+        for item in iter.flatten() {
+            let (key, value) = item;
+            let height = u32::from_be_bytes(key[2..6].try_into().unwrap());
+            let blockhashes: Vec<BlockHash> = encode::deserialize(&value).unwrap_or_default();
+            if !blockhashes.is_empty() {
+                results.push((height, blockhashes));
+            }
+        }
+
+        results
     }
 
     /// Get the shares for a specific height
@@ -909,5 +983,158 @@ mod tests {
         let result_b_first =
             store.first_existing_share_header(&[block_b.block_hash(), block_a.block_hash()]);
         assert_eq!(result_b_first, Some(block_b.block_hash()));
+    }
+
+    #[test]
+    fn test_missing_share_blocks_returns_all_when_none_stored() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let block_a = TestShareBlockBuilder::new().nonce(1).build();
+        let block_b = TestShareBlockBuilder::new().nonce(2).build();
+        let hashes = vec![block_a.block_hash(), block_b.block_hash()];
+
+        let missing = store.missing_share_blocks(&hashes);
+        assert_eq!(missing.len(), 2);
+        assert_eq!(missing, hashes);
+    }
+
+    #[test]
+    fn test_missing_share_blocks_excludes_stored_blocks() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let block_a = TestShareBlockBuilder::new().nonce(1).build();
+        let block_b = TestShareBlockBuilder::new().nonce(2).build();
+
+        let mut batch = Store::get_write_batch();
+        store.add_share_block(&block_a, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let hashes = vec![block_a.block_hash(), block_b.block_hash()];
+        let missing = store.missing_share_blocks(&hashes);
+        assert_eq!(missing, vec![block_b.block_hash()]);
+    }
+
+    #[test]
+    fn test_missing_share_blocks_returns_empty_when_all_stored() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let block_a = TestShareBlockBuilder::new().nonce(1).build();
+        let block_b = TestShareBlockBuilder::new().nonce(2).build();
+
+        let mut batch = Store::get_write_batch();
+        store.add_share_block(&block_a, &mut batch).unwrap();
+        store.add_share_block(&block_b, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let hashes = vec![block_a.block_hash(), block_b.block_hash()];
+        let missing = store.missing_share_blocks(&hashes);
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn test_missing_share_blocks_empty_input() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let missing = store.missing_share_blocks(&[]);
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn test_get_blockhashes_for_height_range_returns_all_heights() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let block_a = TestShareBlockBuilder::new().nonce(1).build();
+        let block_b = TestShareBlockBuilder::new().nonce(2).build();
+        let block_c = TestShareBlockBuilder::new().nonce(3).build();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .set_height_to_blockhash(&block_a.block_hash(), 10, &mut batch)
+            .unwrap();
+        store
+            .set_height_to_blockhash(&block_b.block_hash(), 11, &mut batch)
+            .unwrap();
+        store
+            .set_height_to_blockhash(&block_c.block_hash(), 12, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let results = store.get_blockhashes_for_height_range(10, 12);
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0], (10, vec![block_a.block_hash()]));
+        assert_eq!(results[1], (11, vec![block_b.block_hash()]));
+        assert_eq!(results[2], (12, vec![block_c.block_hash()]));
+    }
+
+    #[test]
+    fn test_get_blockhashes_for_height_range_multiple_blocks_per_height() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let block_a = TestShareBlockBuilder::new().nonce(1).build();
+        let block_b = TestShareBlockBuilder::new().nonce(2).build();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .set_height_to_blockhash(&block_a.block_hash(), 5, &mut batch)
+            .unwrap();
+        store
+            .set_height_to_blockhash(&block_b.block_hash(), 5, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let results = store.get_blockhashes_for_height_range(5, 5);
+        assert_eq!(results.len(), 1);
+        let (height, blockhashes) = &results[0];
+        assert_eq!(*height, 5);
+        assert_eq!(blockhashes.len(), 2);
+        assert!(blockhashes.contains(&block_a.block_hash()));
+        assert!(blockhashes.contains(&block_b.block_hash()));
+    }
+
+    #[test]
+    fn test_get_blockhashes_for_height_range_empty_when_reversed() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let results = store.get_blockhashes_for_height_range(10, 5);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_get_blockhashes_for_height_range_skips_empty_heights() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let block_a = TestShareBlockBuilder::new().nonce(1).build();
+        let block_b = TestShareBlockBuilder::new().nonce(2).build();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .set_height_to_blockhash(&block_a.block_hash(), 10, &mut batch)
+            .unwrap();
+        store
+            .set_height_to_blockhash(&block_b.block_hash(), 15, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let results = store.get_blockhashes_for_height_range(10, 15);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, 10);
+        assert_eq!(results[1].0, 15);
+    }
+
+    #[test]
+    fn test_get_blockhashes_for_height_range_no_entries() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let results = store.get_blockhashes_for_height_range(100, 200);
+        assert!(results.is_empty());
     }
 }

--- a/p2poolv2_lib/src/store/writer/handle.rs
+++ b/p2poolv2_lib/src/store/writer/handle.rs
@@ -323,10 +323,18 @@ impl StoreHandle {
 
     /// Promote candidates to confirmed.
     /// Returns the confirmed chain height after organising, if changed.
-    pub async fn organise_block(&self) -> Result<Option<u32>, StoreError> {
+    /// When promoted_header is provided, the block can be confirmed
+    /// directly if it extends the confirmed tip.
+    pub async fn organise_block(
+        &self,
+        promoted_header: Option<ShareHeader>,
+    ) -> Result<Option<u32>, StoreError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.write_tx
-            .send(WriteCommand::OrganiseBlock { reply: reply_tx })
+            .send(WriteCommand::OrganiseBlock {
+                promoted_header,
+                reply: reply_tx,
+            })
             .map_err(|_| StoreError::ChannelClosed)?;
         reply_rx.await.map_err(|_| StoreError::ChannelClosed)?
     }
@@ -384,7 +392,7 @@ mockall::mock! {
 
         // Serialized writes (async)
         pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;
-        pub async fn organise_block(&self) -> Result<Option<u32>, StoreError>;
+        pub async fn organise_block(&self, promoted_header: Option<ShareHeader>) -> Result<Option<u32>, StoreError>;
         pub async fn add_share_block(&self, share: ShareBlock) -> Result<(), StoreError>;
         pub async fn add_share_block_and_organise_header(&self, share: ShareBlock) -> Result<Option<u32>, StoreError>;
         pub async fn setup_genesis(&self, genesis: ShareBlock) -> Result<(), StoreError>;

--- a/p2poolv2_lib/src/store/writer/mod.rs
+++ b/p2poolv2_lib/src/store/writer/mod.rs
@@ -139,7 +139,10 @@ pub enum WriteCommand {
 
     /// Promote candidates to confirmed.
     /// Returns the confirmed chain height after organising, if changed.
+    /// When promoted_header is provided, the block can be confirmed
+    /// directly if it extends the confirmed tip, bypassing stuck candidates.
     OrganiseBlock {
+        promoted_header: Option<ShareHeader>,
         reply: oneshot::Sender<Result<Option<u32>, StoreError>>,
     },
 }
@@ -264,12 +267,18 @@ impl StoreWriter {
                 let _ = reply.send(result);
             }
 
-            WriteCommand::OrganiseBlock { reply } => {
+            WriteCommand::OrganiseBlock {
+                promoted_header,
+                reply,
+            } => {
                 let mut batch = Store::get_write_batch();
-                let result = self.store.organise_block(&mut batch).and_then(|height| {
-                    self.store.commit_batch(batch).map_err(StoreError::from)?;
-                    Ok(height)
-                });
+                let result = self
+                    .store
+                    .organise_block(promoted_header.as_ref(), &mut batch)
+                    .and_then(|height| {
+                        self.store.commit_batch(batch).map_err(StoreError::from)?;
+                        Ok(height)
+                    });
                 let _ = reply.send(result);
             }
         }

--- a/p2poolv2_tests/src/common/mod.rs
+++ b/p2poolv2_tests/src/common/mod.rs
@@ -40,6 +40,7 @@ pub fn default_test_config() -> Config {
             max_transaction_per_second: 100,
             max_requests_per_second: 1,
             dial_timeout_secs: 30,
+            blocked_ips: vec![],
         },
         bitcoinrpc: BitcoinRpcConfig {
             url: "http://localhost:8332".to_string(),

--- a/p2poolv2_tests/src/node_swarm_test.rs
+++ b/p2poolv2_tests/src/node_swarm_test.rs
@@ -268,7 +268,7 @@ async fn test_three_nodes_share_sync() {
             .organise_header(share_block.header.clone())
             .await
             .unwrap();
-        chain_store_handle1.organise_block().await.unwrap();
+        chain_store_handle1.organise_block(None).await.unwrap();
     }
 
     // Verify node 1 has all shares


### PR DESCRIPTION
A big PR, apologies.

- Catch up from past forks
- Move coinbase validation to validation with chain context. So these are validated at confirmation time, not candidate time.
- Don't try to catch up with peer's chain tip using stale mechanism, we are already catching up
- Reduce max headers limit from 2000 to 1500. At 2000 we hit the yamux default limits
- Use batch queries when querying headers to respond to getheaders
- Limit number of shares at a height. This will only be exceeded in case of an attack or a bug. If a node receives more shares at a height than this limit from a peer, it disconnects from the peer.

CLI commands

- blocked ips management
- query share chain transactions