### PR TITLE
Remove uncle should not be confirmed share rule

### DIFF
--- a/p2poolv2_lib/src/accounting/payout/sharechain_pplns/payout.rs
+++ b/p2poolv2_lib/src/accounting/payout/sharechain_pplns/payout.rs
@@ -289,6 +289,21 @@ mod tests {
                 status: Status::Confirmed,
             })
         });
+        mock.expect_get_block_metadata_batch().returning(|hashes| {
+            hashes
+                .iter()
+                .map(|hash| {
+                    (
+                        *hash,
+                        BlockMetadata {
+                            expected_height: Some(0),
+                            chain_work: Work::from_le_bytes([0u8; 32]),
+                            status: Status::BlockValid,
+                        },
+                    )
+                })
+                .collect()
+        });
         mock.expect_get_confirmed_headers_in_range()
             .returning(move |_, _| Ok(confirmed_headers.clone()));
         mock.expect_get_share_headers()
@@ -369,6 +384,21 @@ mod tests {
                 chain_work: Work::from_le_bytes([0u8; 32]),
                 status: Status::Confirmed,
             })
+        });
+        mock.expect_get_block_metadata_batch().returning(|hashes| {
+            hashes
+                .iter()
+                .map(|hash| {
+                    (
+                        *hash,
+                        BlockMetadata {
+                            expected_height: Some(0),
+                            chain_work: Work::from_le_bytes([0u8; 32]),
+                            status: Status::BlockValid,
+                        },
+                    )
+                })
+                .collect()
         });
         mock.expect_get_confirmed_headers_in_range()
             .returning(move |_, _| Ok(confirmed_headers.clone()));
@@ -577,6 +607,21 @@ mod tests {
                 chain_work: Work::from_le_bytes([0u8; 32]),
                 status: Status::Confirmed,
             })
+        });
+        mock.expect_get_block_metadata_batch().returning(|hashes| {
+            hashes
+                .iter()
+                .map(|hash| {
+                    (
+                        *hash,
+                        BlockMetadata {
+                            expected_height: Some(0),
+                            chain_work: Work::from_le_bytes([0u8; 32]),
+                            status: Status::BlockValid,
+                        },
+                    )
+                })
+                .collect()
         });
         mock.expect_get_confirmed_headers_in_range()
             .returning(move |_, _| Ok(confirmed_headers.clone()));

--- a/p2poolv2_lib/src/accounting/payout/sharechain_pplns/pplns_window.rs
+++ b/p2poolv2_lib/src/accounting/payout/sharechain_pplns/pplns_window.rs
@@ -28,6 +28,7 @@ use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::chain::chain_store_handle::ConfirmedHeaderResult;
 use crate::shares::share_block::ShareHeader;
+use crate::store::block_tx_metadata::Status;
 use bitcoin::Address;
 use bitcoin::BlockHash;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -686,7 +687,8 @@ impl PplnsWindow {
             return Ok(HashMap::new());
         }
 
-        let uncle_headers = chain_store_handle.get_share_headers(uncle_hashes)?;
+        let filtered_hashes = non_confirmed_uncle_hashes(chain_store_handle, uncle_hashes);
+        let uncle_headers = chain_store_handle.get_share_headers(&filtered_hashes)?;
         let mut uncle_lookup = HashMap::with_capacity(uncle_headers.len());
         for (blockhash, header) in uncle_headers {
             let difficulty = header.get_difficulty(self.network);
@@ -695,6 +697,23 @@ impl PplnsWindow {
         }
         Ok(uncle_lookup)
     }
+}
+
+/// Return uncle hashes that are not on the confirmed chain.
+///
+/// A block on the confirmed chain must not also be counted as an uncle
+/// in PPLNS, otherwise its difficulty would be paid out twice. Uses a
+/// single batch metadata lookup to filter them out.
+fn non_confirmed_uncle_hashes(
+    chain_store_handle: &ChainStoreHandle,
+    uncle_hashes: &[BlockHash],
+) -> Vec<BlockHash> {
+    chain_store_handle
+        .get_block_metadata_batch(uncle_hashes)
+        .into_iter()
+        .filter(|(_, metadata)| metadata.status != Status::Confirmed)
+        .map(|(blockhash, _)| blockhash)
+        .collect()
 }
 
 /// Collect unique uncle blockhashes from confirmed headers for batch fetching.

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -847,11 +847,6 @@ impl ShareValidator for DefaultShareValidator {
                     "Uncle {uncle} not found in store"
                 )));
             };
-            if chain_store_handle.has_status(uncle, Status::Confirmed) {
-                return Err(ValidationError::new(format!(
-                    "Uncle {uncle} is on confirmed chain"
-                )));
-            }
         }
         Ok(())
     }
@@ -1309,13 +1304,10 @@ mod tests {
         let uncle2 = TestShareBlockBuilder::new().miner_pubkey(PUBKEY_2G).build();
         let uncle3 = TestShareBlockBuilder::new().miner_pubkey(PUBKEY_3G).build();
 
-        // All uncles exist and are not confirmed
+        // All uncles exist in the store
         chain_store_handle
             .expect_share_block_exists()
             .returning(|_| true);
-        chain_store_handle
-            .expect_has_status()
-            .returning(|_, _| false);
 
         let valid_share = TestShareBlockBuilder::new()
             .uncles(vec![
@@ -1397,35 +1389,6 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("not found in store")
-        );
-    }
-
-    #[tokio::test]
-    async fn test_validate_uncles_on_confirmed_chain() {
-        let mut chain_store_handle = ChainStoreHandle::default();
-
-        let uncle1 = TestShareBlockBuilder::new().miner_pubkey(PUBKEY_G).build();
-
-        // Uncle exists but is on the confirmed chain
-        chain_store_handle
-            .expect_share_block_exists()
-            .returning(|_| true);
-        chain_store_handle
-            .expect_has_status()
-            .returning(|_, _| true);
-
-        let invalid_share = TestShareBlockBuilder::new()
-            .uncles(vec![uncle1.block_hash()])
-            .miner_pubkey(PUBKEY_G)
-            .build();
-
-        let result = validator().validate_uncles(&invalid_share, &chain_store_handle);
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("on confirmed chain")
         );
     }
 


### PR DESCRIPTION
This can happen temporarily as a chain is being organised. A nephew block will refer to an uncle which has been previously confirmed. By imposing this rule we block out chain reorganisation that will remove that block as a confirmed block and bring it back to being an uncle.