### PR TITLE
Confirm in candidate order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.11.0] - 2026-05-25
+
+### Fixed
+
+- Fix confirmed chain divergence during sync. Blocks are now confirmed
+  strictly in candidate chain order instead of by block body arrival
+  order. The candidate chain resolves historical forks via cumulative
+  work (ASERT breaks equal-work ties at the next height through
+  different parent timestamps), and the confirmed chain follows it.
+  Previously, `build_direct_candidates` confirmed whichever block body
+  arrived first at each height, which could diverge from the peer's
+  confirmed chain, causing PPLNS distribution mismatches and merkle
+  root validation failures.
+
+- Add uncle body availability check before block confirmation. Both
+  `should_extend_confirmed` and `reorg_confirmed` now verify that all
+  uncle bodies referenced by candidate blocks are available in the
+  store before promoting them. This prevents missing uncle data in the
+  PPLNS window which caused incorrect payout distributions.
+
+- Add fallback confirmation path. When the candidate chain cannot be
+  advanced (e.g. stuck on a fork with missing block data), any block
+  at confirmed_height + 1 that is a child of the confirmed tip with
+  all block and uncle data available can be confirmed. This allows
+  locally mined blocks to advance the confirmed chain.
+
+- Trigger confirmed chain advancement when blocks are buffered by the
+  organise worker. After a candidate chain reorg, the block at
+  `confirmed_tip + 1` may already have its body stored but no
+  OrganiseEvent was sent for it. The organise worker now calls
+  organise_block when buffering blocks to pick up such blocks.
+
+- Downgrade uncle-on-confirmed-chain validation log from error to
+  debug. This validation failure is expected during sync when the
+  confirmed chain has not yet settled and is harmless because the
+  block body is still stored and confirmed via the candidate chain
+  path.
+
+- Cap the candidate chain scan in `find_promotable_candidates` to
+  `FETCH_BATCH_SIZE` entries beyond the confirmed tip. Previously
+  scanned the entire gap to the candidate tip (up to 50k+ entries),
+  causing ~25ms delays per call during sync.
+
 ## [v0.10.15] - 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindrpc"
-version = "0.10.16"
+version = "0.11.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3252,7 +3252,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2poolv2_api"
-version = "0.10.16"
+version = "0.11.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_cli"
-version = "0.10.16"
+version = "0.11.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_config"
-version = "0.10.16"
+version = "0.11.0"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_lib"
-version = "0.10.16"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_node"
-version = "0.10.16"
+version = "0.11.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_tests"
-version = "0.10.16"
+version = "0.11.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.16"
+version = "0.11.0"
 edition = "2024"
 authors = ["Kulpreet Singh<kp@opdup.com>"]
 license = "AGPL-3.0-or-later"

--- a/p2poolv2_lib/src/node/organise_worker.rs
+++ b/p2poolv2_lib/src/node/organise_worker.rs
@@ -177,6 +177,18 @@ impl OrganiseWorker {
     ) -> Result<(), OrganiseError> {
         if let Some(parent_height) = self.should_buffer_block(&share_block) {
             self.buffer_block(parent_height, share_block);
+            // The buffered block is too far ahead to promote, but the
+            // candidate chain may have reorged since the last
+            // organise_block call. The block at confirmed_tip + 1 on
+            // the candidate chain might already have its body stored
+            // (e.g. it failed context-free validation but was stored
+            // by the block receiver). Try to advance the confirmed
+            // chain from the candidate chain, then drain any buffered
+            // blocks that become processable.
+            if let Ok(Some(_)) = self.chain_store_handle.organise_block().await {
+                self.update_pplns_window();
+                self.drain_pending_blocks().await?;
+            }
             return Ok(());
         }
 
@@ -754,6 +766,9 @@ mod tests {
             .expect_get_tip_height()
             .returning(|| Ok(Some(5)));
         mock_chain_handle.expect_promote_block().never();
+        mock_chain_handle
+            .expect_organise_block()
+            .returning(|| Ok(None));
 
         let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
         let (notify_tx, _notify_rx) = create_test_notify_channel();
@@ -866,6 +881,9 @@ mod tests {
             });
 
         mock_chain_handle
+            .expect_organise_block()
+            .returning(|| Ok(None));
+        mock_chain_handle
             .expect_promote_block()
             .returning(|_| Ok(Some(100)));
         mock_chain_handle
@@ -960,6 +978,9 @@ mod tests {
                 promote_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 Ok(Some(10))
             });
+        mock_chain_handle
+            .expect_organise_block()
+            .returning(|| Ok(None));
         mock_chain_handle
             .expect_get_candidate_tip_height()
             .returning(|| Ok(Some(10)));

--- a/p2poolv2_lib/src/node/organise_worker.rs
+++ b/p2poolv2_lib/src/node/organise_worker.rs
@@ -185,9 +185,20 @@ impl OrganiseWorker {
             // by the block receiver). Try to advance the confirmed
             // chain from the candidate chain, then drain any buffered
             // blocks that become processable.
-            if let Ok(Some(_)) = self.chain_store_handle.organise_block().await {
-                self.update_pplns_window();
-                self.drain_pending_blocks().await?;
+            match self.chain_store_handle.organise_block().await {
+                Ok(Some(_)) => {
+                    self.update_pplns_window();
+                    self.drain_pending_blocks().await?;
+                }
+                Ok(None) => {}
+                Err(StoreError::ChannelClosed) => {
+                    return Err(OrganiseError {
+                        message: "Store writer channel closed".to_string(),
+                    });
+                }
+                Err(error) => {
+                    error!("Error advancing confirmed from buffer trigger: {error}");
+                }
             }
             return Ok(());
         }

--- a/p2poolv2_lib/src/node/request_response_handler/block_fetcher/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/block_fetcher/mod.rs
@@ -55,7 +55,7 @@ const BLOCK_FETCHER_CHANNEL_CAPACITY: usize = 8192;
 /// queue at a time. The next batch is loaded only after the current
 /// batch is fully dispatched and all responses have been received,
 /// bounding memory in the downstream block receiver.
-const FETCH_BATCH_SIZE: usize = 1000;
+pub(crate) const FETCH_BATCH_SIZE: usize = 1000;
 
 /// A blockhash queued for fetching, with an optional preferred peer
 /// that is known to have the block body (the inv/headers source).

--- a/p2poolv2_lib/src/node/validation_worker.rs
+++ b/p2poolv2_lib/src/node/validation_worker.rs
@@ -196,7 +196,12 @@ async fn validate_and_emit(
     if let Err(validation_error) =
         share_validator.validate_share_block(&share_block, &chain_store_handle)
     {
-        error!("Share block {block_hash} validation failed: {validation_error}");
+        let error_message = validation_error.to_string();
+        if error_message.contains("is on confirmed chain") {
+            debug!("Share block {block_hash} validation: {error_message}");
+        } else {
+            error!("Share block {block_hash} validation failed: {error_message}");
+        }
         return;
     }
 

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -707,13 +707,9 @@ impl ChainStoreHandle {
 
     /// Promote candidates to confirmed.
     /// Returns the confirmed chain height after organising, if changed.
-    /// When promoted_header is provided, the block can be confirmed
-    /// directly if it extends the confirmed tip.
-    pub async fn organise_block(
-        &self,
-        promoted_header: Option<ShareHeader>,
-    ) -> Result<Option<u32>, StoreError> {
-        let height = self.store_handle.organise_block(promoted_header).await?;
+    /// Confirms blocks strictly from the candidate chain order.
+    pub async fn organise_block(&self) -> Result<Option<u32>, StoreError> {
+        let height = self.store_handle.organise_block().await?;
         debug!("Organised block at confirmed height {height:?}");
         Ok(height)
     }
@@ -729,8 +725,8 @@ impl ChainStoreHandle {
     /// the next promote_block call will pick up.
     pub async fn promote_block(&self, header: ShareHeader) -> Result<Option<u32>, StoreError> {
         let blockhash = header.block_hash();
-        self.organise_header(header.clone()).await?;
-        let height = self.organise_block(Some(header)).await?;
+        self.organise_header(header).await?;
+        let height = self.organise_block().await?;
         info!("Promoted block {blockhash} to confirmed height {height:?}");
         Ok(height)
     }
@@ -825,7 +821,7 @@ mockall::mock! {
         pub fn get_btcaddresses_for_user_ids(&self, user_ids: &[u64]) -> Result<Vec<(u64, String)>, StoreError>;
         pub async fn init_or_setup_genesis(&self, genesis_block: ShareBlock) -> Result<(), StoreError>;
         pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;
-        pub async fn organise_block(&self, promoted_header: Option<ShareHeader>) -> Result<Option<u32>, StoreError>;
+        pub async fn organise_block(&self) -> Result<Option<u32>, StoreError>;
         pub async fn promote_block(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;
         pub async fn add_share_block(&self, share: ShareBlock) -> Result<(), StoreError>;
         pub async fn add_share_block_and_organise_header(&self, share: ShareBlock) -> Result<Option<u32>, StoreError>;
@@ -945,7 +941,7 @@ mod tests {
                 .organise_header(share.header.clone())
                 .await
                 .unwrap();
-            chain_handle.organise_block(None).await.unwrap();
+            chain_handle.organise_block().await.unwrap();
             prev_hash = share.block_hash();
             shares.push(share);
         }
@@ -1012,7 +1008,7 @@ mod tests {
                 .organise_header(share.header.clone())
                 .await
                 .unwrap();
-            chain_handle.organise_block(None).await.unwrap();
+            chain_handle.organise_block().await.unwrap();
             prev_hash = share.block_hash();
             shares.push(share);
         }
@@ -1081,7 +1077,7 @@ mod tests {
                 .organise_header(share.header.clone())
                 .await
                 .unwrap();
-            chain_handle.organise_block(None).await.unwrap();
+            chain_handle.organise_block().await.unwrap();
             prev_hash = share.block_hash();
             shares.push(share);
         }
@@ -1197,7 +1193,7 @@ mod tests {
             .organise_header(share_a.header.clone())
             .await
             .unwrap();
-        chain_handle.organise_block(None).await.unwrap();
+        chain_handle.organise_block().await.unwrap();
 
         let share_b = TestShareBlockBuilder::new()
             .prev_share_blockhash(share_a.block_hash().to_string())
@@ -1209,7 +1205,7 @@ mod tests {
             .organise_header(share_b.header.clone())
             .await
             .unwrap();
-        chain_handle.organise_block(None).await.unwrap();
+        chain_handle.organise_block().await.unwrap();
 
         // Store an uncle at height 1 (same height as share_a) via the
         // underlying Store, which puts it in the BlockHeight CF without
@@ -1289,7 +1285,7 @@ mod tests {
                 .organise_header(share.header.clone())
                 .await
                 .unwrap();
-            chain_handle.organise_block(None).await.unwrap();
+            chain_handle.organise_block().await.unwrap();
             prev_hash = share.block_hash();
             confirmed_shares.push(share);
         }

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -707,7 +707,9 @@ impl ChainStoreHandle {
 
     /// Promote candidates to confirmed.
     /// Returns the confirmed chain height after organising, if changed.
-    /// Confirms blocks strictly from the candidate chain order.
+    /// Prefers the candidate chain order. Falls back to any child of
+    /// the confirmed tip with full block and uncle data when no
+    /// candidate blocks can be promoted.
     pub async fn organise_block(&self) -> Result<Option<u32>, StoreError> {
         let height = self.store_handle.organise_block().await?;
         debug!("Organised block at confirmed height {height:?}");

--- a/p2poolv2_lib/src/store/mod.rs
+++ b/p2poolv2_lib/src/store/mod.rs
@@ -392,7 +392,7 @@ impl Store {
         self.add_share_block(share, &mut batch)?;
         self.commit_batch(batch)?;
         let mut batch = Store::get_write_batch();
-        let result = self.organise_block(None, &mut batch)?;
+        let result = self.organise_block(&mut batch)?;
         self.commit_batch(batch)?;
         Ok(result)
     }

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -31,6 +31,30 @@ const CONFIRMED_SUFFIX: &str = ":f";
 const TOP_CONFIRMED_KEY: &str = "meta:top_confirmed_height";
 
 impl Store {
+    /// Check that every block in the list has its body stored and that
+    /// all uncles referenced by each block also have their bodies stored.
+    ///
+    /// Returns false (with a debug log) on the first missing block body
+    /// or uncle body. Used by both `should_extend_confirmed` and
+    /// `reorg_confirmed` to ensure PPLNS can resolve all uncle data
+    /// before a block is promoted.
+    fn all_block_and_uncle_data_available(&self, blockhashes: &[BlockHash]) -> bool {
+        for blockhash in blockhashes {
+            if !self.share_block_exists(blockhash) {
+                debug!("Block {blockhash} missing block data");
+                return false;
+            }
+            if let Ok(Some(header)) = self.get_share_header(blockhash) {
+                for uncle in &header.uncles {
+                    if !self.share_block_exists(uncle) {
+                        debug!("Uncle {uncle} of block {blockhash} missing block data");
+                        return false;
+                    }
+                }
+            }
+        }
+        true
+    }
     /// Check if the candidate chain should reorg the confirmed chain.
     ///
     /// Returns true when the last candidate has more cumulative work
@@ -105,12 +129,11 @@ impl Store {
             StoreError::NotFound("Empty branch returned from get_branch_to_chain.".into())
         })?;
 
-        // Do not reorg if any block in the fork branch lacks block data
-        for to_confirm in &fork_branch {
-            if !self.share_block_exists(to_confirm) {
-                debug!("Reorg skipped: block {} missing block data", to_confirm);
-                return Ok(None);
-            }
+        // Do not reorg if any block or its uncles lack block data
+        let fork_hashes: Vec<BlockHash> = fork_branch.iter().copied().collect();
+        if !self.all_block_and_uncle_data_available(&fork_hashes) {
+            debug!("Reorg skipped: block or uncle missing block data");
+            return Ok(None);
         }
 
         let reorged_out_chain = self.get_confirmed_chain(fork_point, Some(top_confirmed))?;
@@ -311,9 +334,11 @@ impl Store {
 
     /// Check if the confirmed chain can be extended by the local candidate chain.
     ///
-    /// Accepts the effective candidate chain built locally (avoiding stale
-    /// reads from the DB within the same WriteBatch).
-    /// Returns true if the first candidate is a child of the top confirmed.
+    /// Returns true when the first candidate is a child of the top
+    /// confirmed AND all candidates (plus their uncles) have block
+    /// body data available in the store. The uncle check ensures the
+    /// PPLNS window can resolve all uncle entries when computing
+    /// payout distributions.
     pub(super) fn should_extend_confirmed(
         &self,
         candidates: &Chain,
@@ -338,11 +363,14 @@ impl Store {
 
         debug!("First candidate header {:?}", first_candidate_header);
 
-        // First candidate must be a child of top confirmed
-        Ok(
-            first_candidate_header.prev_share_blockhash == top_confirmed_hash
-                && top_confirmed_height + 1 == candidates[0].0,
-        )
+        if first_candidate_header.prev_share_blockhash != top_confirmed_hash
+            || top_confirmed_height + 1 != candidates[0].0
+        {
+            return Ok(false);
+        }
+
+        let candidate_hashes: Vec<BlockHash> = candidates.iter().map(|(_, hash)| *hash).collect();
+        Ok(self.all_block_and_uncle_data_available(&candidate_hashes))
     }
 
     /// Promote candidates to confirmed.

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -38,7 +38,7 @@ impl Store {
     /// or uncle body. Used by both `should_extend_confirmed` and
     /// `reorg_confirmed` to ensure PPLNS can resolve all uncle data
     /// before a block is promoted.
-    fn all_block_and_uncle_data_available(&self, blockhashes: &[BlockHash]) -> bool {
+    pub(super) fn all_block_and_uncle_data_available(&self, blockhashes: &[BlockHash]) -> bool {
         for blockhash in blockhashes {
             if !self.share_block_exists(blockhash) {
                 debug!("Block {blockhash} missing block data");

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -15,6 +15,7 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use super::{Chain, Height, Store, TopResult};
+use crate::node::request_response_handler::block_fetcher::FETCH_BATCH_SIZE;
 use crate::store::writer::StoreError;
 use tracing::debug;
 
@@ -34,9 +35,16 @@ impl Store {
     /// Returns the new confirmed height if it changed, or None if unchanged.
     /// Promote candidates to confirmed if conditions are met.
     ///
-    /// Reads candidate and confirmed state, then extends or reorgs the
-    /// confirmed chain from candidates whose block data (and uncle
-    /// data) is available.
+    /// First tries the candidate chain: reads candidate and confirmed
+    /// state, then extends or reorgs the confirmed chain from
+    /// candidates whose block data (and uncle data) is available.
+    ///
+    /// When no candidate blocks can be promoted (e.g. the candidate
+    /// chain is on a fork whose block data is missing), falls back to
+    /// confirming any block at `confirmed_height + 1` that is a child
+    /// of the confirmed tip and has all block and uncle data available.
+    /// This allows locally mined blocks to advance the confirmed chain
+    /// even when the candidate chain is stuck.
     ///
     /// Returns the new confirmed height if it changed, or None if unchanged.
     pub(crate) fn organise_block(
@@ -49,18 +57,54 @@ impl Store {
 
         let candidates = self.find_promotable_candidates(&top_confirmed)?;
 
-        if candidates.is_empty() {
-            return Ok(None);
+        if !candidates.is_empty() {
+            let promotable_height = candidates.last().unwrap().0;
+
+            if self.should_extend_confirmed(
+                &candidates,
+                top_confirmed.height,
+                top_confirmed.hash,
+            )? {
+                return self.extend_confirmed(promotable_height, &candidates, batch);
+            }
+
+            if self.should_reorg_confirmed(&top_confirmed, &candidates) {
+                return self.reorg_confirmed(&top_confirmed, &candidates, batch);
+            }
         }
 
-        let promotable_height = candidates.last().unwrap().0;
+        self.try_fallback_confirmation(&top_confirmed, batch)
+    }
 
-        if self.should_extend_confirmed(&candidates, top_confirmed.height, top_confirmed.hash)? {
-            return self.extend_confirmed(promotable_height, &candidates, batch);
-        }
+    /// Fallback: when no candidate chain blocks can be promoted, look
+    /// for any block at the next height that is a child of the
+    /// confirmed tip with all block and uncle data available.
+    fn try_fallback_confirmation(
+        &self,
+        top_confirmed: &TopResult,
+        batch: &mut rocksdb::WriteBatch,
+    ) -> Result<Option<Height>, StoreError> {
+        let next_height = top_confirmed.height + 1;
+        let height_entries = self.get_blockhashes_for_height_range(next_height, next_height);
 
-        if self.should_reorg_confirmed(&top_confirmed, &candidates) {
-            return self.reorg_confirmed(&top_confirmed, &candidates, batch);
+        for (_, blockhashes) in &height_entries {
+            for blockhash in blockhashes {
+                let Some(header) = self.get_share_header(blockhash)? else {
+                    continue;
+                };
+                if header.prev_share_blockhash != top_confirmed.hash {
+                    continue;
+                }
+                if !self.all_block_and_uncle_data_available(&[*blockhash]) {
+                    continue;
+                }
+                debug!(
+                    "Fallback confirmation: block {blockhash} at height {next_height} \
+                     extends confirmed tip"
+                );
+                let candidates = vec![(next_height, *blockhash)];
+                return self.extend_confirmed(next_height, &candidates, batch);
+            }
         }
 
         Ok(None)
@@ -81,7 +125,9 @@ impl Store {
             top_confirmed, top_candidate
         );
 
-        let all_candidates = self.get_candidates(top_confirmed.height + 1, top_candidate.height)?;
+        let scan_limit = top_confirmed.height + 1 + FETCH_BATCH_SIZE as u32;
+        let scan_end = std::cmp::min(scan_limit, top_candidate.height);
+        let all_candidates = self.get_candidates(top_confirmed.height + 1, scan_end)?;
         Ok(self.contiguous_candidates_with_block_data(&all_candidates))
     }
 
@@ -1080,6 +1126,87 @@ mod tests {
         store.commit_batch(batch).unwrap();
 
         // Now organise_block confirms from the candidate chain
+        let mut batch = Store::get_write_batch();
+        let result = store.organise_block(&mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        assert_eq!(result, Some(2));
+        assert_eq!(store.get_top_confirmed_height().unwrap(), 2);
+        assert_eq!(
+            store.get_confirmed_at_height(2).unwrap(),
+            local_block.block_hash()
+        );
+    }
+
+    /// Fallback confirmation when candidate chain is stuck on a fork
+    /// whose block data is missing and the local block cannot reorg
+    /// the candidate chain (equal cumulative work).
+    ///
+    /// Scenario:
+    /// - genesis -> share1(h:1) confirmed
+    /// - Candidate chain on a fork at h:1 (header only, no block data)
+    ///   with a second fork block at h:2 (header only) keeping the
+    ///   candidate tip ahead
+    /// - Local block at h:2, parent = share1, WITH block data
+    /// - Local block has equal cumulative work so cannot reorg candidates
+    /// - organise_block falls back to confirming the local block
+    #[test]
+    fn test_fallback_confirms_block_when_candidate_chain_stuck() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // share1: confirmed at h:1
+        let share1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695792)
+            .build();
+        store.push_to_confirmed_chain(&share1).unwrap();
+        assert_eq!(store.get_top_confirmed_height().unwrap(), 1);
+
+        // fork_share: different child of genesis on a competing fork.
+        // Header only, no block data.
+        let fork_share = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695799)
+            .build();
+        store.push_to_candidate_chain(&fork_share).unwrap();
+
+        // fork_share2: extends fork to h:2 (header only, no block data).
+        // This keeps the candidate tip ahead of confirmed.
+        let fork_share2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(fork_share.block_hash().to_string())
+            .nonce(0xe9695800)
+            .build();
+        store.push_to_candidate_chain(&fork_share2).unwrap();
+        assert_eq!(store.get_top_candidate_height().ok(), Some(2));
+
+        // local_block: child of share1 (confirmed tip), WITH block data.
+        // It has equal cumulative work to fork_share at the same height,
+        // so organise_header cannot reorg the candidate chain.
+        let local_block = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share1.block_hash().to_string())
+            .nonce(0xe9695801)
+            .build();
+        let mut batch = Store::get_write_batch();
+        store.add_share_block(&local_block, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+        let mut batch = Store::get_write_batch();
+        store
+            .organise_header(&local_block.header, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Candidate chain still on the fork (local block could not reorg)
+        assert!(!store.share_block_exists(&fork_share.block_hash()));
+
+        // organise_block: candidate chain has no block data at h:1,
+        // so find_promotable_candidates returns empty. Fallback finds
+        // local_block at h:2 with parent = confirmed tip and confirms it.
         let mut batch = Store::get_write_batch();
         let result = store.organise_block(&mut batch).unwrap();
         store.commit_batch(batch).unwrap();

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -22,31 +22,20 @@ use tracing::debug;
 impl Store {
     /// Promote candidates to confirmed if conditions are met.
     ///
-    /// When `promoted_header` is provided and it directly extends the
-    /// confirmed tip, the block is confirmed immediately without
-    /// consulting the candidate chain. This prevents the node from
-    /// getting stuck when the candidate chain is on a fork whose blocks
-    /// lack block data.
-    ///
-    /// Otherwise falls back to the candidate chain: reads candidate and
-    /// confirmed state, then extends or reorgs the confirmed chain from
-    /// candidates whose block data is available.
-    ///
-    /// Returns the new confirmed height if it changed, or None if unchanged.
-    /// Promote candidates to confirmed if conditions are met.
-    ///
-    /// First tries the candidate chain: reads candidate and confirmed
-    /// state, then extends or reorgs the confirmed chain from
-    /// candidates whose block data (and uncle data) is available.
+    /// Strictly follows the candidate chain order: finds the
+    /// contiguous prefix of candidates (from confirmed tip + 1) that
+    /// have block and uncle data available, then extends or reorgs
+    /// the confirmed chain accordingly.
     ///
     /// When no candidate blocks can be promoted (e.g. the candidate
     /// chain is on a fork whose block data is missing), falls back to
-    /// confirming any block at `confirmed_height + 1` that is a child
-    /// of the confirmed tip and has all block and uncle data available.
-    /// This allows locally mined blocks to advance the confirmed chain
-    /// even when the candidate chain is stuck.
+    /// confirming any block at confirmed_height + 1 that is a child
+    /// of the confirmed tip and has all block and uncle data
+    /// available. This allows locally mined blocks to advance the
+    /// confirmed chain even when the candidate chain is stuck.
     ///
-    /// Returns the new confirmed height if it changed, or None if unchanged.
+    /// Returns the new confirmed height if it changed, or None if
+    /// unchanged.
     pub(crate) fn organise_block(
         &self,
         batch: &mut rocksdb::WriteBatch,

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -15,7 +15,6 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use super::{Chain, Height, Store, TopResult};
-use crate::shares::share_block::ShareHeader;
 use crate::store::writer::StoreError;
 use tracing::debug;
 
@@ -33,26 +32,22 @@ impl Store {
     /// candidates whose block data is available.
     ///
     /// Returns the new confirmed height if it changed, or None if unchanged.
+    /// Promote candidates to confirmed if conditions are met.
+    ///
+    /// Reads candidate and confirmed state, then extends or reorgs the
+    /// confirmed chain from candidates whose block data (and uncle
+    /// data) is available.
+    ///
+    /// Returns the new confirmed height if it changed, or None if unchanged.
     pub(crate) fn organise_block(
         &self,
-        promoted_header: Option<&ShareHeader>,
         batch: &mut rocksdb::WriteBatch,
     ) -> Result<Option<Height>, StoreError> {
         let top_confirmed = self.get_top_confirmed().map_err(|_| {
             StoreError::Database("organise_block called without a genesis block".into())
         })?;
 
-        let candidates = if let Some(header) = promoted_header {
-            self.build_direct_candidates(header, &top_confirmed)
-        } else {
-            Vec::new()
-        };
-
-        let candidates = if candidates.is_empty() {
-            self.find_promotable_candidates(&top_confirmed)?
-        } else {
-            candidates
-        };
+        let candidates = self.find_promotable_candidates(&top_confirmed)?;
 
         if candidates.is_empty() {
             return Ok(None);
@@ -88,40 +83,6 @@ impl Store {
 
         let all_candidates = self.get_candidates(top_confirmed.height + 1, top_candidate.height)?;
         Ok(self.contiguous_candidates_with_block_data(&all_candidates))
-    }
-
-    /// Build a single-element candidates vec from the promoted block
-    /// if it directly extends the confirmed tip.
-    ///
-    /// Returns an empty vec when the promoted block is not a child of
-    /// the confirmed tip or its metadata is not ready. This allows the
-    /// caller to fall through to the normal candidate search.
-    fn build_direct_candidates(
-        &self,
-        promoted_header: &ShareHeader,
-        top_confirmed: &TopResult,
-    ) -> Chain {
-        if promoted_header.prev_share_blockhash != top_confirmed.hash {
-            return Vec::new();
-        }
-
-        let blockhash = promoted_header.block_hash();
-        let Ok(metadata) = self.get_block_metadata(&blockhash) else {
-            return Vec::new();
-        };
-        let Some(expected_height) = metadata.expected_height else {
-            return Vec::new();
-        };
-
-        if expected_height != top_confirmed.height + 1 {
-            return Vec::new();
-        }
-
-        debug!(
-            "Direct confirmed extension: block {blockhash} at height {expected_height} \
-             extends confirmed tip"
-        );
-        vec![(expected_height, blockhash)]
     }
 
     /// Return the contiguous prefix of candidates that have full block
@@ -175,7 +136,7 @@ mod tests {
         // Now confirmed == candidate tip. Calling organise_block again
         // must return None since there is nothing new to promote.
         let mut batch = Store::get_write_batch();
-        let result = store.organise_block(None, &mut batch).unwrap();
+        let result = store.organise_block(&mut batch).unwrap();
         assert_eq!(
             result, None,
             "organise_block should return None when confirmed has caught up to candidates"
@@ -198,7 +159,7 @@ mod tests {
         assert!(store.get_top_candidate().is_err());
 
         let mut batch = Store::get_write_batch();
-        let result = store.organise_block(None, &mut batch).unwrap();
+        let result = store.organise_block(&mut batch).unwrap();
         assert_eq!(
             result, None,
             "organise_block should return None when no candidate chain exists"
@@ -939,7 +900,7 @@ mod tests {
 
         // organise_block should not promote since first candidate has no block data
         let mut batch = Store::get_write_batch();
-        let result = store.organise_block(None, &mut batch).unwrap();
+        let result = store.organise_block(&mut batch).unwrap();
         assert_eq!(
             result, None,
             "organise_block should not promote candidates without block data"
@@ -993,7 +954,7 @@ mod tests {
 
         // organise_block should promote only share1 and share2
         let mut batch = Store::get_write_batch();
-        let result = store.organise_block(None, &mut batch).unwrap();
+        let result = store.organise_block(&mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         assert_eq!(result, Some(2));
@@ -1057,16 +1018,17 @@ mod tests {
         assert!(store.get_confirmed_at_height(3).is_err());
     }
 
-    /// Direct confirmed extension bypasses a stuck candidate chain.
+    /// Candidate chain reorg allows confirmation when the old
+    /// candidate fork lacks block data.
     ///
-    /// Scenario
+    /// Scenario:
     /// - genesis -> share1(h:1) confirmed
-    /// - Candidate chain on a different fork (header-only, no block data)
-    /// - Local block at h:2 with parent = share1 (confirmed tip), with block data
-    /// - organise_block with promoted_header = local block
-    /// - Confirmed extends to h:2 with the local block
+    /// - Candidate chain on a fork (header-only, no block data)
+    /// - Local block at h:2 with parent = share1, with block data
+    /// - organise_header reorgs candidate chain to include local block
+    /// - organise_block confirms from the new candidate chain
     #[test]
-    fn test_direct_confirmed_extension_bypasses_stuck_candidates() {
+    fn test_candidate_reorg_allows_confirmation_after_stuck_fork() {
         let temp_dir = tempdir().unwrap();
         let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
 
@@ -1084,56 +1046,42 @@ mod tests {
         assert_eq!(store.get_top_confirmed_height().unwrap(), 1);
 
         // fork_share: different child of genesis, candidate at h:1 on a
-        // different fork. Push header only (no block data) to simulate
-        // a peer's fork with headers but no bodies.
+        // different fork. Push header only (no block data).
         let fork_share = TestShareBlockBuilder::new()
             .prev_share_blockhash(genesis.block_hash().to_string())
             .nonce(0xe9695799)
             .build();
         store.push_to_candidate_chain(&fork_share).unwrap();
 
-        // fork_share2: extends the fork to h:2 (header only, no block data)
-        let fork_share2 = TestShareBlockBuilder::new()
-            .prev_share_blockhash(fork_share.block_hash().to_string())
-            .nonce(0xe9695800)
-            .build();
-        store.push_to_candidate_chain(&fork_share2).unwrap();
-
-        // Candidate tip is now on the fork at h:2 with no block data
-        assert_eq!(store.get_top_candidate_height().ok(), Some(2));
+        // Candidate tip is on the fork at h:1 with no block data
         assert!(!store.share_block_exists(&fork_share.block_hash()));
 
+        // organise_block returns None: candidate has no block data
+        let mut batch = Store::get_write_batch();
+        let result = store.organise_block(&mut batch).unwrap();
+        assert_eq!(result, None, "Candidates stuck on fork with no data");
+
         // local_block: child of share1 (confirmed tip), WITH block data.
-        // This simulates a locally mined block.
         let local_block = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(0xe9695801)
             .build();
-        // Store block data
         let mut batch = Store::get_write_batch();
         store.add_share_block(&local_block, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
-        // Initialise metadata via organise_header
+
+        // organise_header reorgs candidate chain if local_block has
+        // more cumulative work than the fork. After this, the candidate
+        // chain includes local_block.
         let mut batch = Store::get_write_batch();
         store
             .organise_header(&local_block.header, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
-        // organise_block without promoted_header returns None (candidates
-        // stuck on fork with no block data)
+        // Now organise_block confirms from the candidate chain
         let mut batch = Store::get_write_batch();
-        let result = store.organise_block(None, &mut batch).unwrap();
-        assert_eq!(
-            result, None,
-            "Without promoted_header, candidates are stuck"
-        );
-
-        // organise_block WITH promoted_header should directly extend confirmed
-        let mut batch = Store::get_write_batch();
-        let result = store
-            .organise_block(Some(&local_block.header), &mut batch)
-            .unwrap();
+        let result = store.organise_block(&mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
         assert_eq!(result, Some(2));

--- a/p2poolv2_lib/src/store/writer/handle.rs
+++ b/p2poolv2_lib/src/store/writer/handle.rs
@@ -323,7 +323,9 @@ impl StoreHandle {
 
     /// Promote candidates to confirmed.
     /// Returns the confirmed chain height after organising, if changed.
-    /// Confirms blocks strictly from the candidate chain order.
+    /// Prefers the candidate chain order. Falls back to any child of
+    /// the confirmed tip with full block and uncle data when no
+    /// candidate blocks can be promoted.
     pub async fn organise_block(&self) -> Result<Option<u32>, StoreError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.write_tx

--- a/p2poolv2_lib/src/store/writer/handle.rs
+++ b/p2poolv2_lib/src/store/writer/handle.rs
@@ -323,18 +323,11 @@ impl StoreHandle {
 
     /// Promote candidates to confirmed.
     /// Returns the confirmed chain height after organising, if changed.
-    /// When promoted_header is provided, the block can be confirmed
-    /// directly if it extends the confirmed tip.
-    pub async fn organise_block(
-        &self,
-        promoted_header: Option<ShareHeader>,
-    ) -> Result<Option<u32>, StoreError> {
+    /// Confirms blocks strictly from the candidate chain order.
+    pub async fn organise_block(&self) -> Result<Option<u32>, StoreError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.write_tx
-            .send(WriteCommand::OrganiseBlock {
-                promoted_header,
-                reply: reply_tx,
-            })
+            .send(WriteCommand::OrganiseBlock { reply: reply_tx })
             .map_err(|_| StoreError::ChannelClosed)?;
         reply_rx.await.map_err(|_| StoreError::ChannelClosed)?
     }
@@ -392,7 +385,7 @@ mockall::mock! {
 
         // Serialized writes (async)
         pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;
-        pub async fn organise_block(&self, promoted_header: Option<ShareHeader>) -> Result<Option<u32>, StoreError>;
+        pub async fn organise_block(&self) -> Result<Option<u32>, StoreError>;
         pub async fn add_share_block(&self, share: ShareBlock) -> Result<(), StoreError>;
         pub async fn add_share_block_and_organise_header(&self, share: ShareBlock) -> Result<Option<u32>, StoreError>;
         pub async fn setup_genesis(&self, genesis: ShareBlock) -> Result<(), StoreError>;

--- a/p2poolv2_lib/src/store/writer/mod.rs
+++ b/p2poolv2_lib/src/store/writer/mod.rs
@@ -139,7 +139,9 @@ pub enum WriteCommand {
 
     /// Promote candidates to confirmed.
     /// Returns the confirmed chain height after organising, if changed.
-    /// Confirms blocks strictly from the candidate chain order.
+    /// Prefers the candidate chain order. Falls back to any child of
+    /// the confirmed tip with full block and uncle data when no
+    /// candidate blocks can be promoted.
     OrganiseBlock {
         reply: oneshot::Sender<Result<Option<u32>, StoreError>>,
     },

--- a/p2poolv2_lib/src/store/writer/mod.rs
+++ b/p2poolv2_lib/src/store/writer/mod.rs
@@ -139,10 +139,8 @@ pub enum WriteCommand {
 
     /// Promote candidates to confirmed.
     /// Returns the confirmed chain height after organising, if changed.
-    /// When promoted_header is provided, the block can be confirmed
-    /// directly if it extends the confirmed tip, bypassing stuck candidates.
+    /// Confirms blocks strictly from the candidate chain order.
     OrganiseBlock {
-        promoted_header: Option<ShareHeader>,
         reply: oneshot::Sender<Result<Option<u32>, StoreError>>,
     },
 }
@@ -267,18 +265,12 @@ impl StoreWriter {
                 let _ = reply.send(result);
             }
 
-            WriteCommand::OrganiseBlock {
-                promoted_header,
-                reply,
-            } => {
+            WriteCommand::OrganiseBlock { reply } => {
                 let mut batch = Store::get_write_batch();
-                let result = self
-                    .store
-                    .organise_block(promoted_header.as_ref(), &mut batch)
-                    .and_then(|height| {
-                        self.store.commit_batch(batch).map_err(StoreError::from)?;
-                        Ok(height)
-                    });
+                let result = self.store.organise_block(&mut batch).and_then(|height| {
+                    self.store.commit_batch(batch).map_err(StoreError::from)?;
+                    Ok(height)
+                });
                 let _ = reply.send(result);
             }
         }

--- a/p2poolv2_tests/src/node_swarm_test.rs
+++ b/p2poolv2_tests/src/node_swarm_test.rs
@@ -268,7 +268,7 @@ async fn test_three_nodes_share_sync() {
             .organise_header(share_block.header.clone())
             .await
             .unwrap();
-        chain_store_handle1.organise_block(None).await.unwrap();
+        chain_store_handle1.organise_block().await.unwrap();
     }
 
     // Verify node 1 has all shares


### PR DESCRIPTION
Confirm blocks from candidate chain so we don't go down the wrong branches.

Also trigger confirmation whenever candidate change changes or blocks are buffered.