### PR TITLE
Skip pool difficulty check in standalone mode

### DIFF
--- a/p2poolv2_config/src/lib.rs
+++ b/p2poolv2_config/src/lib.rs
@@ -51,6 +51,28 @@ pub fn parse_address(address: &str, network: Network) -> Result<Address, ConfigE
 /// Max length for pool signature P2Poolv2 + 8 more bytes for users to add
 const MAX_POOL_SIGNATURE_LENGTH: usize = 16;
 
+/// Pool operating mode.
+///
+/// P2Poolv2 mode runs the full share chain with ASERT difficulty and
+/// P2P networking.  Hydrapool mode runs a standalone PPLNS pool where
+/// the share chain ASERT difficulty is not enforced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PoolMode {
+    /// Full P2Poolv2 share chain mode (default)
+    #[serde(alias = "P2Poolv2", alias = "p2poolv2")]
+    P2poolv2,
+    /// Standalone PPLNS pool mode
+    #[serde(alias = "Hydrapool", alias = "hydrapool")]
+    Hydrapool,
+}
+
+impl Default for PoolMode {
+    fn default() -> Self {
+        PoolMode::P2poolv2
+    }
+}
+
 /// Marker type for raw (unparsed) StratumConfig state
 #[derive(Debug, Clone, Default)]
 pub struct Raw;
@@ -104,6 +126,9 @@ pub struct StratumConfig<State = Raw> {
     /// connections. Set to false when bootstrapping a new network.
     #[serde(default = "default_wait_for_chain_sync")]
     pub wait_for_chain_sync: bool,
+    /// Pool operating mode. Defaults to P2Poolv2 when not specified.
+    #[serde(default)]
+    pub mode: PoolMode,
 
     // Parsed addresses - only available when State = Parsed
     #[serde(skip)]
@@ -174,6 +199,7 @@ impl StratumConfig<Raw> {
             pool_signature: self.pool_signature,
             max_connections: self.max_connections,
             wait_for_chain_sync: self.wait_for_chain_sync,
+            mode: self.mode,
             bootstrap_address_parsed: Some(bootstrap_address_parsed),
             donation_address_parsed,
             fee_address_parsed,
@@ -226,6 +252,7 @@ impl StratumConfig<Raw> {
             pool_signature: None,
             max_connections: None,
             wait_for_chain_sync: true,
+            mode: PoolMode::default(),
             bootstrap_address_parsed: None,
             donation_address_parsed: None,
             fee_address_parsed: None,

--- a/p2poolv2_config/src/lib.rs
+++ b/p2poolv2_config/src/lib.rs
@@ -841,5 +841,4 @@ mod tests {
         let parsed = config.parse().unwrap();
         assert_eq!(parsed.mode, PoolMode::Hydrapool);
     }
-
 }

--- a/p2poolv2_config/src/lib.rs
+++ b/p2poolv2_config/src/lib.rs
@@ -821,4 +821,25 @@ mod tests {
         assert!(parsed.donation_address_parsed.is_none());
         assert!(parsed.fee_address_parsed.is_none());
     }
+
+    #[test]
+    fn test_pool_mode_defaults_to_p2poolv2_when_absent() {
+        let config = Config::load("../config.sample.toml").unwrap();
+        assert_eq!(config.stratum.mode, PoolMode::P2poolv2);
+    }
+
+    #[test]
+    fn test_pool_mode_defaults_to_p2poolv2_in_test_helper() {
+        let config = StratumConfig::<Raw>::new_for_test_default();
+        assert_eq!(config.mode, PoolMode::P2poolv2);
+    }
+
+    #[test]
+    fn test_pool_mode_survives_parse() {
+        let mut config = StratumConfig::<Raw>::new_for_test_default();
+        config.mode = PoolMode::Hydrapool;
+        let parsed = config.parse().unwrap();
+        assert_eq!(parsed.mode, PoolMode::Hydrapool);
+    }
+
 }

--- a/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
@@ -154,6 +154,7 @@ mod tests {
     use crate::accounting::stats::metrics;
     use crate::stratum::difficulty_adjuster::DifficultyAdjuster;
     use crate::stratum::messages::Id;
+    use crate::stratum::server::PoolMode;
     use crate::stratum::server::StratumContext;
     use crate::stratum::work::tracker::start_tracker_actor;
     use crate::test_utils::setup_test_chain_store_handle;
@@ -198,6 +199,7 @@ mod tests {
             network: bitcoin::network::Network::Testnet,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Execute
@@ -296,6 +298,7 @@ mod tests {
             network: bitcoin::network::Network::Testnet,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Execute
@@ -433,6 +436,7 @@ mod tests {
             network: bitcoin::network::Network::Testnet,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Execute
@@ -529,6 +533,7 @@ mod tests {
             network: bitcoin::network::Network::Testnet,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let messages = handle_authorize(request, &mut session, ctx).await.unwrap();
@@ -586,6 +591,7 @@ mod tests {
             network: bitcoin::network::Network::Testnet,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let messages = handle_authorize(request, &mut session, ctx).await.unwrap();
@@ -645,6 +651,7 @@ mod tests {
             network: bitcoin::network::Network::Testnet,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Execute
@@ -708,6 +715,7 @@ mod tests {
             network: bitcoin::network::Network::Testnet,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let result = handle_authorize(request, &mut session, ctx).await;

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -276,7 +276,6 @@ mod handle_submit_tests {
     use crate::stratum::difficulty_adjuster::{DifficultyAdjuster, MockDifficultyAdjusterTrait};
     use crate::stratum::messages::Id;
     use crate::stratum::messages::SetDifficultyNotification;
-    use crate::stratum::server::PoolMode;
     use crate::stratum::session::Session;
     use crate::stratum::work::gbt::build_merkle_branches_for_template;
     use crate::stratum::work::tracker::start_tracker_actor;

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -270,6 +270,7 @@ mod handle_submit_tests {
     use crate::stratum::difficulty_adjuster::{DifficultyAdjuster, MockDifficultyAdjusterTrait};
     use crate::stratum::messages::Id;
     use crate::stratum::messages::SetDifficultyNotification;
+    use crate::stratum::server::PoolMode;
     use crate::stratum::session::Session;
     use crate::stratum::work::gbt::build_merkle_branches_for_template;
     use crate::stratum::work::tracker::start_tracker_actor;
@@ -354,6 +355,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Signet,
             metrics: metrics_handle.clone(),
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let message = handle_submit(submit, &mut session, ctx).await.unwrap();
@@ -448,6 +450,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Signet,
             metrics: metrics_handle.clone(),
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let response = handle_submit(submit, &mut session, ctx).await.unwrap();
@@ -542,6 +545,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Signet,
             metrics: metrics_handle.clone(),
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let response = handle_submit(submit, &mut session, ctx).await.unwrap();
@@ -634,6 +638,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Signet,
             metrics: metrics_handle.clone(),
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let message = handle_submit(submit, &mut session, ctx).await.unwrap();
@@ -702,6 +707,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Signet,
             metrics: metrics_handle.clone(),
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let message = handle_submit(submit, &mut session, ctx).await.unwrap();
@@ -778,6 +784,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Signet,
             metrics: metrics_handle.clone(),
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let message = handle_submit(submit, &mut session, ctx).await.unwrap();
@@ -870,6 +877,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Signet,
             metrics: metrics_handle.clone(),
             chain_store_handle: chain_store_handle.clone(),
+            mode: PoolMode::P2poolv2,
         };
 
         let message = handle_submit(submit.clone(), &mut session, ctx)
@@ -906,6 +914,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Signet,
             metrics: metrics_handle.clone(),
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let message2 = handle_submit(submit, &mut session, ctx2).await.unwrap();
@@ -988,6 +997,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Signet,
             metrics: metrics_handle.clone(),
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let message = handle_submit(submit, &mut session, ctx).await.unwrap();
@@ -1056,6 +1066,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Regtest,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let messages = handle_submit(submit, &mut session, ctx).await.unwrap();
@@ -1136,6 +1147,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Signet,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Verify the inserted job is properly registered
@@ -1233,6 +1245,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Regtest,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let messages = handle_submit(submit, &mut session, ctx).await.unwrap();
@@ -1314,6 +1327,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Regtest,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let messages = handle_submit(submit, &mut session, ctx).await.unwrap();
@@ -1396,6 +1410,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Regtest,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let messages = handle_submit(submit, &mut session, ctx).await.unwrap();
@@ -1456,6 +1471,7 @@ mod handle_submit_tests {
             network: bitcoin::network::Network::Regtest,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let messages = handle_submit(submit, &mut session, ctx).await.unwrap();

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -15,6 +15,7 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::accounting::payout::simple_pplns::SimplePplnsShare;
+use crate::config::PoolMode;
 use crate::shares::extranonce::Extranonce;
 use crate::stratum::{
     difficulty_adjuster::DifficultyAdjusterTrait,
@@ -127,9 +128,13 @@ pub(crate) async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
         submit_block(&block, &stratum_context.bitcoindrpc_client).await;
     }
 
-    // In p2poolv2 mode, reject shares that do not meet the pool difficulty target.
+    // In P2Poolv2 mode, reject shares that do not meet the pool difficulty target.
     // The share commitment carries the ASERT-computed pool target (bits).
-    if let Some(commitment) = &job.share_commitment {
+    // In Hydrapool mode this check is skipped so that low-hashrate miners
+    // are not rejected when a high-hashrate miner raises the ASERT difficulty.
+    if stratum_context.mode == PoolMode::P2poolv2
+        && let Some(commitment) = &job.share_commitment
+    {
         let pool_target = bitcoin::Target::from_compact(commitment.bits);
         if !pool_target.is_met_by(validation_result.header.block_hash()) {
             debug!(
@@ -267,6 +272,7 @@ fn get_true_difficulty(hash: &bitcoin::BlockHash) -> u128 {
 mod handle_submit_tests {
     use super::*;
     use crate::accounting::stats::metrics;
+    use crate::shares::share_commitment::ShareCommitment;
     use crate::stratum::difficulty_adjuster::{DifficultyAdjuster, MockDifficultyAdjusterTrait};
     use crate::stratum::messages::Id;
     use crate::stratum::messages::SetDifficultyNotification;
@@ -1483,5 +1489,170 @@ mod handle_submit_tests {
         let err = response.error.as_ref().unwrap();
         assert_eq!(err.code, 24, "should be UnauthorizedWorker (code 24)");
         assert_eq!(err.message, "Not authorized");
+    }
+
+    /// Build a commitment with an impossibly hard pool target so that
+    /// any test share will fail the ASERT pool difficulty check.
+    fn create_hard_pool_difficulty_commitment() -> ShareCommitment {
+        let mut commitment = create_test_commitment();
+        // 0x01003456 is an extremely hard target that no test share can meet
+        commitment.bits = bitcoin::CompactTarget::from_consensus(0x01003456);
+        commitment
+    }
+
+    #[tokio::test]
+    async fn test_p2poolv2_mode_rejects_share_not_meeting_pool_difficulty() {
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
+        let tracker_handle = start_tracker_actor();
+
+        let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+        mock_submit_block_with_any_body(&mock_server).await;
+
+        let (template, notify, submit, authorize_response) =
+            load_valid_stratum_work_components("../p2poolv2_tests/test_data/validation/stratum/b/");
+
+        let enonce1 = authorize_response.result.unwrap()[1].clone();
+        let enonce1: &str = enonce1.as_str().unwrap();
+        session.enonce1 =
+            u32::from_le_bytes(hex::decode(enonce1).unwrap().as_slice().try_into().unwrap());
+        session.enonce1_hex = enonce1.to_string();
+        session.btcaddress = Some("tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string());
+        session.user_id = Some(1);
+
+        let job_id = JobId(u64::from_str_radix(&notify.params.job_id, 16).unwrap());
+
+        let merkle_branches = build_merkle_branches_for_template(&template)
+            .into_iter()
+            .map(bitcoin::TxMerkleNode::from_raw_hash)
+            .collect();
+        let _ = tracker_handle.insert_job(
+            Arc::new(template),
+            notify.params.coinbase1.to_string(),
+            notify.params.coinbase2.to_string(),
+            Some(create_hard_pool_difficulty_commitment()),
+            TEST_COINBASE_NSECS,
+            merkle_branches,
+            job_id,
+        );
+
+        let (emissions_tx, _emissions_rx) = mpsc::channel(10);
+        let stats_dir = tempfile::tempdir().unwrap();
+        let metrics_handle = metrics::start_metrics(stats_dir.path().to_str().unwrap().to_string())
+            .await
+            .unwrap();
+        let (notify_tx, _notify_rx) = mpsc::channel(10);
+        let (chain_store_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+
+        let ctx = StratumContext {
+            notify_tx,
+            tracker_handle: tracker_handle.clone(),
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
+            start_difficulty: 1,
+            minimum_difficulty: 1,
+            maximum_difficulty: None,
+            ignore_difficulty: false,
+            validate_addresses: true,
+            emissions_tx,
+            network: bitcoin::network::Network::Signet,
+            metrics: metrics_handle,
+            chain_store_handle,
+            mode: PoolMode::P2poolv2,
+        };
+
+        let messages = handle_submit(submit, &mut session, ctx).await.unwrap();
+        let response = match &messages[..] {
+            [Message::Response(r)] => r,
+            _ => panic!("expected Response"),
+        };
+        assert_eq!(response.result, None, "should be an error, not a result");
+        let err = response.error.as_ref().unwrap();
+        assert_eq!(err.code, 23, "should be LowDifficultyShare (code 23)");
+    }
+
+    #[tokio::test]
+    async fn test_hydrapool_mode_accepts_share_despite_hard_pool_difficulty() {
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
+        session.subscribed = true;
+        let tracker_handle = start_tracker_actor();
+
+        let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+        mock_submit_block_with_any_body(&mock_server).await;
+
+        let (template, notify, submit, authorize_response) =
+            load_valid_stratum_work_components("../p2poolv2_tests/test_data/validation/stratum/b/");
+
+        let enonce1 = authorize_response.result.unwrap()[1].clone();
+        let enonce1: &str = enonce1.as_str().unwrap();
+        session.enonce1 =
+            u32::from_le_bytes(hex::decode(enonce1).unwrap().as_slice().try_into().unwrap());
+        session.enonce1_hex = enonce1.to_string();
+        session.btcaddress = Some("tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string());
+        session.user_id = Some(1);
+
+        let job_id = JobId(u64::from_str_radix(&notify.params.job_id, 16).unwrap());
+
+        let merkle_branches = build_merkle_branches_for_template(&template)
+            .into_iter()
+            .map(bitcoin::TxMerkleNode::from_raw_hash)
+            .collect();
+        let _ = tracker_handle.insert_job(
+            Arc::new(template),
+            notify.params.coinbase1.to_string(),
+            notify.params.coinbase2.to_string(),
+            Some(create_hard_pool_difficulty_commitment()),
+            TEST_COINBASE_NSECS,
+            merkle_branches,
+            job_id,
+        );
+
+        let (emissions_tx, mut emissions_rx) = mpsc::channel(10);
+        let stats_dir = tempfile::tempdir().unwrap();
+        let metrics_handle = metrics::start_metrics(stats_dir.path().to_str().unwrap().to_string())
+            .await
+            .unwrap();
+        let (notify_tx, _notify_rx) = mpsc::channel(10);
+        let (chain_store_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+
+        let ctx = StratumContext {
+            notify_tx,
+            tracker_handle: tracker_handle.clone(),
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
+            start_difficulty: 1,
+            minimum_difficulty: 1,
+            maximum_difficulty: None,
+            ignore_difficulty: false,
+            validate_addresses: true,
+            emissions_tx,
+            network: bitcoin::network::Network::Signet,
+            metrics: metrics_handle,
+            chain_store_handle,
+            mode: PoolMode::Hydrapool,
+        };
+
+        let messages = handle_submit(submit, &mut session, ctx).await.unwrap();
+        let response = match &messages[..] {
+            [Message::Response(response)] => response,
+            _ => panic!("expected Response"),
+        };
+        // Share is accepted despite not meeting pool difficulty
+        assert_eq!(response.result, Some(json!(true)));
+
+        // Share was emitted for PPLNS accounting
+        let share = emissions_rx.try_recv().unwrap();
+        assert_eq!(
+            share.pplns.btcaddress,
+            Some("tb1q3udk7r26qs32ltf9nmqrjaaa7tr55qmkk30q5d".to_string())
+        );
     }
 }

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -15,6 +15,7 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::accounting::stats::metrics;
+pub use crate::config::PoolMode;
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 #[cfg(not(test))]
 use crate::stratum::client_connections::ClientConnectionsHandle;
@@ -57,6 +58,7 @@ pub struct StratumServer {
     pub version_mask: i32,
     pub max_connections: Option<u32>,
     pub wait_for_chain_sync: bool,
+    pub mode: PoolMode,
     shutdown_rx: oneshot::Receiver<()>,
     connections_handle: ClientConnectionsHandle,
     emissions_tx: EmissionSender,
@@ -82,6 +84,7 @@ pub struct StratumServerBuilder {
     emissions_tx: Option<EmissionSender>,
     zmqpubhashblock: Option<String>,
     chain_store_handle: Option<ChainStoreHandle>,
+    mode: Option<PoolMode>,
 }
 
 impl StratumServerBuilder {
@@ -165,6 +168,11 @@ impl StratumServerBuilder {
         self
     }
 
+    pub fn mode(mut self, mode: PoolMode) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+
     pub async fn build(self) -> Result<StratumServer, Box<dyn std::error::Error + Send + Sync>> {
         Ok(StratumServer {
             hostname: self.hostname.ok_or("hostname is required")?,
@@ -189,6 +197,7 @@ impl StratumServerBuilder {
             emissions_tx: self.emissions_tx.ok_or("shares_tx is required")?,
             max_connections: self.max_connections.unwrap_or(None),
             wait_for_chain_sync: self.wait_for_chain_sync.unwrap_or(true),
+            mode: self.mode.unwrap_or_default(),
             chain_store_handle: self
                 .chain_store_handle
                 .ok_or("chain store handle is required")?,
@@ -310,6 +319,7 @@ impl StratumServer {
                                         network: self.network,
                                         metrics: metrics.clone(),
                                         chain_store_handle: self.chain_store_handle.clone(),
+                                        mode: self.mode,
                                     };
                                     accept_connection(
                                         stream,
@@ -422,6 +432,7 @@ pub(crate) struct StratumContext {
     pub network: bitcoin::network::Network,
     pub metrics: metrics::MetricsHandle,
     pub chain_store_handle: ChainStoreHandle,
+    pub mode: PoolMode,
 }
 
 /// Handles a single connection to the Stratum server.  This function
@@ -775,6 +786,7 @@ mod stratum_server_tests {
             emissions_tx,
             network: bitcoin::network::Network::Regtest,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Run the handler
@@ -897,6 +909,7 @@ mod stratum_server_tests {
             emissions_tx,
             network: bitcoin::network::Network::Regtest,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Run the handler
@@ -980,6 +993,7 @@ mod stratum_server_tests {
             metrics: metrics_handle,
             network: bitcoin::network::Network::Regtest,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Run the handler
@@ -1061,6 +1075,7 @@ mod stratum_server_tests {
             network: bitcoin::network::Network::Regtest,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Run the handler
@@ -1162,6 +1177,7 @@ mod stratum_server_tests {
             network: bitcoin::network::Network::Testnet,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Spawn the handler in a separate task
@@ -1282,6 +1298,7 @@ mod stratum_server_tests {
             network: bitcoin::network::Network::Regtest,
             metrics: metrics_handle,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Spawn the handler in a separate task
@@ -1392,6 +1409,7 @@ mod stratum_server_tests {
                 emissions_tx,
                 network: bitcoin::network::Network::Regtest,
                 chain_store_handle,
+                mode: PoolMode::P2poolv2,
             };
 
             // wait for subscribe/authorize messages
@@ -1474,6 +1492,7 @@ mod stratum_server_tests {
                 emissions_tx,
                 network: bitcoin::network::Network::Signet,
                 chain_store_handle,
+                mode: PoolMode::P2poolv2,
             };
 
             let subscribe_message =
@@ -1614,6 +1633,7 @@ mod stratum_server_tests {
             emissions_tx,
             network: bitcoin::network::Network::Testnet,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Pre-load a template before starting handle_connection
@@ -1743,6 +1763,7 @@ mod stratum_server_tests {
             emissions_tx,
             network: bitcoin::network::Network::Testnet,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         // Start with no template - will send one after authorization
@@ -1882,6 +1903,7 @@ mod stratum_server_tests {
             emissions_tx,
             network: bitcoin::network::Network::Regtest,
             chain_store_handle,
+            mode: PoolMode::P2poolv2,
         };
 
         let (template_tx, template_rx) = watch::channel(None);

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -475,8 +475,8 @@ where
     monitor.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     monitor.tick().await;
 
-    // In Hydrapool mode pass None so share_commitment is not built,
-    // which skips the ASERT pool difficulty check on share submission.
+    // In Hydrapool mode pass None so the commitment hash is not
+    // embedded in the coinbase, saving bytes in coinbase.
     let is_hydrapool = ctx.mode == PoolMode::Hydrapool;
 
     // Process each line as it arrives

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -475,6 +475,10 @@ where
     monitor.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     monitor.tick().await;
 
+    // In Hydrapool mode pass None so share_commitment is not built,
+    // which skips the ASERT pool difficulty check on share submission.
+    let is_hydrapool = ctx.mode == PoolMode::Hydrapool;
+
     // Process each line as it arrives
     loop {
         // After authorization, send the first notify from the current template
@@ -483,11 +487,13 @@ where
             // Clone inside a block to ensure the watch Ref guard is dropped before await
             let prepared_template = { template_rx.borrow_and_update().clone() };
             if let Some(prepared) = prepared_template {
-                match build_notify_from_prepared(
-                    &prepared,
-                    session.parsed_address.as_ref(),
-                    &ctx.tracker_handle,
-                ) {
+                let commitment_address = if is_hydrapool {
+                    None
+                } else {
+                    session.parsed_address.as_ref()
+                };
+                match build_notify_from_prepared(&prepared, commitment_address, &ctx.tracker_handle)
+                {
                     Ok(notify_json) => {
                         debug!("Sending first notify after authorize");
                         if let Err(e) = writer
@@ -530,7 +536,12 @@ where
                 if session.username.is_none() {
                     // Not yet authorized, skip building notify
                 } else if let Some(prepared) = prepared_template {
-                    match build_notify_from_prepared(&prepared, session.parsed_address.as_ref(), &ctx.tracker_handle) {
+                    let commitment_address = if is_hydrapool {
+                        None
+                    } else {
+                        session.parsed_address.as_ref()
+                    };
+                    match build_notify_from_prepared(&prepared, commitment_address, &ctx.tracker_handle) {
                         Ok(notify_json) => {
                             debug!("Send notify in reponse to new template");
                             if let Err(e) = writer.write_all(format!("{notify_json}\n").as_bytes()).await {

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -475,8 +475,8 @@ where
     monitor.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     monitor.tick().await;
 
-    // In Hydrapool mode pass None so the commitment hash is not
-    // embedded in the coinbase, saving bytes in coinbase.
+    // In Hydrapool mode pass None as commitment address as we don't
+    // need it.
     let is_hydrapool = ctx.mode == PoolMode::Hydrapool;
 
     // Process each line as it arrives

--- a/p2poolv2_node/src/main.rs
+++ b/p2poolv2_node/src/main.rs
@@ -266,6 +266,7 @@ async fn main() -> ExitCode {
             .max_connections(stratum_config.max_connections)
             .wait_for_chain_sync(stratum_config.wait_for_chain_sync)
             .chain_store_handle(chain_store_handle_for_stratum)
+            .mode(stratum_config.mode)
             .build()
             .await
             .unwrap();


### PR DESCRIPTION
Introduce the notion of pool mode - hydrapool and p2poolv2

Stratum config section supports this pool mode. By default it is p2poolv2 mode and only set in hydrapool config files, which are not in this repo. See the hydrapool repo.

Finally, apply the pool difficulty check for submitted shares only in p2p2oolv2 mode.