### PR TITLE
Use pplns impl based on feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -598,7 +598,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 We used tags like hydrapool.v0.x.0 and we didn't keep a changelog.
 
-[Unreleased]: https://github.com/p2poolv2/p2poolv2/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/p2poolv2/p2poolv2/compare/v0.12.0...HEAD
+[v0.12.0]: https://github.com/p2poolv2/p2poolv2/compare/v0.11.2...v0.12.0
 [v0.11.2]: https://github.com/p2poolv2/p2poolv2/compare/v0.11.0...v0.11.2
 [v0.11.0]: https://github.com/p2poolv2/p2poolv2/compare/v0.10.15...v0.11.0
 [v0.10.15]: https://github.com/p2poolv2/p2poolv2/compare/v0.10.14...v0.10.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.12.0] - 2026-06-12
+
+### Changed
+
+- PPLNS payout implementation is selected based on pool mode from
+  stratum config. Simple PPLNS uses shares stored in rocksdb for
+  hydrapool standalone PPLNS mode. Sharechain PPLNS uses shares from
+  rocksdb stored for the chain DAG.
+
 ## [v0.11.2] - 2026-06-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindrpc"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3252,7 +3252,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p2poolv2_api"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_cli"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_config"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_lib"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_node"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_tests"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.2"
+version = "0.12.0"
 edition = "2024"
 authors = ["Kulpreet Singh<kp@opdup.com>"]
 license = "AGPL-3.0-or-later"

--- a/p2poolv2_lib/src/accounting/payout/mod.rs
+++ b/p2poolv2_lib/src/accounting/payout/mod.rs
@@ -17,3 +17,35 @@
 pub mod payout_distribution;
 pub mod sharechain_pplns;
 pub mod simple_pplns;
+
+use crate::config::PoolMode;
+use payout_distribution::PayoutDistribution;
+use sharechain_pplns::pplns_window::PplnsWindow;
+use std::sync::{Arc, RwLock};
+
+/// Build the payout implementation and shared PPLNS window for the
+/// given pool mode.
+///
+/// In P2Poolv2 mode the share chain PPLNS payout walks the confirmed
+/// chain and the returned window is shared with the organise worker.
+///
+/// In Hydrapool mode the simple PPLNS payout reads shares directly
+/// from rocksdb. The returned window is an empty placeholder that
+/// satisfies the NodeHandle interface but is not used for payouts.
+pub fn build_payout_for_mode(
+    mode: PoolMode,
+    network: bitcoin::Network,
+) -> (Box<dyn PayoutDistribution + Send>, Arc<RwLock<PplnsWindow>>) {
+    match mode {
+        PoolMode::P2poolv2 => {
+            let payout = sharechain_pplns::Payout::new(network);
+            let window = payout.shared_pplns_window();
+            (Box::new(payout), window)
+        }
+        PoolMode::Hydrapool => {
+            let payout = simple_pplns::payout::Payout::new(86400);
+            let window = Arc::new(RwLock::new(PplnsWindow::new(network)));
+            (Box::new(payout), window)
+        }
+    }
+}

--- a/p2poolv2_lib/src/accounting/payout/mod.rs
+++ b/p2poolv2_lib/src/accounting/payout/mod.rs
@@ -23,6 +23,8 @@ use payout_distribution::PayoutDistribution;
 use sharechain_pplns::pplns_window::PplnsWindow;
 use std::sync::{Arc, RwLock};
 
+const DEFAULT_SIMPLE_PPLNS_STEP_SIZE_SECONDS: u64 = 86_400;
+
 /// Build the payout implementation and shared PPLNS window for the
 /// given pool mode.
 ///
@@ -31,7 +33,8 @@ use std::sync::{Arc, RwLock};
 ///
 /// In Hydrapool mode the simple PPLNS payout reads shares directly
 /// from rocksdb. The returned window is an empty placeholder that
-/// satisfies the NodeHandle interface but is not used for payouts.
+/// satisfies the NodeHandle interface but is not used for simple
+/// pplns payouts.
 pub fn build_payout_for_mode(
     mode: PoolMode,
     network: bitcoin::Network,
@@ -43,7 +46,7 @@ pub fn build_payout_for_mode(
             (Box::new(payout), window)
         }
         PoolMode::Hydrapool => {
-            let payout = simple_pplns::payout::Payout::new(86400);
+            let payout = simple_pplns::payout::Payout::new(DEFAULT_SIMPLE_PPLNS_STEP_SIZE_SECONDS);
             let window = Arc::new(RwLock::new(PplnsWindow::new(network)));
             (Box::new(payout), window)
         }

--- a/p2poolv2_node/src/main.rs
+++ b/p2poolv2_node/src/main.rs
@@ -16,7 +16,7 @@
 
 use clap::Parser;
 use p2poolv2_api::start_api_server;
-use p2poolv2_lib::accounting::payout::sharechain_pplns::Payout;
+use p2poolv2_lib::accounting::payout::build_payout_for_mode;
 use p2poolv2_lib::accounting::stats::metrics;
 use p2poolv2_lib::config::Config;
 use p2poolv2_lib::logging::setup_logging;
@@ -207,8 +207,8 @@ async fn main() -> ExitCode {
         PoolDifficulty::build(&chain_store_handle).expect("Failed to build pool difficulty");
 
     let cloned_stratum_config = stratum_config.clone();
-    let payout = Payout::new(cloned_stratum_config.network);
-    let shared_pplns_window = payout.shared_pplns_window();
+    let (payout, shared_pplns_window) =
+        build_payout_for_mode(stratum_config.mode, cloned_stratum_config.network);
     let exit_sender_notify = exit_sender.clone();
     let exit_receiver_notify = exit_sender.subscribe();
     tokio::spawn(async move {
@@ -218,7 +218,7 @@ async fn main() -> ExitCode {
             template_tx,
             chain_store_handle_for_notify,
             &cloned_stratum_config,
-            Box::new(payout),
+            payout,
             pool_difficulty_for_notify,
         )
         .await;


### PR DESCRIPTION
PPLNS payout implementation is selected based on pool mode from stratum config. Simple PPLNS uses shares stored in rocksdb for hydrapool standalone PPLNS mode. Sharechain PPLNS uses shares from rocksdb stored for the chain DAG.