### PR TITLE
fix(p2p): don't advertise observed_addr (ephemeral source port)

### DIFF
--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -433,9 +433,9 @@ impl Node {
                         .kademlia
                         .add_address(&peer_id, addr.clone());
                 }
-                // Also add our observed address to Kademlia so other peers can reach us
+                // Note, we don't advertise observed_addr: its port is our
+                // ephemeral outbound source port, not a listen port.
                 debug!("Peer {} observed us as {}", peer_id, info.observed_addr);
-                self.swarm.add_external_address(info.observed_addr);
                 if let Err(e) = self.swarm.behaviour_mut().kademlia.bootstrap() {
                     warn!("Failed to bootstrap Kademlia: {}", e);
                 } else {


### PR DESCRIPTION
Discovered this while playing around with large numbers of peers in #558 

Appears to be an actual bug; don't know under what real-world scenarios it would matter, but clearly an ephemeral source port is not something you should advertise as reachable.

Btw is AutoNAT ever relevant to this project?