### PR TITLE
Improve peer discovery with external address and kademlia

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -13,6 +13,9 @@ max_inventory_per_second = 100
 max_transaction_per_second = 100
 max_requests_per_second = 100
 dial_timeout_secs = 30
+# Optional external address for nodes behind NAT. If set, this address
+# is advertised to peers instead of auto-detecting from identify observations.
+# external_address = "/ip4/203.0.113.1/tcp/6884"
 
 [store]
 path = "./store.db"

--- a/p2poolv2_config/src/lib.rs
+++ b/p2poolv2_config/src/lib.rs
@@ -299,6 +299,11 @@ pub struct NetworkConfig {
     /// are immediately disconnected.
     #[serde(default)]
     pub blocked_ips: Vec<String>,
+    /// Optional external address override for nodes behind NAT.
+    /// If set, this address is advertised to peers via the identify protocol.
+    /// Format: Multiaddr string, e.g. "/ip4/203.0.113.1/tcp/6884"
+    #[serde(default)]
+    pub external_address: Option<String>,
 }
 
 impl Default for NetworkConfig {
@@ -319,6 +324,7 @@ impl Default for NetworkConfig {
             max_requests_per_second: 100,
             dial_timeout_secs: 30,
             blocked_ips: vec![],
+            external_address: None,
         }
     }
 }

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -440,6 +440,13 @@ impl NodeActor {
         sync_retry_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         sync_retry_interval.tick().await;
 
+        const KADEMLIA_BOOTSTRAP_INTERVAL_SECS: u64 = 300;
+        let mut kademlia_bootstrap_interval = tokio::time::interval(
+            std::time::Duration::from_secs(KADEMLIA_BOOTSTRAP_INTERVAL_SECS),
+        );
+        kademlia_bootstrap_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        kademlia_bootstrap_interval.tick().await;
+
         loop {
             tokio::select! {
                 buf = self.node.swarm_rx.recv() => {
@@ -679,6 +686,9 @@ impl NodeActor {
                             error!("Sync retry getheaders failed: {error}");
                         }
                     }
+                }
+                _ = kademlia_bootstrap_interval.tick() => {
+                    self.node.attempt_kademlia_bootstrap();
                 }
             }
         }

--- a/p2poolv2_lib/src/node/address_filter.rs
+++ b/p2poolv2_lib/src/node/address_filter.rs
@@ -89,6 +89,48 @@ pub fn is_routable_multiaddr(address: &Multiaddr) -> bool {
     false
 }
 
+/// Extracts the TCP port from a multiaddr string (e.g. "/ip4/0.0.0.0/tcp/6884").
+/// Returns None if the string is not a valid multiaddr or has no TCP component.
+pub fn extract_listen_port(listen_address: &str) -> Option<u16> {
+    let multiaddr: Multiaddr = listen_address.parse().ok()?;
+    for protocol in multiaddr.iter() {
+        if let Protocol::Tcp(port) = protocol {
+            return Some(port);
+        }
+    }
+    None
+}
+
+/// Builds an external multiaddr by taking the IP from `observed_addr` and
+/// replacing the port with `listen_port`. Returns None if the observed address
+/// has no IP component or the IP is not globally routable.
+pub fn build_external_address(observed_addr: &Multiaddr, listen_port: u16) -> Option<Multiaddr> {
+    for protocol in observed_addr.iter() {
+        match protocol {
+            Protocol::Ip4(ip) => {
+                if is_ipv4_global(&ip) {
+                    let mut addr = Multiaddr::empty();
+                    addr.push(Protocol::Ip4(ip));
+                    addr.push(Protocol::Tcp(listen_port));
+                    return Some(addr);
+                }
+                return None;
+            }
+            Protocol::Ip6(ip) => {
+                if is_ipv6_global(&ip) {
+                    let mut addr = Multiaddr::empty();
+                    addr.push(Protocol::Ip6(ip));
+                    addr.push(Protocol::Tcp(listen_port));
+                    return Some(addr);
+                }
+                return None;
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -169,5 +211,53 @@ mod tests {
     fn test_rejects_documentation_range() {
         let addr: Multiaddr = "/ip4/192.0.2.1/tcp/6884".parse().unwrap();
         assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_extract_listen_port_from_valid_multiaddr() {
+        assert_eq!(extract_listen_port("/ip4/0.0.0.0/tcp/6884"), Some(6884));
+    }
+
+    #[test]
+    fn test_extract_listen_port_from_ipv6() {
+        assert_eq!(extract_listen_port("/ip6/::0/tcp/9999"), Some(9999));
+    }
+
+    #[test]
+    fn test_extract_listen_port_returns_none_for_no_tcp() {
+        assert_eq!(extract_listen_port("/ip4/0.0.0.0/udp/6884"), None);
+    }
+
+    #[test]
+    fn test_extract_listen_port_returns_none_for_invalid() {
+        assert_eq!(extract_listen_port("not-a-multiaddr"), None);
+    }
+
+    #[test]
+    fn test_build_external_address_replaces_port() {
+        let observed: Multiaddr = "/ip4/8.8.8.8/tcp/54321".parse().unwrap();
+        let result = build_external_address(&observed, 6884);
+        let expected: Multiaddr = "/ip4/8.8.8.8/tcp/6884".parse().unwrap();
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn test_build_external_address_with_ipv6() {
+        let observed: Multiaddr = "/ip6/2001:4860:4860::8888/tcp/54321".parse().unwrap();
+        let result = build_external_address(&observed, 6884);
+        let expected: Multiaddr = "/ip6/2001:4860:4860::8888/tcp/6884".parse().unwrap();
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn test_build_external_address_rejects_private() {
+        let observed: Multiaddr = "/ip4/192.168.1.1/tcp/54321".parse().unwrap();
+        assert_eq!(build_external_address(&observed, 6884), None);
+    }
+
+    #[test]
+    fn test_build_external_address_rejects_loopback() {
+        let observed: Multiaddr = "/ip4/127.0.0.1/tcp/54321".parse().unwrap();
+        assert_eq!(build_external_address(&observed, 6884), None);
     }
 }

--- a/p2poolv2_lib/src/node/address_filter.rs
+++ b/p2poolv2_lib/src/node/address_filter.rs
@@ -1,0 +1,173 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+use libp2p::Multiaddr;
+use libp2p::multiaddr::Protocol;
+
+/// Returns true if an IPv4 address is globally routable.
+/// Rejects loopback, private (RFC 1918), link-local, unspecified,
+/// broadcast, documentation, and shared address space ranges.
+fn is_ipv4_global(ip: &std::net::Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    let first = octets[0];
+    let second = octets[1];
+    // Unspecified (0.0.0.0/8)
+    if first == 0 {
+        return false;
+    }
+    // Loopback (127.0.0.0/8)
+    if ip.is_loopback() {
+        return false;
+    }
+    // Private: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+    if ip.is_private() {
+        return false;
+    }
+    // Link-local (169.254.0.0/16)
+    if ip.is_link_local() {
+        return false;
+    }
+    // Broadcast (255.255.255.255)
+    if ip.is_broadcast() {
+        return false;
+    }
+    // Documentation: 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24
+    if (first == 192 && second == 0 && octets[2] == 2)
+        || (first == 198 && second == 51 && octets[2] == 100)
+        || (first == 203 && second == 0 && octets[2] == 113)
+    {
+        return false;
+    }
+    // Shared address space (100.64.0.0/10)
+    if first == 100 && (second & 0xC0) == 64 {
+        return false;
+    }
+    true
+}
+
+/// Returns true if an IPv6 address is globally routable.
+/// Rejects loopback, unspecified, link-local, and unique local addresses.
+fn is_ipv6_global(ip: &std::net::Ipv6Addr) -> bool {
+    if ip.is_loopback() || ip.is_unspecified() {
+        return false;
+    }
+    let segments = ip.segments();
+    // Link-local (fe80::/10)
+    if (segments[0] & 0xFFC0) == 0xFE80 {
+        return false;
+    }
+    // Unique local (fc00::/7)
+    if (segments[0] & 0xFE00) == 0xFC00 {
+        return false;
+    }
+    true
+}
+
+/// Returns true if the multiaddr contains a globally routable IP address.
+/// Rejects loopback, private, link-local, and unspecified addresses.
+pub fn is_routable_multiaddr(address: &Multiaddr) -> bool {
+    for protocol in address.iter() {
+        match protocol {
+            Protocol::Ip4(ip) => return is_ipv4_global(&ip),
+            Protocol::Ip6(ip) => return is_ipv6_global(&ip),
+            _ => {}
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rejects_loopback() {
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_private_10() {
+        let addr: Multiaddr = "/ip4/10.0.0.1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_private_172() {
+        let addr: Multiaddr = "/ip4/172.16.0.1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_private_192() {
+        let addr: Multiaddr = "/ip4/192.168.1.1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_unspecified() {
+        let addr: Multiaddr = "/ip4/0.0.0.0/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_ipv6_loopback() {
+        let addr: Multiaddr = "/ip6/::1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_ipv6_link_local() {
+        let addr: Multiaddr = "/ip6/fe80::1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_ipv6_unique_local() {
+        let addr: Multiaddr = "/ip6/fd00::1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_accepts_public_ipv4() {
+        let addr: Multiaddr = "/ip4/8.8.8.8/tcp/6884".parse().unwrap();
+        assert!(is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_accepts_public_ipv6() {
+        let addr: Multiaddr = "/ip6/2001:4860:4860::8888/tcp/6884".parse().unwrap();
+        assert!(is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_no_ip() {
+        let addr: Multiaddr = "/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_shared_address_space() {
+        let addr: Multiaddr = "/ip4/100.64.0.1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_documentation_range() {
+        let addr: Multiaddr = "/ip4/192.0.2.1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+}

--- a/p2poolv2_lib/src/node/address_filter.rs
+++ b/p2poolv2_lib/src/node/address_filter.rs
@@ -19,7 +19,8 @@ use libp2p::multiaddr::Protocol;
 
 /// Returns true if an IPv4 address is globally routable.
 /// Rejects loopback, private (RFC 1918), link-local, unspecified,
-/// broadcast, documentation, and shared address space ranges.
+/// broadcast, documentation, shared address space, multicast,
+/// reserved, and benchmarking ranges.
 fn is_ipv4_global(ip: &std::net::Ipv4Addr) -> bool {
     let octets = ip.octets();
     let first = octets[0];
@@ -55,13 +56,26 @@ fn is_ipv4_global(ip: &std::net::Ipv4Addr) -> bool {
     if first == 100 && (second & 0xC0) == 64 {
         return false;
     }
+    // Multicast (224.0.0.0/4)
+    if first >= 224 && first <= 239 {
+        return false;
+    }
+    // Reserved for future use (240.0.0.0/4, excluding broadcast)
+    if first >= 240 {
+        return false;
+    }
+    // Benchmarking (198.18.0.0/15)
+    if first == 198 && (second == 18 || second == 19) {
+        return false;
+    }
     true
 }
 
 /// Returns true if an IPv6 address is globally routable.
-/// Rejects loopback, unspecified, link-local, and unique local addresses.
+/// Rejects loopback, unspecified, link-local, unique local,
+/// documentation, discard-only, and IPv4-mapped/compatible ranges.
 fn is_ipv6_global(ip: &std::net::Ipv6Addr) -> bool {
-    if ip.is_loopback() || ip.is_unspecified() {
+    if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
         return false;
     }
     let segments = ip.segments();
@@ -71,6 +85,23 @@ fn is_ipv6_global(ip: &std::net::Ipv6Addr) -> bool {
     }
     // Unique local (fc00::/7)
     if (segments[0] & 0xFE00) == 0xFC00 {
+        return false;
+    }
+    // Documentation (2001:db8::/32)
+    if segments[0] == 0x2001 && segments[1] == 0x0DB8 {
+        return false;
+    }
+    // Discard-only (100::/64, RFC 6666)
+    if segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0 {
+        return false;
+    }
+    // IPv4-mapped (::ffff:0:0/96) and IPv4-compatible (deprecated, ::/96)
+    if segments[0] == 0
+        && segments[1] == 0
+        && segments[2] == 0
+        && segments[3] == 0
+        && segments[4] == 0
+    {
         return false;
     }
     true
@@ -90,12 +121,22 @@ pub fn is_routable_multiaddr(address: &Multiaddr) -> bool {
 }
 
 /// Extracts the TCP port from a multiaddr string (e.g. "/ip4/0.0.0.0/tcp/6884").
-/// Returns None if the string is not a valid multiaddr or has no TCP component.
+/// Returns None if the string is not a valid multiaddr, has no TCP component,
+/// or the port is 0 (ephemeral).
 pub fn extract_listen_port(listen_address: &str) -> Option<u16> {
     let multiaddr: Multiaddr = listen_address.parse().ok()?;
-    for protocol in multiaddr.iter() {
+    extract_tcp_port(&multiaddr)
+}
+
+/// Extracts a non-zero TCP port from a parsed multiaddr.
+/// Returns None if no TCP component is present or the port is 0.
+pub fn extract_tcp_port(address: &Multiaddr) -> Option<u16> {
+    for protocol in address.iter() {
         if let Protocol::Tcp(port) = protocol {
-            return Some(port);
+            if port > 0 {
+                return Some(port);
+            }
+            return None;
         }
     }
     None
@@ -184,6 +225,24 @@ mod tests {
     }
 
     #[test]
+    fn test_rejects_ipv6_documentation() {
+        let addr: Multiaddr = "/ip6/2001:db8::1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_ipv6_discard_only() {
+        let addr: Multiaddr = "/ip6/100::1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_ipv4_mapped_ipv6() {
+        let addr: Multiaddr = "/ip6/::ffff:192.0.2.1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
     fn test_accepts_public_ipv4() {
         let addr: Multiaddr = "/ip4/8.8.8.8/tcp/6884".parse().unwrap();
         assert!(is_routable_multiaddr(&addr));
@@ -214,6 +273,24 @@ mod tests {
     }
 
     #[test]
+    fn test_rejects_multicast() {
+        let addr: Multiaddr = "/ip4/224.0.0.1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_reserved() {
+        let addr: Multiaddr = "/ip4/240.0.0.1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
+    fn test_rejects_benchmarking() {
+        let addr: Multiaddr = "/ip4/198.18.0.1/tcp/6884".parse().unwrap();
+        assert!(!is_routable_multiaddr(&addr));
+    }
+
+    #[test]
     fn test_extract_listen_port_from_valid_multiaddr() {
         assert_eq!(extract_listen_port("/ip4/0.0.0.0/tcp/6884"), Some(6884));
     }
@@ -231,6 +308,23 @@ mod tests {
     #[test]
     fn test_extract_listen_port_returns_none_for_invalid() {
         assert_eq!(extract_listen_port("not-a-multiaddr"), None);
+    }
+
+    #[test]
+    fn test_extract_listen_port_returns_none_for_ephemeral() {
+        assert_eq!(extract_listen_port("/ip4/0.0.0.0/tcp/0"), None);
+    }
+
+    #[test]
+    fn test_extract_tcp_port_from_resolved_address() {
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/45678".parse().unwrap();
+        assert_eq!(extract_tcp_port(&addr), Some(45678));
+    }
+
+    #[test]
+    fn test_extract_tcp_port_returns_none_for_zero() {
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/0".parse().unwrap();
+        assert_eq!(extract_tcp_port(&addr), None);
     }
 
     #[test]

--- a/p2poolv2_lib/src/node/behaviour/mod.rs
+++ b/p2poolv2_lib/src/node/behaviour/mod.rs
@@ -65,13 +65,15 @@ impl P2PoolBehaviour {
         kad_config.set_query_timeout(tokio::time::Duration::from_secs(60));
         kad_config.set_protocol_names(vec![libp2p::StreamProtocol::new("/p2pool/kad/1.0.0")]);
 
-        let kademlia_behaviour =
+        let mut kademlia_behaviour =
             kad::Behaviour::with_config(local_key.public().to_peer_id(), store, kad_config);
+        kademlia_behaviour.set_mode(Some(kad::Mode::Server));
 
-        let identify_behaviour = identify::Behaviour::new(identify::Config::new(
-            "/p2pool/1.0.0".to_string(),
-            local_key.public(),
-        ));
+        let identify_config =
+            identify::Config::new("/p2pool/1.0.0".to_string(), local_key.public())
+                .with_agent_version(format!("p2poolv2/{}", env!("CARGO_PKG_VERSION")))
+                .with_push_listen_addr_updates(true);
+        let identify_behaviour = identify::Behaviour::new(identify_config);
 
         let limits_config = connection_limits::ConnectionLimits::default()
             .with_max_pending_incoming(Some(config.network.max_pending_incoming))

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -111,6 +111,8 @@ struct Node {
     external_address_confirmed: bool,
     /// Cached TCP listen port extracted from config
     listen_port: Option<u16>,
+    /// Whether kademlia bootstrap has been triggered at least once
+    has_bootstrapped_kad: bool,
 }
 
 impl Node {
@@ -273,6 +275,7 @@ impl Node {
             connection_tracker: ConnectionTracker::new(blocked_ips),
             external_address_confirmed,
             listen_port,
+            has_bootstrapped_kad: false,
         })
     }
 
@@ -477,14 +480,26 @@ impl Node {
                     }
                 }
                 self.try_confirm_external_address(&info.observed_addr);
-                if let Err(e) = self.swarm.behaviour_mut().kademlia.bootstrap() {
-                    warn!("Failed to bootstrap Kademlia: {}", e);
-                } else {
-                    debug!("Successfully started Kademlia bootstrap");
+                if !self.has_bootstrapped_kad {
+                    self.attempt_kademlia_bootstrap();
                 }
             }
             _ => {
                 debug!("Other identify event: {:?}", event);
+            }
+        }
+    }
+
+    /// Triggers a kademlia bootstrap query to discover peers in the DHT.
+    /// Called once on first identify event and periodically thereafter.
+    fn attempt_kademlia_bootstrap(&mut self) {
+        match self.swarm.behaviour_mut().kademlia.bootstrap() {
+            Ok(_) => {
+                debug!("Started Kademlia bootstrap");
+                self.has_bootstrapped_kad = true;
+            }
+            Err(error) => {
+                warn!("Failed to bootstrap Kademlia: {error}");
             }
         }
     }

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -613,13 +613,12 @@ mod tests {
     use crate::node::validation_worker::create_validation_channel;
     use bitcoindrpc::BitcoinRpcConfig;
     use futures::StreamExt;
+    use libp2p::swarm::SwarmEvent;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
     #[tokio::test]
     async fn test_node_dial_timeout_does_not_hang() {
-        use libp2p::swarm::SwarmEvent;
-
         // Use a local address that will refuse connections immediately
         let unreachable_peer = "/ip4/127.0.0.1/tcp/65535".to_string(); // Fast fail
 
@@ -738,5 +737,190 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn build_test_config(listen_address: &str, external_address: Option<String>) -> Config {
+        Config {
+            network: NetworkConfig {
+                listen_address: listen_address.to_string(),
+                dial_peers: vec![],
+                max_pending_incoming: 10,
+                max_pending_outgoing: 10,
+                max_established_incoming: 10,
+                max_established_outgoing: 10,
+                max_established_per_peer: 10,
+                max_workbase_per_second: 10,
+                max_userworkbase_per_second: 10,
+                max_miningshare_per_second: 10,
+                max_inventory_per_second: 10,
+                max_transaction_per_second: 10,
+                max_requests_per_second: 1,
+                dial_timeout_secs: 2,
+                blocked_ips: vec![],
+                external_address,
+            },
+            bitcoinrpc: BitcoinRpcConfig {
+                url: "http://localhost:8332".to_string(),
+                username: "testuser".to_string(),
+                password: "testpass".to_string(),
+            },
+            store: StoreConfig {
+                path: "test_chain.db".to_string(),
+                background_task_frequency_hours: 1,
+                pplns_ttl_days: 3,
+            },
+            stratum: StratumConfig::new_for_test_default(),
+            logging: LoggingConfig {
+                console: Some(true),
+                level: "info".to_string(),
+                file: Some("./p2pool.log".to_string()),
+                stats_dir: "./logs/stats".to_string(),
+            },
+            api: ApiConfig {
+                hostname: "127.0.0.1".to_string(),
+                port: 3000,
+                auth_user: None,
+                auth_token: None,
+                auth_password: None,
+                cors_allowed: false,
+            },
+        }
+    }
+
+    fn build_test_node(config: Config) -> Node {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_clone()
+            .returning(ChainStoreHandle::default);
+        let (block_fetcher_tx, _block_fetcher_rx) = create_block_fetcher_channel();
+        let (validation_tx, _validation_rx) = create_validation_channel();
+        let (block_receiver_handle, _block_receiver_rx) = create_block_receiver_channel();
+        let (monitoring_tx, _monitoring_rx) = create_monitoring_event_channel();
+        Node::new(
+            config,
+            chain_store_handle,
+            block_fetcher_tx,
+            validation_tx,
+            block_receiver_handle,
+            monitoring_tx,
+            Arc::new(crate::shares::validation::MockDefaultShareValidator::default()),
+        )
+        .expect("Node initialization failed")
+    }
+
+    #[tokio::test]
+    async fn test_config_external_address_is_added_to_swarm() {
+        let config = build_test_config(
+            "/ip4/127.0.0.1/tcp/0",
+            Some("/ip4/203.0.113.5/tcp/6884".to_string()),
+        );
+        let node = build_test_node(config);
+
+        let external_addrs: Vec<_> = node.swarm.external_addresses().cloned().collect();
+        let expected: libp2p::Multiaddr = "/ip4/203.0.113.5/tcp/6884".parse().unwrap();
+        assert!(
+            external_addrs.contains(&expected),
+            "Expected external address {expected} not found in {external_addrs:?}"
+        );
+        assert!(node.external_address_confirmed);
+    }
+
+    #[tokio::test]
+    async fn test_no_config_external_address_leaves_unconfirmed() {
+        let config = build_test_config("/ip4/127.0.0.1/tcp/0", None);
+        let node = build_test_node(config);
+
+        let external_addrs: Vec<_> = node.swarm.external_addresses().cloned().collect();
+        assert!(
+            external_addrs.is_empty(),
+            "Expected no external addresses, got {external_addrs:?}"
+        );
+        assert!(!node.external_address_confirmed);
+    }
+
+    #[tokio::test]
+    async fn test_try_confirm_from_routable_observation() {
+        let config = build_test_config("/ip4/127.0.0.1/tcp/0", None);
+        let mut node = build_test_node(config);
+        node.listen_port = Some(7001);
+
+        assert!(!node.external_address_confirmed);
+
+        let observed: libp2p::Multiaddr = "/ip4/93.184.216.34/tcp/54321".parse().unwrap();
+        node.try_confirm_external_address(&observed);
+
+        assert!(node.external_address_confirmed);
+        let external_addrs: Vec<_> = node.swarm.external_addresses().cloned().collect();
+        let expected: libp2p::Multiaddr = "/ip4/93.184.216.34/tcp/7001".parse().unwrap();
+        assert!(
+            external_addrs.contains(&expected),
+            "Expected external address {expected} not found in {external_addrs:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_try_confirm_ignores_private_observation() {
+        let config = build_test_config("/ip4/127.0.0.1/tcp/0", None);
+        let mut node = build_test_node(config);
+        node.listen_port = Some(7002);
+
+        let observed: libp2p::Multiaddr = "/ip4/192.168.1.1/tcp/54321".parse().unwrap();
+        node.try_confirm_external_address(&observed);
+
+        assert!(!node.external_address_confirmed);
+        let external_addrs: Vec<_> = node.swarm.external_addresses().cloned().collect();
+        assert!(
+            external_addrs.is_empty(),
+            "Expected no external addresses, got {external_addrs:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_try_confirm_noop_when_already_confirmed() {
+        let config = build_test_config(
+            "/ip4/127.0.0.1/tcp/0",
+            Some("/ip4/203.0.113.5/tcp/7003".to_string()),
+        );
+        let mut node = build_test_node(config);
+        node.listen_port = Some(7003);
+        assert!(node.external_address_confirmed);
+
+        let observed: libp2p::Multiaddr = "/ip4/198.51.100.99/tcp/54321".parse().unwrap();
+        node.try_confirm_external_address(&observed);
+
+        let external_addrs: Vec<_> = node.swarm.external_addresses().cloned().collect();
+        let should_not_exist: libp2p::Multiaddr = "/ip4/198.51.100.99/tcp/7003".parse().unwrap();
+        assert!(
+            !external_addrs.contains(&should_not_exist),
+            "Second observation should not override confirmed address"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_try_confirm_noop_when_no_listen_port() {
+        let config = build_test_config("/ip4/127.0.0.1/tcp/0", None);
+        let mut node = build_test_node(config);
+        assert!(node.listen_port.is_none());
+
+        let observed: libp2p::Multiaddr = "/ip4/198.51.100.7/tcp/54321".parse().unwrap();
+        node.try_confirm_external_address(&observed);
+
+        assert!(!node.external_address_confirmed);
+    }
+
+    #[tokio::test]
+    async fn test_new_listen_addr_resolves_ephemeral_port() {
+        let config = build_test_config("/ip4/127.0.0.1/tcp/0", None);
+        let mut node = build_test_node(config);
+        assert!(node.listen_port.is_none());
+
+        let resolved_addr: libp2p::Multiaddr = "/ip4/127.0.0.1/tcp/45678".parse().unwrap();
+        let event = SwarmEvent::NewListenAddr {
+            listener_id: libp2p::core::transport::ListenerId::next(),
+            address: resolved_addr,
+        };
+        node.handle_swarm_event(event).await.unwrap();
+
+        assert_eq!(node.listen_port, Some(45678));
     }
 }

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -107,6 +107,10 @@ struct Node {
     monitoring_event_sender: MonitoringEventSender,
     peer_reconnector: peer_reconnector::PeerReconnector,
     connection_tracker: ConnectionTracker,
+    /// Whether an external address has been confirmed and advertised
+    external_address_confirmed: bool,
+    /// Cached TCP listen port extracted from config
+    listen_port: Option<u16>,
 }
 
 impl Node {
@@ -157,6 +161,28 @@ impl Node {
             .build();
 
         info!("Local peer id: {}", swarm.local_peer_id());
+
+        let listen_port = address_filter::extract_listen_port(&config.network.listen_address);
+
+        let external_address_confirmed =
+            if let Some(ref external_addr_str) = config.network.external_address {
+                match external_addr_str.parse::<Multiaddr>() {
+                    Ok(external_addr) => {
+                        info!("Using configured external address: {}", external_addr);
+                        swarm.add_external_address(external_addr);
+                        true
+                    }
+                    Err(error) => {
+                        warn!(
+                            "Invalid external_address '{}' in config: {}",
+                            external_addr_str, error
+                        );
+                        false
+                    }
+                }
+            } else {
+                false
+            };
 
         if !config.network.listen_address.is_empty() {
             match config.network.listen_address.parse() {
@@ -245,6 +271,8 @@ impl Node {
             monitoring_event_sender,
             peer_reconnector,
             connection_tracker: ConnectionTracker::new(blocked_ips),
+            external_address_confirmed,
+            listen_port,
         })
     }
 
@@ -323,7 +351,14 @@ impl Node {
     ) -> Result<(), Box<dyn Error>> {
         match event {
             SwarmEvent::NewListenAddr { address, .. } => {
-                debug!("Listening on {address:?}");
+                info!("Listening on {address:?}");
+                if !self.external_address_confirmed
+                    && address_filter::is_routable_multiaddr(&address)
+                {
+                    self.swarm.add_external_address(address.clone());
+                    self.external_address_confirmed = true;
+                    info!("Added routable listen address as external: {address}");
+                }
                 Ok(())
             }
             SwarmEvent::ConnectionEstablished {
@@ -441,7 +476,7 @@ impl Node {
                         );
                     }
                 }
-                debug!("Peer {} observed us as {}", peer_id, info.observed_addr);
+                self.try_confirm_external_address(&info.observed_addr);
                 if let Err(e) = self.swarm.behaviour_mut().kademlia.bootstrap() {
                     warn!("Failed to bootstrap Kademlia: {}", e);
                 } else {
@@ -451,6 +486,30 @@ impl Node {
             _ => {
                 debug!("Other identify event: {:?}", event);
             }
+        }
+    }
+
+    /// Attempts to derive and confirm an external address from an identify
+    /// observation. Uses the observed IP combined with our listen port.
+    fn try_confirm_external_address(&mut self, observed_addr: &Multiaddr) {
+        if self.external_address_confirmed {
+            return;
+        }
+        let listen_port = match self.listen_port {
+            Some(port) => port,
+            None => {
+                debug!("No listen port configured, skipping external address detection");
+                return;
+            }
+        };
+        if let Some(external_addr) =
+            address_filter::build_external_address(observed_addr, listen_port)
+        {
+            info!("Detected external address from peer observation: {external_addr}");
+            self.swarm.add_external_address(external_addr);
+            self.external_address_confirmed = true;
+        } else {
+            debug!("Peer observed us as {observed_addr}, not usable as external address");
         }
     }
 
@@ -559,6 +618,7 @@ mod tests {
             max_requests_per_second: 1,
             dial_timeout_secs: 2,
             blocked_ips: vec![],
+            external_address: None,
         };
         network_config.dial_peers = vec![unreachable_peer];
         network_config.dial_timeout_secs = 2;

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
+mod address_filter;
 pub mod behaviour;
 pub mod connection_tracker;
 pub mod emission_worker;
@@ -426,15 +427,20 @@ impl Node {
                     "Identified Peer {} with protocol version {}",
                     peer_id, info.protocol_version
                 );
-                // Add the peer's advertised addresses to Kademlia
+                // Add the peer's routable advertised addresses to Kademlia
                 for addr in info.listen_addrs {
-                    self.swarm
-                        .behaviour_mut()
-                        .kademlia
-                        .add_address(&peer_id, addr.clone());
+                    if address_filter::is_routable_multiaddr(&addr) {
+                        self.swarm
+                            .behaviour_mut()
+                            .kademlia
+                            .add_address(&peer_id, addr.clone());
+                    } else {
+                        debug!(
+                            "Skipping non-routable address {} from peer {}",
+                            addr, peer_id
+                        );
+                    }
                 }
-                // Note, we don't advertise observed_addr: its port is our
-                // ephemeral outbound source port, not a listen port.
                 debug!("Peer {} observed us as {}", peer_id, info.observed_addr);
                 if let Err(e) = self.swarm.behaviour_mut().kademlia.bootstrap() {
                     warn!("Failed to bootstrap Kademlia: {}", e);

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -355,6 +355,12 @@ impl Node {
         match event {
             SwarmEvent::NewListenAddr { address, .. } => {
                 info!("Listening on {address:?}");
+                if self.listen_port.is_none() {
+                    if let Some(port) = address_filter::extract_tcp_port(&address) {
+                        info!("Resolved actual listen port: {port}");
+                        self.listen_port = Some(port);
+                    }
+                }
                 if !self.external_address_confirmed
                     && address_filter::is_routable_multiaddr(&address)
                 {

--- a/p2poolv2_tests/src/common/mod.rs
+++ b/p2poolv2_tests/src/common/mod.rs
@@ -41,6 +41,7 @@ pub fn default_test_config() -> Config {
             max_requests_per_second: 1,
             dial_timeout_secs: 30,
             blocked_ips: vec![],
+            external_address: None,
         },
         bitcoinrpc: BitcoinRpcConfig {
             url: "http://localhost:8332".to_string(),


### PR DESCRIPTION
Advertise a node's address by allowing users to provide an external address, or using observed address from libp2p's Identify protocol and deriving an external address from the observed IP and listen address.

For now we haven't adopted autoNAT for gathering observed addresses and checking reachability. We can add this once the network has grown with a few reachable nodes.  