### PR TITLE
Send block when share is found

### DIFF
--- a/docs/architecture/share-processing-pipeline.md
+++ b/docs/architecture/share-processing-pipeline.md
@@ -265,7 +265,9 @@ Within a single `WriteBatch`, reads from the DB return pre-batch (committed) sta
   1. Reads the share block from the chain store
   2. Calls `validate_share_block()` which returns Ok early if the block
      already has `BlockValid` status (avoids redundant work for re-scheduled blocks)
-  3. On success: sends `OrganiseEvent::Block` and `SwarmSend::BroadcastBlock`
+  3. On success: sends `OrganiseEvent::Block` always; sends
+     `SwarmSend::BroadcastBlock` only when `is_current()` is true
+     (suppresses relay of historic blocks during initial sync)
   4. Calls `schedule_dependents()` which looks up children (via
      `get_children_blockhashes`) and nephews (via `get_nephews`) and sends
      `ValidateBlock` events back through the validation channel

--- a/docs/architecture/share-processing-pipeline.md
+++ b/docs/architecture/share-processing-pipeline.md
@@ -265,7 +265,7 @@ Within a single `WriteBatch`, reads from the DB return pre-batch (committed) sta
   1. Reads the share block from the chain store
   2. Calls `validate_share_block()` which returns Ok early if the block
      already has `BlockValid` status (avoids redundant work for re-scheduled blocks)
-  3. On success: sends `OrganiseEvent::Block` and `SwarmSend::Inv`
+  3. On success: sends `OrganiseEvent::Block` and `SwarmSend::BroadcastBlock`
   4. Calls `schedule_dependents()` which looks up children (via
      `get_children_blockhashes`) and nephews (via `get_nephews`) and sends
      `ValidateBlock` events back through the validation channel

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -35,6 +35,7 @@ use crate::node::p2p_message_handlers::receivers::block_receiver::{
 };
 use crate::node::p2p_message_handlers::senders::send_block_inventory;
 use crate::node::p2p_message_handlers::senders::send_getheaders;
+use crate::node::p2p_message_handlers::senders::send_share_block_broadcast;
 use crate::node::request_response_handler::block_fetcher::{
     BlockFetcher, BlockFetcherError, create_block_fetcher_channel,
 };
@@ -488,6 +489,23 @@ impl NodeActor {
                             .await
                             {
                                 error!("Failed to relay inv for block {block_hash}: {relay_error}");
+                            }
+                        }
+                        Some(SwarmSend::BroadcastBlock(share_block)) => {
+                            let block_hash = share_block.block_hash();
+                            let connected_peers = self.node.connected_peers();
+                            let peer_knowledge = self.node
+                                .request_response_handler
+                                .peer_block_knowledge_mut();
+                            if let Err(broadcast_error) = send_share_block_broadcast(
+                                share_block,
+                                &connected_peers,
+                                peer_knowledge,
+                                self.node.swarm_tx.clone(),
+                            )
+                            .await
+                            {
+                                error!("Failed to broadcast share block {block_hash}: {broadcast_error}");
                             }
                         }
                         Some(SwarmSend::Disconnect(peer_id)) => {

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -479,34 +479,25 @@ impl NodeActor {
                             let peer_knowledge = self.node
                                 .request_response_handler
                                 .peer_block_knowledge();
-                            if let Err(relay_error) = send_block_inventory(
+                            send_block_inventory(
                                 block_hash,
                                 None,
                                 &connected_peers,
                                 peer_knowledge,
-                                self.node.swarm_tx.clone(),
-                            )
-                            .await
-                            {
-                                error!("Failed to relay inv for block {block_hash}: {relay_error}");
-                            }
+                                &mut self.node.swarm,
+                            );
                         }
                         Some(SwarmSend::BroadcastBlock(share_block)) => {
-                            let block_hash = share_block.block_hash();
                             let connected_peers = self.node.connected_peers();
                             let peer_knowledge = self.node
                                 .request_response_handler
                                 .peer_block_knowledge_mut();
-                            if let Err(broadcast_error) = send_share_block_broadcast(
+                            send_share_block_broadcast(
                                 share_block,
                                 &connected_peers,
                                 peer_knowledge,
-                                self.node.swarm_tx.clone(),
-                            )
-                            .await
-                            {
-                                error!("Failed to broadcast share block {block_hash}: {broadcast_error}");
-                            }
+                                &mut self.node.swarm,
+                            );
                         }
                         Some(SwarmSend::Disconnect(peer_id)) => {
                             if let Err(_e) = self.node.swarm.disconnect_peer_id(peer_id) {

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -419,7 +419,7 @@ impl NodeActor {
     }
 
     async fn run(mut self) {
-        // Spawn emission worker - processes shares in separate task and enqueues SwarmSend::Inv
+        // Spawn emission worker - processes shares in separate task and enqueues SwarmSend::BroadcastBlock
         let emission_worker = EmissionWorker::new(
             self.emissions_rx,
             self.node.swarm_tx.clone(),

--- a/p2poolv2_lib/src/node/emission_worker.rs
+++ b/p2poolv2_lib/src/node/emission_worker.rs
@@ -83,10 +83,14 @@ impl EmissionWorker {
                     {
                         error!("Failed to send block to organise worker: {e}");
                     }
-                    // Announce block to peers via inventory message
+                    // Broadcast block directly to peers
                     let block_hash = share_block.block_hash();
-                    if let Err(e) = self.swarm_tx.send(SwarmSend::Inv(block_hash)).await {
-                        error!("Failed to queue inv for block {block_hash}: {e}");
+                    if let Err(e) = self
+                        .swarm_tx
+                        .send(SwarmSend::BroadcastBlock(share_block))
+                        .await
+                    {
+                        error!("Failed to queue broadcast for block {block_hash}: {e}");
                     }
                 }
                 Ok(None) => {
@@ -243,8 +247,8 @@ mod tests {
 
         let swarm_event = tokio::time::timeout(Duration::from_secs(2), swarm_rx.recv()).await;
         assert!(
-            matches!(swarm_event, Ok(Some(SwarmSend::Inv(_)))),
-            "Expected SwarmSend::Inv"
+            matches!(swarm_event, Ok(Some(SwarmSend::BroadcastBlock(_)))),
+            "Expected SwarmSend::BroadcastBlock"
         );
 
         worker_handle.await.unwrap();
@@ -334,8 +338,8 @@ mod tests {
             "Expected OrganiseEvent::Block from second emission"
         );
         assert!(
-            matches!(swarm_rx.try_recv(), Ok(SwarmSend::Inv(_))),
-            "Expected SwarmSend::Inv from second emission"
+            matches!(swarm_rx.try_recv(), Ok(SwarmSend::BroadcastBlock(_))),
+            "Expected SwarmSend::BroadcastBlock from second emission"
         );
 
         assert!(

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -21,6 +21,7 @@ pub mod emission_worker;
 pub mod organise_worker;
 pub mod peer_reconnector;
 pub mod request_response_handler;
+pub mod request_sender;
 pub mod validation_worker;
 pub use crate::config::Config;
 pub mod actor;

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -40,6 +40,7 @@ use crate::node::validation_worker::ValidationSender;
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 #[cfg(not(test))]
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
+use crate::shares::share_block::ShareBlock;
 use crate::shares::validation::ShareValidator;
 use behaviour::{P2PoolBehaviour, P2PoolBehaviourEvent};
 use bitcoin::BlockHash;
@@ -91,6 +92,10 @@ pub enum SwarmSend<C> {
     /// Sent after a ShareBlock is successfully validated and stored, so
     /// that other peers learn about the block and can request it via GetData.
     Inv(BlockHash),
+    /// Broadcast a full ShareBlock to connected peers, filtering by
+    /// peer_block_knowledge. The actor records each recipient so that
+    /// subsequent broadcasts of the same block are suppressed.
+    BroadcastBlock(ShareBlock),
     Disconnect(PeerId),
 }
 

--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -40,7 +40,7 @@ use receivers::share_headers::handle_share_headers;
 use std::error::Error;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 const MAX_HEADERS_IN_RESPONSE: usize = 1500;
 
@@ -116,12 +116,24 @@ pub async fn handle_request<C: Send + Sync, T: TimeProvider + Send + Sync>(
             )
             .await
         }
-        Message::ShareBlock(_) => {
-            warn!(
-                "Ignoring unsolicited ShareBlock from peer {}; blocks should be announced via inv",
-                ctx.peer
-            );
-            Ok(())
+        Message::ShareBlock(share_block) => {
+            if let Err(err) = ctx
+                .swarm_tx
+                .send(SwarmSend::Response(ctx.response_channel, Message::Ack))
+                .await
+            {
+                error!("Failed to send ShareBlock ack to peer {}: {err}", ctx.peer);
+                return Err(format!("Failed to send ShareBlock ack: {err}").into());
+            }
+            handle_share_block(
+                share_block,
+                &ctx.chain_store_handle,
+                ctx.validation_tx,
+                &ctx.block_receiver_handle,
+                &ctx.block_fetcher_handle,
+                ctx.share_validator.as_ref(),
+            )
+            .await
         }
         other => {
             debug!("Unexpected request type {other}");
@@ -666,15 +678,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_request_share_block_ignored() {
+    async fn test_handle_request_share_block_sends_ack_and_processes() {
         let peer_id = libp2p::PeerId::random();
-        let (swarm_tx, _swarm_rx) = mpsc::channel(32);
+        let (swarm_tx, mut swarm_rx) = mpsc::channel(32);
         let response_channel = 1u32;
-        let chain_store_handle = ChainStoreHandle::default();
+        let mut chain_store_handle = ChainStoreHandle::default();
         let time_provider = TestTimeProvider::new(SystemTime::now());
         let (block_fetcher_handle, validation_tx, block_receiver_handle) = test_handles();
 
         let share_block = valid_share_block_from_fixture();
+
+        // Block already confirmed -- simplest path through handle_share_block
+        chain_store_handle
+            .expect_share_block_exists()
+            .returning(|_| true);
+        chain_store_handle
+            .expect_has_status()
+            .returning(|_, _| true);
 
         let ctx = RequestContext {
             peer: peer_id,
@@ -690,9 +710,19 @@ mod tests {
         };
 
         let result = handle_request(ctx).await;
+        assert!(result.is_ok());
+
+        let ack_message = swarm_rx.recv().await.unwrap();
+        match ack_message {
+            SwarmSend::Response(channel, Message::Ack) => {
+                assert_eq!(channel, 1u32);
+            }
+            _ => panic!("Expected SwarmSend::Response with Ack"),
+        }
+
         assert!(
-            result.is_ok(),
-            "Unsolicited ShareBlock should be ignored, not error"
+            swarm_rx.try_recv().is_err(),
+            "No additional messages expected"
         );
     }
 

--- a/p2poolv2_lib/src/node/p2p_message_handlers/senders/inventory.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/senders/inventory.rs
@@ -14,13 +14,11 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::node::SwarmSend;
 use crate::node::messages::{InventoryMessage, Message};
 use crate::node::request_response_handler::peer_block_knowledge::PeerBlockKnowledge;
+use crate::node::request_sender::RequestSender;
 use bitcoin::BlockHash;
 use libp2p::PeerId;
-use std::error::Error;
-use tokio::sync::mpsc;
 use tracing::debug;
 
 /// Send a block inventory announcement to one or all connected peers.
@@ -29,13 +27,17 @@ use tracing::debug;
 /// If `target_peer` is None, sends the inv to all `connected_peers`.
 /// Peers that are already known to have the block (tracked in
 /// `peer_block_knowledge`) are skipped.
-pub async fn send_block_inventory<C: Send + Sync>(
+///
+/// Sends directly via the swarm to avoid deadlocking the actor's
+/// select loop (which would happen if we awaited on the bounded
+/// swarm_tx channel that the actor also drains).
+pub fn send_block_inventory(
     block_hash: BlockHash,
     target_peer: Option<PeerId>,
     connected_peers: &[PeerId],
     peer_block_knowledge: &PeerBlockKnowledge,
-    swarm_tx: mpsc::Sender<SwarmSend<C>>,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+    request_sender: &mut impl RequestSender,
+) {
     let inventory_message = Message::Inventory(InventoryMessage::BlockHashes(vec![block_hash]));
 
     let target_peers: Vec<PeerId> = match target_peer {
@@ -48,21 +50,15 @@ pub async fn send_block_inventory<C: Send + Sync>(
             debug!("Skipping inv to peer {peer_id}: already knows block {block_hash}");
         } else {
             debug!("Sending Inv for block {block_hash} to peer {peer_id}");
-            swarm_tx
-                .send(SwarmSend::Request(peer_id, inventory_message.clone()))
-                .await
-                .map_err(|send_error| {
-                    format!("Failed to send inventory to peer {peer_id}: {send_error}")
-                })?;
+            request_sender.send_request(&peer_id, inventory_message.clone());
         }
     }
-
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::node::request_sender::MockRequestSender;
     use bitcoin::hashes::Hash as _;
 
     fn make_block_hash(value: u8) -> BlockHash {
@@ -71,66 +67,49 @@ mod tests {
         BlockHash::from_byte_array(bytes)
     }
 
-    #[tokio::test]
-    async fn test_send_block_inventory_to_single_peer() {
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+    #[test]
+    fn test_send_block_inventory_to_single_peer() {
         let peer_id = PeerId::random();
         let block_hash = make_block_hash(1);
         let knowledge = PeerBlockKnowledge::default();
 
-        let result =
-            send_block_inventory(block_hash, Some(peer_id), &[], &knowledge, swarm_tx).await;
-        assert!(result.is_ok());
+        let mut mock_sender = MockRequestSender::new();
+        mock_sender
+            .expect_send_request()
+            .withf(move |sent_peer_id, message| {
+                *sent_peer_id == peer_id
+                    && matches!(
+                        message,
+                        Message::Inventory(InventoryMessage::BlockHashes(hashes))
+                        if hashes == &vec![block_hash]
+                    )
+            })
+            .times(1)
+            .returning(|_, _| ());
 
-        if let Some(SwarmSend::Request(sent_peer_id, sent_message)) = swarm_rx.recv().await {
-            assert_eq!(sent_peer_id, peer_id);
-            match sent_message {
-                Message::Inventory(InventoryMessage::BlockHashes(hashes)) => {
-                    assert_eq!(hashes, vec![block_hash]);
-                }
-                _ => panic!("Unexpected message type"),
-            }
-        } else {
-            panic!("No message received");
-        }
+        send_block_inventory(block_hash, Some(peer_id), &[], &knowledge, &mut mock_sender);
     }
 
-    #[tokio::test]
-    async fn test_send_block_inventory_to_all_peers() {
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+    #[test]
+    fn test_send_block_inventory_to_all_peers() {
         let peer_a = PeerId::random();
         let peer_b = PeerId::random();
         let peer_c = PeerId::random();
         let block_hash = make_block_hash(1);
         let knowledge = PeerBlockKnowledge::default();
 
+        let mut mock_sender = MockRequestSender::new();
+        mock_sender
+            .expect_send_request()
+            .times(3)
+            .returning(|_, _| ());
+
         let connected = vec![peer_a, peer_b, peer_c];
-        let result = send_block_inventory(block_hash, None, &connected, &knowledge, swarm_tx).await;
-        assert!(result.is_ok());
-
-        // Should receive 3 messages, one for each peer
-        let mut received_peers = Vec::with_capacity(3);
-        for _ in 0..3 {
-            if let Some(SwarmSend::Request(sent_peer_id, Message::Inventory(_))) =
-                swarm_rx.recv().await
-            {
-                received_peers.push(sent_peer_id);
-            } else {
-                panic!("Expected SwarmSend::Request with Inventory message");
-            }
-        }
-
-        assert!(received_peers.contains(&peer_a));
-        assert!(received_peers.contains(&peer_b));
-        assert!(received_peers.contains(&peer_c));
-
-        // No more messages
-        assert!(swarm_rx.try_recv().is_err());
+        send_block_inventory(block_hash, None, &connected, &knowledge, &mut mock_sender);
     }
 
-    #[tokio::test]
-    async fn test_send_block_inventory_filters_known_peers() {
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+    #[test]
+    fn test_send_block_inventory_filters_known_peers() {
         let peer_a = PeerId::random();
         let peer_b = PeerId::random();
         let block_hash = make_block_hash(1);
@@ -138,48 +117,39 @@ mod tests {
         let mut knowledge = PeerBlockKnowledge::default();
         knowledge.record_block_known(&peer_a, block_hash);
 
+        let mut mock_sender = MockRequestSender::new();
+        mock_sender
+            .expect_send_request()
+            .withf(move |sent_peer_id, _| *sent_peer_id == peer_b)
+            .times(1)
+            .returning(|_, _| ());
+
         let connected = vec![peer_a, peer_b];
-        let result = send_block_inventory(block_hash, None, &connected, &knowledge, swarm_tx).await;
-        assert!(result.is_ok());
-
-        // Only peer_b should receive the message (peer_a already knows)
-        if let Some(SwarmSend::Request(sent_peer_id, _)) = swarm_rx.recv().await {
-            assert_eq!(sent_peer_id, peer_b);
-        } else {
-            panic!("Expected message for peer_b");
-        }
-
-        // No more messages
-        assert!(swarm_rx.try_recv().is_err());
+        send_block_inventory(block_hash, None, &connected, &knowledge, &mut mock_sender);
     }
 
-    #[tokio::test]
-    async fn test_send_block_inventory_skips_known_single_peer() {
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+    #[test]
+    fn test_send_block_inventory_skips_known_single_peer() {
         let peer_id = PeerId::random();
         let block_hash = make_block_hash(1);
 
         let mut knowledge = PeerBlockKnowledge::default();
         knowledge.record_block_known(&peer_id, block_hash);
 
-        let result =
-            send_block_inventory(block_hash, Some(peer_id), &[], &knowledge, swarm_tx).await;
-        assert!(result.is_ok());
+        let mut mock_sender = MockRequestSender::new();
+        mock_sender.expect_send_request().never();
 
-        // No message should be sent since the peer already knows
-        assert!(swarm_rx.try_recv().is_err());
+        send_block_inventory(block_hash, Some(peer_id), &[], &knowledge, &mut mock_sender);
     }
 
-    #[tokio::test]
-    async fn test_send_block_inventory_no_connected_peers() {
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+    #[test]
+    fn test_send_block_inventory_no_connected_peers() {
         let block_hash = make_block_hash(1);
         let knowledge = PeerBlockKnowledge::default();
 
-        let result = send_block_inventory(block_hash, None, &[], &knowledge, swarm_tx).await;
-        assert!(result.is_ok());
+        let mut mock_sender = MockRequestSender::new();
+        mock_sender.expect_send_request().never();
 
-        // No messages sent
-        assert!(swarm_rx.try_recv().is_err());
+        send_block_inventory(block_hash, None, &[], &knowledge, &mut mock_sender);
     }
 }

--- a/p2poolv2_lib/src/node/p2p_message_handlers/senders/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/senders/mod.rs
@@ -17,7 +17,9 @@
 pub mod getheaders;
 pub mod handshake;
 pub mod inventory;
+pub mod share_block;
 
 pub use getheaders::send_getheaders;
 pub use handshake::send_handshake;
 pub use inventory::send_block_inventory;
+pub use share_block::send_share_block_broadcast;

--- a/p2poolv2_lib/src/node/p2p_message_handlers/senders/share_block.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/senders/share_block.rs
@@ -1,0 +1,171 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::node::SwarmSend;
+use crate::node::messages::Message;
+use crate::node::request_response_handler::peer_block_knowledge::PeerBlockKnowledge;
+use crate::shares::share_block::ShareBlock;
+use libp2p::PeerId;
+use std::error::Error;
+use tokio::sync::mpsc;
+use tracing::debug;
+
+/// Broadcast a full ShareBlock to all connected peers.
+///
+/// Peers that are already known to have the block (tracked in
+/// `peer_block_knowledge`) are skipped. Returns the list of peers
+/// that were sent the block, so the caller can record outbound
+/// knowledge.
+pub async fn send_share_block_broadcast<C: Send + Sync>(
+    share_block: ShareBlock,
+    connected_peers: &[PeerId],
+    peer_block_knowledge: &PeerBlockKnowledge,
+    swarm_tx: mpsc::Sender<SwarmSend<C>>,
+) -> Result<Vec<PeerId>, Box<dyn Error + Send + Sync>> {
+    let block_hash = share_block.block_hash();
+    let mut sent_to_peers = Vec::with_capacity(connected_peers.len());
+
+    for peer_id in connected_peers {
+        if peer_block_knowledge.peer_knows_block(peer_id, &block_hash) {
+            debug!("Skipping broadcast to peer {peer_id}: already knows block {block_hash}");
+        } else {
+            debug!("Broadcasting ShareBlock {block_hash} to peer {peer_id}");
+            swarm_tx
+                .send(SwarmSend::Request(
+                    *peer_id,
+                    Message::ShareBlock(share_block.clone()),
+                ))
+                .await
+                .map_err(|send_error| {
+                    format!("Failed to send ShareBlock to peer {peer_id}: {send_error}")
+                })?;
+            sent_to_peers.push(*peer_id);
+        }
+    }
+
+    Ok(sent_to_peers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TestShareBlockBuilder;
+
+    #[tokio::test]
+    async fn test_broadcast_to_all_peers() {
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+        let peer_c = PeerId::random();
+        let share_block = TestShareBlockBuilder::new().build();
+        let block_hash = share_block.block_hash();
+        let knowledge = PeerBlockKnowledge::default();
+
+        let connected = vec![peer_a, peer_b, peer_c];
+        let result =
+            send_share_block_broadcast(share_block, &connected, &knowledge, swarm_tx).await;
+        assert!(result.is_ok());
+
+        let sent_to = result.unwrap();
+        assert_eq!(sent_to.len(), 3);
+        assert!(sent_to.contains(&peer_a));
+        assert!(sent_to.contains(&peer_b));
+        assert!(sent_to.contains(&peer_c));
+
+        let mut received_peers = Vec::with_capacity(3);
+        for _ in 0..3 {
+            if let Some(SwarmSend::Request(sent_peer_id, Message::ShareBlock(ref block))) =
+                swarm_rx.recv().await
+            {
+                assert_eq!(block.block_hash(), block_hash);
+                received_peers.push(sent_peer_id);
+            } else {
+                panic!("Expected SwarmSend::Request with ShareBlock message");
+            }
+        }
+
+        assert!(received_peers.contains(&peer_a));
+        assert!(received_peers.contains(&peer_b));
+        assert!(received_peers.contains(&peer_c));
+
+        assert!(swarm_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_filters_known_peers() {
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+        let share_block = TestShareBlockBuilder::new().build();
+        let block_hash = share_block.block_hash();
+
+        let mut knowledge = PeerBlockKnowledge::default();
+        knowledge.record_block_known(&peer_a, block_hash);
+
+        let connected = vec![peer_a, peer_b];
+        let result =
+            send_share_block_broadcast(share_block, &connected, &knowledge, swarm_tx).await;
+        assert!(result.is_ok());
+
+        let sent_to = result.unwrap();
+        assert_eq!(sent_to.len(), 1);
+        assert_eq!(sent_to[0], peer_b);
+
+        if let Some(SwarmSend::Request(sent_peer_id, _)) = swarm_rx.recv().await {
+            assert_eq!(sent_peer_id, peer_b);
+        } else {
+            panic!("Expected message for peer_b");
+        }
+
+        assert!(swarm_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_skips_all_known_peers() {
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+        let share_block = TestShareBlockBuilder::new().build();
+        let block_hash = share_block.block_hash();
+
+        let mut knowledge = PeerBlockKnowledge::default();
+        knowledge.record_block_known(&peer_a, block_hash);
+        knowledge.record_block_known(&peer_b, block_hash);
+
+        let connected = vec![peer_a, peer_b];
+        let result =
+            send_share_block_broadcast(share_block, &connected, &knowledge, swarm_tx).await;
+        assert!(result.is_ok());
+
+        let sent_to = result.unwrap();
+        assert!(sent_to.is_empty());
+        assert!(swarm_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_no_connected_peers() {
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+        let share_block = TestShareBlockBuilder::new().build();
+        let knowledge = PeerBlockKnowledge::default();
+
+        let result = send_share_block_broadcast(share_block, &[], &knowledge, swarm_tx).await;
+        assert!(result.is_ok());
+
+        let sent_to = result.unwrap();
+        assert!(sent_to.is_empty());
+        assert!(swarm_rx.try_recv().is_err());
+    }
+}

--- a/p2poolv2_lib/src/node/p2p_message_handlers/senders/share_block.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/senders/share_block.rs
@@ -14,13 +14,11 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::node::SwarmSend;
 use crate::node::messages::Message;
 use crate::node::request_response_handler::peer_block_knowledge::PeerBlockKnowledge;
+use crate::node::request_sender::RequestSender;
 use crate::shares::share_block::ShareBlock;
 use libp2p::PeerId;
-use std::error::Error;
-use tokio::sync::mpsc;
 use tracing::debug;
 
 /// Broadcast a full ShareBlock to all connected peers.
@@ -29,12 +27,16 @@ use tracing::debug;
 /// `peer_block_knowledge`) are skipped. Each recipient is recorded
 /// in `peer_block_knowledge` so that subsequent broadcasts of the
 /// same block are suppressed.
-pub async fn send_share_block_broadcast<C: Send + Sync>(
+///
+/// Sends directly via the swarm to avoid deadlocking the actor's
+/// select loop (which would happen if we awaited on the bounded
+/// swarm_tx channel that the actor also drains).
+pub fn send_share_block_broadcast(
     share_block: ShareBlock,
     connected_peers: &[PeerId],
     peer_block_knowledge: &mut PeerBlockKnowledge,
-    swarm_tx: mpsc::Sender<SwarmSend<C>>,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+    request_sender: &mut impl RequestSender,
+) {
     let block_hash = share_block.block_hash();
 
     for peer_id in connected_peers {
@@ -42,30 +44,20 @@ pub async fn send_share_block_broadcast<C: Send + Sync>(
             debug!("Skipping broadcast to peer {peer_id}: already knows block {block_hash}");
         } else {
             debug!("Broadcasting ShareBlock {block_hash} to peer {peer_id}");
-            swarm_tx
-                .send(SwarmSend::Request(
-                    *peer_id,
-                    Message::ShareBlock(share_block.clone()),
-                ))
-                .await
-                .map_err(|send_error| {
-                    format!("Failed to send ShareBlock to peer {peer_id}: {send_error}")
-                })?;
+            request_sender.send_request(peer_id, Message::ShareBlock(share_block.clone()));
             peer_block_knowledge.record_block_known(peer_id, block_hash);
         }
     }
-
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::node::request_sender::MockRequestSender;
     use crate::test_utils::TestShareBlockBuilder;
 
-    #[tokio::test]
-    async fn test_broadcast_to_all_peers() {
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+    #[test]
+    fn test_broadcast_to_all_peers() {
         let peer_a = PeerId::random();
         let peer_b = PeerId::random();
         let peer_c = PeerId::random();
@@ -73,36 +65,22 @@ mod tests {
         let block_hash = share_block.block_hash();
         let mut knowledge = PeerBlockKnowledge::default();
 
+        let mut mock_sender = MockRequestSender::new();
+        mock_sender
+            .expect_send_request()
+            .times(3)
+            .returning(|_, _| ());
+
         let connected = vec![peer_a, peer_b, peer_c];
-        let result =
-            send_share_block_broadcast(share_block, &connected, &mut knowledge, swarm_tx).await;
-        assert!(result.is_ok());
-
-        let mut received_peers = Vec::with_capacity(3);
-        for _ in 0..3 {
-            if let Some(SwarmSend::Request(sent_peer_id, Message::ShareBlock(ref block))) =
-                swarm_rx.recv().await
-            {
-                assert_eq!(block.block_hash(), block_hash);
-                received_peers.push(sent_peer_id);
-            } else {
-                panic!("Expected SwarmSend::Request with ShareBlock message");
-            }
-        }
-
-        assert!(received_peers.contains(&peer_a));
-        assert!(received_peers.contains(&peer_b));
-        assert!(received_peers.contains(&peer_c));
-        assert!(swarm_rx.try_recv().is_err());
+        send_share_block_broadcast(share_block, &connected, &mut knowledge, &mut mock_sender);
 
         assert!(knowledge.peer_knows_block(&peer_a, &block_hash));
         assert!(knowledge.peer_knows_block(&peer_b, &block_hash));
         assert!(knowledge.peer_knows_block(&peer_c, &block_hash));
     }
 
-    #[tokio::test]
-    async fn test_broadcast_filters_known_peers() {
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+    #[test]
+    fn test_broadcast_filters_known_peers() {
         let peer_a = PeerId::random();
         let peer_b = PeerId::random();
         let share_block = TestShareBlockBuilder::new().build();
@@ -111,24 +89,21 @@ mod tests {
         let mut knowledge = PeerBlockKnowledge::default();
         knowledge.record_block_known(&peer_a, block_hash);
 
+        let mut mock_sender = MockRequestSender::new();
+        mock_sender
+            .expect_send_request()
+            .withf(move |sent_peer_id, _| *sent_peer_id == peer_b)
+            .times(1)
+            .returning(|_, _| ());
+
         let connected = vec![peer_a, peer_b];
-        let result =
-            send_share_block_broadcast(share_block, &connected, &mut knowledge, swarm_tx).await;
-        assert!(result.is_ok());
+        send_share_block_broadcast(share_block, &connected, &mut knowledge, &mut mock_sender);
 
-        if let Some(SwarmSend::Request(sent_peer_id, _)) = swarm_rx.recv().await {
-            assert_eq!(sent_peer_id, peer_b);
-        } else {
-            panic!("Expected message for peer_b");
-        }
-
-        assert!(swarm_rx.try_recv().is_err());
         assert!(knowledge.peer_knows_block(&peer_b, &block_hash));
     }
 
-    #[tokio::test]
-    async fn test_broadcast_skips_all_known_peers() {
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+    #[test]
+    fn test_broadcast_skips_all_known_peers() {
         let peer_a = PeerId::random();
         let peer_b = PeerId::random();
         let share_block = TestShareBlockBuilder::new().build();
@@ -138,21 +113,21 @@ mod tests {
         knowledge.record_block_known(&peer_a, block_hash);
         knowledge.record_block_known(&peer_b, block_hash);
 
+        let mut mock_sender = MockRequestSender::new();
+        mock_sender.expect_send_request().never();
+
         let connected = vec![peer_a, peer_b];
-        let result =
-            send_share_block_broadcast(share_block, &connected, &mut knowledge, swarm_tx).await;
-        assert!(result.is_ok());
-        assert!(swarm_rx.try_recv().is_err());
+        send_share_block_broadcast(share_block, &connected, &mut knowledge, &mut mock_sender);
     }
 
-    #[tokio::test]
-    async fn test_broadcast_no_connected_peers() {
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
+    #[test]
+    fn test_broadcast_no_connected_peers() {
         let share_block = TestShareBlockBuilder::new().build();
         let mut knowledge = PeerBlockKnowledge::default();
 
-        let result = send_share_block_broadcast(share_block, &[], &mut knowledge, swarm_tx).await;
-        assert!(result.is_ok());
-        assert!(swarm_rx.try_recv().is_err());
+        let mut mock_sender = MockRequestSender::new();
+        mock_sender.expect_send_request().never();
+
+        send_share_block_broadcast(share_block, &[], &mut knowledge, &mut mock_sender);
     }
 }

--- a/p2poolv2_lib/src/node/p2p_message_handlers/senders/share_block.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/senders/share_block.rs
@@ -26,17 +26,16 @@ use tracing::debug;
 /// Broadcast a full ShareBlock to all connected peers.
 ///
 /// Peers that are already known to have the block (tracked in
-/// `peer_block_knowledge`) are skipped. Returns the list of peers
-/// that were sent the block, so the caller can record outbound
-/// knowledge.
+/// `peer_block_knowledge`) are skipped. Each recipient is recorded
+/// in `peer_block_knowledge` so that subsequent broadcasts of the
+/// same block are suppressed.
 pub async fn send_share_block_broadcast<C: Send + Sync>(
     share_block: ShareBlock,
     connected_peers: &[PeerId],
-    peer_block_knowledge: &PeerBlockKnowledge,
+    peer_block_knowledge: &mut PeerBlockKnowledge,
     swarm_tx: mpsc::Sender<SwarmSend<C>>,
-) -> Result<Vec<PeerId>, Box<dyn Error + Send + Sync>> {
+) -> Result<(), Box<dyn Error + Send + Sync>> {
     let block_hash = share_block.block_hash();
-    let mut sent_to_peers = Vec::with_capacity(connected_peers.len());
 
     for peer_id in connected_peers {
         if peer_block_knowledge.peer_knows_block(peer_id, &block_hash) {
@@ -52,11 +51,11 @@ pub async fn send_share_block_broadcast<C: Send + Sync>(
                 .map_err(|send_error| {
                     format!("Failed to send ShareBlock to peer {peer_id}: {send_error}")
                 })?;
-            sent_to_peers.push(*peer_id);
+            peer_block_knowledge.record_block_known(peer_id, block_hash);
         }
     }
 
-    Ok(sent_to_peers)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -72,18 +71,12 @@ mod tests {
         let peer_c = PeerId::random();
         let share_block = TestShareBlockBuilder::new().build();
         let block_hash = share_block.block_hash();
-        let knowledge = PeerBlockKnowledge::default();
+        let mut knowledge = PeerBlockKnowledge::default();
 
         let connected = vec![peer_a, peer_b, peer_c];
         let result =
-            send_share_block_broadcast(share_block, &connected, &knowledge, swarm_tx).await;
+            send_share_block_broadcast(share_block, &connected, &mut knowledge, swarm_tx).await;
         assert!(result.is_ok());
-
-        let sent_to = result.unwrap();
-        assert_eq!(sent_to.len(), 3);
-        assert!(sent_to.contains(&peer_a));
-        assert!(sent_to.contains(&peer_b));
-        assert!(sent_to.contains(&peer_c));
 
         let mut received_peers = Vec::with_capacity(3);
         for _ in 0..3 {
@@ -100,8 +93,11 @@ mod tests {
         assert!(received_peers.contains(&peer_a));
         assert!(received_peers.contains(&peer_b));
         assert!(received_peers.contains(&peer_c));
-
         assert!(swarm_rx.try_recv().is_err());
+
+        assert!(knowledge.peer_knows_block(&peer_a, &block_hash));
+        assert!(knowledge.peer_knows_block(&peer_b, &block_hash));
+        assert!(knowledge.peer_knows_block(&peer_c, &block_hash));
     }
 
     #[tokio::test]
@@ -117,12 +113,8 @@ mod tests {
 
         let connected = vec![peer_a, peer_b];
         let result =
-            send_share_block_broadcast(share_block, &connected, &knowledge, swarm_tx).await;
+            send_share_block_broadcast(share_block, &connected, &mut knowledge, swarm_tx).await;
         assert!(result.is_ok());
-
-        let sent_to = result.unwrap();
-        assert_eq!(sent_to.len(), 1);
-        assert_eq!(sent_to[0], peer_b);
 
         if let Some(SwarmSend::Request(sent_peer_id, _)) = swarm_rx.recv().await {
             assert_eq!(sent_peer_id, peer_b);
@@ -131,6 +123,7 @@ mod tests {
         }
 
         assert!(swarm_rx.try_recv().is_err());
+        assert!(knowledge.peer_knows_block(&peer_b, &block_hash));
     }
 
     #[tokio::test]
@@ -147,11 +140,8 @@ mod tests {
 
         let connected = vec![peer_a, peer_b];
         let result =
-            send_share_block_broadcast(share_block, &connected, &knowledge, swarm_tx).await;
+            send_share_block_broadcast(share_block, &connected, &mut knowledge, swarm_tx).await;
         assert!(result.is_ok());
-
-        let sent_to = result.unwrap();
-        assert!(sent_to.is_empty());
         assert!(swarm_rx.try_recv().is_err());
     }
 
@@ -159,13 +149,10 @@ mod tests {
     async fn test_broadcast_no_connected_peers() {
         let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<u32>>(10);
         let share_block = TestShareBlockBuilder::new().build();
-        let knowledge = PeerBlockKnowledge::default();
+        let mut knowledge = PeerBlockKnowledge::default();
 
-        let result = send_share_block_broadcast(share_block, &[], &knowledge, swarm_tx).await;
+        let result = send_share_block_broadcast(share_block, &[], &mut knowledge, swarm_tx).await;
         assert!(result.is_ok());
-
-        let sent_to = result.unwrap();
-        assert!(sent_to.is_empty());
         assert!(swarm_rx.try_recv().is_err());
     }
 }

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -172,6 +172,14 @@ impl<C: Send + Sync + 'static> RequestResponseHandler<C> {
         &self.peer_block_knowledge
     }
 
+    /// Returns a mutable reference to the peer block knowledge tracker.
+    ///
+    /// Used by the actor to record outbound block broadcasts so that
+    /// subsequent broadcast attempts for the same block are suppressed.
+    pub fn peer_block_knowledge_mut(&mut self) -> &mut PeerBlockKnowledge {
+        &mut self.peer_block_knowledge
+    }
+
     /// Spawn a per-peer service task for a newly connected peer.
     ///
     /// If a handle already exists for this peer (e.g. duplicate

--- a/p2poolv2_lib/src/node/request_sender.rs
+++ b/p2poolv2_lib/src/node/request_sender.rs
@@ -1,0 +1,36 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::node::behaviour::P2PoolBehaviour;
+use crate::node::messages::Message;
+use libp2p::{PeerId, Swarm};
+
+/// Trait for sending request-response messages directly via the swarm.
+///
+/// Abstracts the `swarm.behaviour_mut().request_response.send_request()`
+/// call so that sender functions can be tested without a real swarm.
+#[cfg_attr(test, mockall::automock)]
+pub trait RequestSender {
+    fn send_request(&mut self, peer_id: &PeerId, message: Message);
+}
+
+impl RequestSender for Swarm<P2PoolBehaviour> {
+    fn send_request(&mut self, peer_id: &PeerId, message: Message) {
+        self.behaviour_mut()
+            .request_response
+            .send_request(peer_id, message);
+    }
+}

--- a/p2poolv2_lib/src/node/validation_worker.rs
+++ b/p2poolv2_lib/src/node/validation_worker.rs
@@ -19,7 +19,7 @@
 //! Receives `ValidationEvent` values containing blockhash to validate. It reads the
 //! corresponding share block from the chain store, validates them using
 //! `shares::validation::validate_share_block`, and on success emits
-//! `OrganiseEvent::Block` and `SwarmSend::Inv` events. Runs in a dedicated
+//! `OrganiseEvent::Block` and `SwarmSend::BroadcastBlock` events. Runs in a dedicated
 //! tokio task, decoupled from the P2P message handler hot path.
 
 use crate::node::SwarmSend;
@@ -85,7 +85,7 @@ impl std::error::Error for ValidationWorkerError {}
 /// Receives `ValidationEvent` values containing block hashes, reads
 /// the share block from the chain store, validates it, and on success
 /// emits `OrganiseEvent::Block` for confirmed promotion and
-/// `SwarmSend::Inv` for inventory relay to peers.
+/// `SwarmSend::BroadcastBlock` for block relay to peers.
 ///
 /// After successful validation, the organise worker handles PPLNS
 /// updates and dependent scheduling.
@@ -207,14 +207,19 @@ async fn validate_and_emit(
 
     debug!("Share block {block_hash} validated successfully");
 
+    // Clone before moving to organise_tx, since BroadcastBlock needs the full block.
+    let share_block_for_broadcast = share_block.clone();
     if let Err(send_error) = organise_tx.send(OrganiseEvent::Block(share_block)).await {
         error!("Failed to send validated block to organise worker: {send_error}");
     }
 
-    // Relay block once context free validations are run. If later
+    // Broadcast block once context free validations are run. If later
     // the block is not confirmed, peers should have a copy anyway.
-    if let Err(send_error) = swarm_tx.send(SwarmSend::Inv(block_hash)).await {
-        error!("Failed to send inv relay for validated block {block_hash}: {send_error}");
+    if let Err(send_error) = swarm_tx
+        .send(SwarmSend::BroadcastBlock(share_block_for_broadcast))
+        .await
+    {
+        error!("Failed to send broadcast for validated block {block_hash}: {send_error}");
     }
 }
 
@@ -277,7 +282,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validation_worker_sends_inv_on_success() {
+    async fn test_validation_worker_sends_broadcast_on_success() {
         let (validation_tx, validation_rx) = create_validation_channel();
         let mut mock_chain_handle = MockChainStoreHandle::new();
 
@@ -315,10 +320,10 @@ mod tests {
             .unwrap();
 
         let swarm_event = tokio::time::timeout(Duration::from_secs(2), swarm_rx.recv()).await;
-        if let Ok(Some(SwarmSend::Inv(sent_block_hash))) = swarm_event {
-            assert_eq!(sent_block_hash, block_hash);
+        if let Ok(Some(SwarmSend::BroadcastBlock(broadcast_block))) = swarm_event {
+            assert_eq!(broadcast_block.block_hash(), block_hash);
         } else {
-            panic!("Expected SwarmSend::Inv after successful validation");
+            panic!("Expected SwarmSend::BroadcastBlock after successful validation");
         }
 
         worker_handle.abort();

--- a/p2poolv2_lib/src/node/validation_worker.rs
+++ b/p2poolv2_lib/src/node/validation_worker.rs
@@ -175,6 +175,10 @@ impl ValidationWorker {
 /// Read a share block from the store, validate it, and emit events
 /// on success.
 ///
+/// Sends `OrganiseEvent::Block` for chain promotion. Only broadcasts
+/// to peers when the chain is current, suppressing relay of historic
+/// blocks during initial sync or catchup.
+///
 /// Duplicate validation of already-confirmed blocks is handled by
 /// `validate_share_block` which returns Ok immediately for blocks
 /// with `BlockValid` status.
@@ -207,19 +211,24 @@ async fn validate_and_emit(
 
     debug!("Share block {block_hash} validated successfully");
 
-    // Clone before moving to organise_tx, since BroadcastBlock needs the full block.
-    let share_block_for_broadcast = share_block.clone();
-    if let Err(send_error) = organise_tx.send(OrganiseEvent::Block(share_block)).await {
+    if let Err(send_error) = organise_tx
+        .send(OrganiseEvent::Block(share_block.clone()))
+        .await
+    {
         error!("Failed to send validated block to organise worker: {send_error}");
     }
 
-    // Broadcast block once context free validations are run. If later
-    // the block is not confirmed, peers should have a copy anyway.
-    if let Err(send_error) = swarm_tx
-        .send(SwarmSend::BroadcastBlock(share_block_for_broadcast))
-        .await
-    {
-        error!("Failed to send broadcast for validated block {block_hash}: {send_error}");
+    // Only broadcast when the chain is current. During initial sync or
+    // catchup, validated historic blocks should not be relayed to peers.
+    //
+    // Broadcast block after validation, if later confirmation fails,
+    // the peers should have this block anyway.
+    if chain_store_handle.is_current() {
+        if let Err(send_error) = swarm_tx.send(SwarmSend::BroadcastBlock(share_block)).await {
+            error!("Failed to send broadcast for validated block {block_hash}: {send_error}");
+        }
+    } else {
+        debug!("Skipping broadcast for {block_hash} - chain not current");
     }
 }
 
@@ -247,6 +256,7 @@ mod tests {
             .expect_get_share()
             .returning(move |_| Some(share_block_clone.clone()));
         mock_clone.expect_has_status().returning(|_, _| true);
+        mock_clone.expect_is_current().returning(|| true);
         mock_chain_handle
             .expect_clone()
             .return_once(move || mock_clone);
@@ -295,6 +305,7 @@ mod tests {
             .expect_get_share()
             .returning(move |_| Some(share_block_clone.clone()));
         mock_clone.expect_has_status().returning(|_, _| true);
+        mock_clone.expect_is_current().returning(|| true);
         mock_chain_handle
             .expect_clone()
             .return_once(move || mock_clone);
@@ -325,6 +336,63 @@ mod tests {
         } else {
             panic!("Expected SwarmSend::BroadcastBlock after successful validation");
         }
+
+        worker_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_validation_worker_skips_broadcast_when_not_current() {
+        let (validation_tx, validation_rx) = create_validation_channel();
+        let mut mock_chain_handle = MockChainStoreHandle::new();
+
+        let share_block = TestShareBlockBuilder::new().build();
+        let block_hash = share_block.block_hash();
+        let share_block_clone = share_block.clone();
+
+        let mut mock_clone = MockChainStoreHandle::new();
+        mock_clone
+            .expect_get_share()
+            .returning(move |_| Some(share_block_clone.clone()));
+        mock_clone.expect_has_status().returning(|_, _| true);
+        mock_clone.expect_is_current().returning(|| false);
+        mock_chain_handle
+            .expect_clone()
+            .return_once(move || mock_clone);
+
+        let (organise_tx, mut organise_rx) = organise_worker::create_organise_channel();
+        let (swarm_tx, mut swarm_rx) = mpsc::channel(32);
+
+        let worker = ValidationWorker::new(
+            validation_rx,
+            mock_chain_handle,
+            organise_tx,
+            swarm_tx,
+            1,
+            b"P2Poolv2".to_vec(),
+            PoolDifficulty::default(),
+        );
+
+        let worker_handle = tokio::spawn(worker.run());
+
+        validation_tx
+            .send(ValidationEvent::ValidateBlock(block_hash))
+            .await
+            .unwrap();
+
+        // Organisation event should still be sent
+        let organise_event = tokio::time::timeout(Duration::from_secs(2), organise_rx.recv()).await;
+        if let Ok(Some(OrganiseEvent::Block(received_block))) = organise_event {
+            assert_eq!(received_block.block_hash(), block_hash);
+        } else {
+            panic!("Expected OrganiseEvent::Block even when not current");
+        }
+
+        // Broadcast should NOT be sent during sync
+        let swarm_result = tokio::time::timeout(Duration::from_millis(500), swarm_rx.recv()).await;
+        assert!(
+            swarm_result.is_err(),
+            "No SwarmSend expected when chain is not current"
+        );
 
         worker_handle.abort();
     }


### PR DESCRIPTION
For ease of debugging we used to follow the old loop of inv -> getheaders -> headers -> get data -> block when new share blocks were found. @AdamISZ noticed this results in high latency of block propagation. See issue #562 .

This PR, removes the round trips and immediately sends a share block once it is mined or received from a peer and validated. We lean on existing infra to detect peer block knowledge before sending a block to a peer. This avoid duplicate sends to a peers. We also have existing infra now that can handle validating and confirming blocks as they arrive.

This change should result in lowering the uncle rate as found from the work in #558 .