### PR TITLE
Update Candidate chain when local block is Confirmed bypassing the candidate chain

### DIFF
--- a/debug_tools/README.md
+++ b/debug_tools/README.md
@@ -63,7 +63,7 @@ Checks performed:
 - Uncle parent is an ancestor of the nephew (ancestor-type, not sibling)
 
 ```
-just run /path/to/store.db
+just verify_chain /path/to/store.db
 ```
 
 Returns exit code 0 on success, 1 if any errors are found.

--- a/justfile
+++ b/justfile
@@ -97,7 +97,7 @@ bench-flamegraph package="p2poolv2_lib" name="pplns_window" function="get_addres
 
 # Verify chain integrity in a store.db
 verify_chain db_path:
-    cargo run --bin verify_chain --features debug-tools -- {{ db_path }}
+    cargo run --release --bin verify_chain --features debug-tools -- {{ db_path }}
 
 # fix common warnings
 fix:

--- a/p2poolv2_lib/src/store/organise/candidate.rs
+++ b/p2poolv2_lib/src/store/organise/candidate.rs
@@ -68,9 +68,10 @@ impl Store {
 
     /// Directly set top candidate height without consecutive-height validation.
     ///
-    /// Used by `reorg_candidate` which computes the correct final height
-    /// locally instead of reading stale DB state within a single WriteBatch.
-    fn set_top_candidate_height(&self, height: Height, batch: &mut rocksdb::WriteBatch) {
+    /// Used by `reorg_candidate` and `try_fallback_confirmation` which
+    /// compute the correct final height locally instead of reading
+    /// stale DB state within a single WriteBatch.
+    pub(super) fn set_top_candidate_height(&self, height: Height, batch: &mut rocksdb::WriteBatch) {
         let block_height_cf = self.db.cf_handle(&ColumnFamily::BlockHeight).unwrap();
         let serialized_height = consensus::serialize(&height);
         batch.put_cf(
@@ -101,7 +102,11 @@ impl Store {
     }
 
     /// Write a candidate index entry directly into the batch.
-    fn put_candidate_entry(
+    /// Write a candidate index entry directly into the batch.
+    ///
+    /// Used by `try_fallback_confirmation` to add the confirmed block
+    /// to the candidate index without touching metadata status.
+    pub(super) fn put_candidate_entry(
         &self,
         height: Height,
         blockhash: &BlockHash,

--- a/p2poolv2_lib/src/store/organise/candidate.rs
+++ b/p2poolv2_lib/src/store/organise/candidate.rs
@@ -68,10 +68,9 @@ impl Store {
 
     /// Directly set top candidate height without consecutive-height validation.
     ///
-    /// Used by `reorg_candidate` and `try_fallback_confirmation` which
-    /// compute the correct final height locally instead of reading
-    /// stale DB state within a single WriteBatch.
-    pub(super) fn set_top_candidate_height(&self, height: Height, batch: &mut rocksdb::WriteBatch) {
+    /// Used by `reorg_candidate` which computes the correct final height
+    /// locally instead of reading stale DB state within a single WriteBatch.
+    fn set_top_candidate_height(&self, height: Height, batch: &mut rocksdb::WriteBatch) {
         let block_height_cf = self.db.cf_handle(&ColumnFamily::BlockHeight).unwrap();
         let serialized_height = consensus::serialize(&height);
         batch.put_cf(
@@ -101,12 +100,7 @@ impl Store {
         }
     }
 
-    /// Write a candidate index entry directly into the batch.
-    /// Write a candidate index entry directly into the batch.
-    ///
-    /// Used by `try_fallback_confirmation` to add the confirmed block
-    /// to the candidate index without touching metadata status.
-    pub(super) fn put_candidate_entry(
+    fn put_candidate_entry(
         &self,
         height: Height,
         blockhash: &BlockHash,

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -91,6 +91,13 @@ impl Store {
                     "Fallback confirmation: block {blockhash} at height {next_height} \
                      extends confirmed tip"
                 );
+                // Write the candidate index entry so the candidate
+                // chain stays consistent with the confirmed chain.
+                // Only the index is updated -- metadata status is left
+                // untouched so extend_confirmed is the sole writer
+                // that sets it to Confirmed.
+                self.put_candidate_entry(next_height, blockhash, batch);
+                self.set_top_candidate_height(next_height, batch);
                 let candidates = vec![(next_height, *blockhash)];
                 return self.extend_confirmed(next_height, &candidates, batch);
             }

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -91,13 +91,6 @@ impl Store {
                     "Fallback confirmation: block {blockhash} at height {next_height} \
                      extends confirmed tip"
                 );
-                // Write the candidate index entry so the candidate
-                // chain stays consistent with the confirmed chain.
-                // Only the index is updated -- metadata status is left
-                // untouched so extend_confirmed is the sole writer
-                // that sets it to Confirmed.
-                self.put_candidate_entry(next_height, blockhash, batch);
-                self.set_top_candidate_height(next_height, batch);
                 let candidates = vec![(next_height, *blockhash)];
                 return self.extend_confirmed(next_height, &candidates, batch);
             }

--- a/p2poolv2_lib/src/store/organise/organise_header.rs
+++ b/p2poolv2_lib/src/store/organise/organise_header.rs
@@ -899,4 +899,85 @@ mod tests {
         store.commit_batch(batch).unwrap();
         assert!(result.is_ok());
     }
+
+    /// Fallback confirmation must also extend the candidate chain so
+    /// that a later organise_header call does not overwrite the
+    /// Confirmed status.
+    ///
+    /// Scenario:
+    /// - genesis -> share1(h:1) confirmed via push_to_confirmed_chain
+    ///   (share1 is also the top candidate)
+    /// - share2(h:2, parent=share1) stored with block data and valid
+    ///   metadata but NOT on the candidate chain.
+    /// - organise_block promotes share2 via try_fallback_confirmation.
+    ///   The fix: fallback also writes a candidate entry so the
+    ///   candidate chain stays consistent with the confirmed chain.
+    /// - organise_header(share2) is called again (peer re-send).
+    ///   share2 must remain Confirmed.
+    #[test]
+    fn test_fallback_confirmation_extends_candidate_chain() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // share1: confirmed at h:1, also top candidate
+        let share1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695792)
+            .build();
+        store.push_to_confirmed_chain(&share1).unwrap();
+        assert!(store.is_confirmed(&share1.block_hash()));
+
+        let top_candidate = store.get_top_candidate().unwrap();
+        assert_eq!(top_candidate.hash, share1.block_hash());
+        assert_eq!(top_candidate.height, 1);
+
+        // share2: child of share1, stored with block data and
+        // HeaderValid metadata but NOT on the candidate chain.
+        let share2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share1.block_hash().to_string())
+            .nonce(0xe9695793)
+            .build();
+        store.store_with_valid_metadata(&share2);
+
+        // Promote share2 via fallback confirmation (organise_block).
+        // try_fallback_confirmation finds share2 at h:2 with parent =
+        // confirmed tip (share1) and promotes it to Confirmed.
+        // The fix also extends the candidate chain.
+        let mut batch = Store::get_write_batch();
+        let result = store.organise_block(&mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+        assert_eq!(result, Some(2));
+        assert!(store.is_confirmed(&share2.block_hash()));
+        assert_eq!(store.get_top_confirmed_height().unwrap(), 2);
+
+        // Candidate chain must also be extended to share2
+        let top_candidate = store.get_top_candidate().unwrap();
+        assert_eq!(top_candidate.hash, share2.block_hash());
+        assert_eq!(top_candidate.height, 2);
+
+        // Simulate a peer re-sending share2's header.
+        // organise_header must not downgrade the Confirmed status.
+        let mut batch = Store::get_write_batch();
+        store.organise_header(&share2.header, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let metadata = store.get_block_metadata(&share2.block_hash()).unwrap();
+        assert_eq!(
+            metadata.status,
+            Status::Confirmed,
+            "organise_header must not downgrade Confirmed to Candidate \
+             after fallback confirmation extended the candidate chain"
+        );
+
+        // The confirmed index must still point to share2
+        assert_eq!(
+            store.get_confirmed_at_height(2).unwrap(),
+            share2.block_hash()
+        );
+    }
 }

--- a/p2poolv2_lib/src/store/organise/organise_header.rs
+++ b/p2poolv2_lib/src/store/organise/organise_header.rs
@@ -65,6 +65,17 @@ impl Store {
             }
         };
 
+        // A Confirmed block must not be re-organised into the candidate
+        // chain. This can happen when a peer re-sends a block that was
+        // already confirmed via try_fallback_confirmation while the
+        // candidate chain was on a different fork. Without this guard,
+        // should_extend_candidates would match (parent == top candidate,
+        // height and work match) and append_to_candidates would
+        // overwrite the Confirmed status to Candidate.
+        if metadata.status == Status::Confirmed {
+            return Ok(None);
+        }
+
         let top_candidate = self.get_top_candidate().ok();
         let Some(top_confirmed) = self.get_top_confirmed().ok() else {
             return Err(StoreError::Database(
@@ -900,9 +911,8 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    /// Fallback confirmation must also extend the candidate chain so
-    /// that a later organise_header call does not overwrite the
-    /// Confirmed status.
+    /// organise_header must not downgrade a Confirmed block even when
+    /// the candidate chain diverges from the confirmed chain.
     ///
     /// Scenario:
     /// - genesis -> share1(h:1) confirmed via push_to_confirmed_chain
@@ -910,12 +920,14 @@ mod tests {
     /// - share2(h:2, parent=share1) stored with block data and valid
     ///   metadata but NOT on the candidate chain.
     /// - organise_block promotes share2 via try_fallback_confirmation.
-    ///   The fix: fallback also writes a candidate entry so the
-    ///   candidate chain stays consistent with the confirmed chain.
+    ///   The candidate chain is NOT updated, so share1 remains the
+    ///   top candidate.
     /// - organise_header(share2) is called again (peer re-send).
-    ///   share2 must remain Confirmed.
+    ///   Without the Confirmed guard, should_extend_candidates would
+    ///   match and append_to_candidates would overwrite Confirmed to
+    ///   Candidate. The guard prevents this.
     #[test]
-    fn test_fallback_confirmation_extends_candidate_chain() {
+    fn test_organise_header_skips_confirmed_block() {
         let temp_dir = tempdir().unwrap();
         let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
 
@@ -947,7 +959,7 @@ mod tests {
         // Promote share2 via fallback confirmation (organise_block).
         // try_fallback_confirmation finds share2 at h:2 with parent =
         // confirmed tip (share1) and promotes it to Confirmed.
-        // The fix also extends the candidate chain.
+        // The candidate chain is NOT updated.
         let mut batch = Store::get_write_batch();
         let result = store.organise_block(&mut batch).unwrap();
         store.commit_batch(batch).unwrap();
@@ -955,23 +967,23 @@ mod tests {
         assert!(store.is_confirmed(&share2.block_hash()));
         assert_eq!(store.get_top_confirmed_height().unwrap(), 2);
 
-        // Candidate chain must also be extended to share2
+        // Candidate chain still has share1 as top
         let top_candidate = store.get_top_candidate().unwrap();
-        assert_eq!(top_candidate.hash, share2.block_hash());
-        assert_eq!(top_candidate.height, 2);
+        assert_eq!(top_candidate.hash, share1.block_hash());
+        assert_eq!(top_candidate.height, 1);
 
         // Simulate a peer re-sending share2's header.
-        // organise_header must not downgrade the Confirmed status.
+        // The Confirmed guard in organise_header must skip it.
         let mut batch = Store::get_write_batch();
-        store.organise_header(&share2.header, &mut batch).unwrap();
+        let result = store.organise_header(&share2.header, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
+        assert_eq!(result, None);
 
         let metadata = store.get_block_metadata(&share2.block_hash()).unwrap();
         assert_eq!(
             metadata.status,
             Status::Confirmed,
-            "organise_header must not downgrade Confirmed to Candidate \
-             after fallback confirmation extended the candidate chain"
+            "organise_header must not downgrade Confirmed to Candidate"
         );
 
         // The confirmed index must still point to share2


### PR DESCRIPTION
Fixes a subtle bug where if a confirmed chain is extended by a locally
mined block, while a candidate tip is the same work as the confirmed
tip, or the candidate tip is stuck for any other reason, missing
dependency etc. Then when if we received the same new tip block again,
we would end up changing it's metadata status to Candidate, as it
didn't appear as the candidate tip.

With this fix, if a block is received, validate and promoted for the
second time, we won't mark it as Candidate.

This bug didn't break the chain, but the data in the db is
inconsistent. One more reason to reset the testnet4 chain. It'll be
a lot of work to clean the chain on the multiple peers and will be
error prone. Best to reset, given we are in stealth mode.