### PR TITLE
Broadcast mined shares after validation

### DIFF
--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -424,7 +424,6 @@ impl NodeActor {
         let emission_worker = EmissionWorker::new(
             self.emissions_rx,
             self.chain_store_handle.clone(),
-            self.node.config.stratum.network,
             self.validation_tx,
         );
         tokio::spawn(emission_worker.run());

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -419,10 +419,9 @@ impl NodeActor {
     }
 
     async fn run(mut self) {
-        // Spawn emission worker - processes shares in separate task and enqueues SwarmSend::BroadcastBlock
+        // Spawn emission worker - processes shares in a separate task.
         let emission_worker = EmissionWorker::new(
             self.emissions_rx,
-            self.node.swarm_tx.clone(),
             self.chain_store_handle.clone(),
             self.node.config.stratum.network,
             self.organise_tx,

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -28,7 +28,7 @@ use crate::node::Node;
 use crate::node::SwarmSend;
 use crate::node::emission_worker::EmissionWorker;
 use crate::node::messages::Message;
-use crate::node::organise_worker::{OrganiseError, OrganiseSender};
+use crate::node::organise_worker::OrganiseError;
 use crate::node::organise_worker::{OrganiseWorker, create_organise_channel};
 use crate::node::p2p_message_handlers::receivers::block_receiver::{
     BlockReceiver, create_block_receiver_channel,
@@ -40,7 +40,7 @@ use crate::node::request_response_handler::block_fetcher::{
     BlockFetcher, BlockFetcherError, create_block_fetcher_channel,
 };
 use crate::node::validation_worker::{
-    ValidationWorker, ValidationWorkerError, create_validation_channel,
+    ValidationSender, ValidationWorker, ValidationWorkerError, create_validation_channel,
 };
 #[cfg(test)]
 #[mockall_double::double]
@@ -300,7 +300,7 @@ struct NodeActor {
     chain_store_handle: ChainStoreHandle,
     #[allow(dead_code)]
     metrics: MetricsHandle,
-    organise_tx: OrganiseSender,
+    validation_tx: ValidationSender,
     organise_handle: tokio::task::JoinHandle<Result<(), OrganiseError>>,
     block_fetcher_handle: tokio::task::JoinHandle<Result<(), BlockFetcherError>>,
     validation_handle: tokio::task::JoinHandle<Result<(), ValidationWorkerError>>,
@@ -332,6 +332,7 @@ impl NodeActor {
 
         // Clone handles for workers before moving them into Node::new
         let validation_tx_for_worker = validation_tx.clone();
+        let validation_tx_for_emission = validation_tx.clone();
         let block_fetcher_tx_for_receiver = block_fetcher_tx.clone();
         let difficulty_multiplier = config.stratum.difficulty_multiplier as u128;
         let pool_signature = config
@@ -408,7 +409,7 @@ impl NodeActor {
                 emissions_rx,
                 chain_store_handle,
                 metrics,
-                organise_tx,
+                validation_tx: validation_tx_for_emission,
                 organise_handle,
                 block_fetcher_handle,
                 validation_handle,
@@ -424,7 +425,7 @@ impl NodeActor {
             self.emissions_rx,
             self.chain_store_handle.clone(),
             self.node.config.stratum.network,
-            self.organise_tx,
+            self.validation_tx,
         );
         tokio::spawn(emission_worker.run());
 

--- a/p2poolv2_lib/src/node/emission_worker.rs
+++ b/p2poolv2_lib/src/node/emission_worker.rs
@@ -20,8 +20,6 @@
 //! event loop, improving P2P responsiveness. Storage is delegated to the
 //! ChainStoreHandle for serialized database writes.
 
-use crate::node::SwarmSend;
-use crate::node::messages::Message;
 use crate::node::organise_worker::{OrganiseEvent, OrganiseSender};
 #[cfg(test)]
 #[mockall_double::double]
@@ -29,15 +27,8 @@ use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 #[cfg(not(test))]
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::handle_stratum_share::handle_stratum_share;
-#[cfg(feature = "sim")]
-use crate::sim_overrides;
 use crate::stratum::emission::EmissionReceiver;
-use libp2p::request_response::ResponseChannel;
-use tokio::sync::mpsc;
 use tracing::{debug, error, info};
-
-/// Type alias for the swarm sender used by the emission worker.
-type SwarmSender = mpsc::Sender<SwarmSend<ResponseChannel<Message>>>;
 
 /// Worker that processes emissions from the stratum server.
 ///
@@ -45,7 +36,6 @@ type SwarmSender = mpsc::Sender<SwarmSend<ResponseChannel<Message>>>;
 /// during CPU-intensive share processing operations.
 pub struct EmissionWorker {
     emissions_rx: EmissionReceiver,
-    swarm_tx: SwarmSender,
     chain_store_handle: ChainStoreHandle,
     network: bitcoin::Network,
     organise_tx: OrganiseSender,
@@ -55,14 +45,12 @@ impl EmissionWorker {
     /// Creates a new emission worker.
     pub fn new(
         emissions_rx: EmissionReceiver,
-        swarm_tx: SwarmSender,
         chain_store_handle: ChainStoreHandle,
         network: bitcoin::Network,
         organise_tx: OrganiseSender,
     ) -> Self {
         Self {
             emissions_rx,
-            swarm_tx,
             chain_store_handle,
             network,
             organise_tx,
@@ -80,27 +68,10 @@ impl EmissionWorker {
                     // Send block to organise worker for confirmed promotion.
                     if let Err(e) = self
                         .organise_tx
-                        .send(OrganiseEvent::Block(share_block.clone()))
+                        .send(OrganiseEvent::Block(share_block))
                         .await
                     {
                         error!("Failed to send block to organise worker: {e}");
-                    }
-                    // Announce the block to peers.
-                    #[cfg(not(feature = "sim"))]
-                    {
-                        if let Err(_) = self
-                            .swarm_tx
-                            .send(SwarmSend::BroadcastBlock(share_block))
-                            .await
-                        {
-                            error!("Failed to broadcast share block");
-                        }
-                    }
-                    // Under sim, optionally delay the announcement to model
-                    // network latency. All jitter logic lives in sim_overrides.
-                    #[cfg(feature = "sim")]
-                    {
-                        sim_overrides::spawn_delayed_broadcast(self.swarm_tx.clone(), share_block);
                     }
                 }
                 Ok(None) => {
@@ -131,6 +102,7 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
+    use tokio::sync::mpsc;
 
     fn create_test_blocktemplate() -> BlockTemplate {
         BlockTemplate {
@@ -225,9 +197,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_run_with_p2p_share_sends_organise_and_inv() {
+    async fn test_run_with_p2p_share_sends_organise_event() {
         let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<ResponseChannel<Message>>>(10);
         let (organise_tx, mut organise_rx) = create_organise_channel();
 
         let mut mock_chain_store = ChainStoreHandle::default();
@@ -237,7 +208,6 @@ mod tests {
 
         let worker = EmissionWorker::new(
             emissions_rx,
-            swarm_tx,
             mock_chain_store,
             bitcoin::Network::Regtest,
             organise_tx,
@@ -256,19 +226,12 @@ mod tests {
             "Expected OrganiseEvent::Block"
         );
 
-        let swarm_event = tokio::time::timeout(Duration::from_secs(2), swarm_rx.recv()).await;
-        assert!(
-            matches!(swarm_event, Ok(Some(SwarmSend::BroadcastBlock(_)))),
-            "Expected SwarmSend::BroadcastBlock"
-        );
-
         worker_handle.await.unwrap();
     }
 
     #[tokio::test]
     async fn test_run_without_commitment_sends_nothing() {
         let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<ResponseChannel<Message>>>(10);
         let (organise_tx, mut organise_rx) = create_organise_channel();
 
         let mut mock_chain_store = ChainStoreHandle::default();
@@ -278,7 +241,6 @@ mod tests {
 
         let worker = EmissionWorker::new(
             emissions_rx,
-            swarm_tx,
             mock_chain_store,
             bitcoin::Network::Regtest,
             organise_tx,
@@ -297,16 +259,11 @@ mod tests {
             organise_rx.try_recv().is_err(),
             "No OrganiseEvent expected for PPLNS-only share"
         );
-        assert!(
-            swarm_rx.try_recv().is_err(),
-            "No SwarmSend expected for PPLNS-only share"
-        );
     }
 
     #[tokio::test]
     async fn test_run_continues_after_handle_error() {
         let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
-        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<ResponseChannel<Message>>>(10);
         let (organise_tx, mut organise_rx) = create_organise_channel();
 
         let mut mock_chain_store = ChainStoreHandle::default();
@@ -322,7 +279,6 @@ mod tests {
 
         let worker = EmissionWorker::new(
             emissions_rx,
-            swarm_tx,
             mock_chain_store,
             bitcoin::Network::Regtest,
             organise_tx,
@@ -343,37 +299,27 @@ mod tests {
 
         worker_handle.await.unwrap();
 
-        // Only the second emission should produce organise + inv events
+        // Only the second emission should produce an organise event
         assert!(
             matches!(organise_rx.try_recv(), Ok(OrganiseEvent::Block(_))),
             "Expected OrganiseEvent::Block from second emission"
-        );
-        assert!(
-            matches!(swarm_rx.try_recv(), Ok(SwarmSend::BroadcastBlock(_))),
-            "Expected SwarmSend::BroadcastBlock from second emission"
         );
 
         assert!(
             organise_rx.try_recv().is_err(),
             "No more organise events expected"
         );
-        assert!(
-            swarm_rx.try_recv().is_err(),
-            "No more swarm events expected"
-        );
     }
 
     #[tokio::test]
     async fn test_run_stops_when_channel_closes() {
         let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
-        let (swarm_tx, _swarm_rx) = mpsc::channel::<SwarmSend<ResponseChannel<Message>>>(10);
         let (organise_tx, _organise_rx) = create_organise_channel();
 
         let mock_chain_store = ChainStoreHandle::default();
 
         let worker = EmissionWorker::new(
             emissions_rx,
-            swarm_tx,
             mock_chain_store,
             bitcoin::Network::Regtest,
             organise_tx,

--- a/p2poolv2_lib/src/node/emission_worker.rs
+++ b/p2poolv2_lib/src/node/emission_worker.rs
@@ -39,7 +39,6 @@ use tracing::{debug, error, info};
 pub struct EmissionWorker {
     emissions_rx: EmissionReceiver,
     chain_store_handle: ChainStoreHandle,
-    network: bitcoin::Network,
     validation_tx: ValidationSender,
 }
 
@@ -48,13 +47,11 @@ impl EmissionWorker {
     pub fn new(
         emissions_rx: EmissionReceiver,
         chain_store_handle: ChainStoreHandle,
-        network: bitcoin::Network,
         validation_tx: ValidationSender,
     ) -> Self {
         Self {
             emissions_rx,
             chain_store_handle,
-            network,
             validation_tx,
         }
     }
@@ -211,12 +208,7 @@ mod tests {
             .expect_add_share_block()
             .returning(|_| Ok(()));
 
-        let worker = EmissionWorker::new(
-            emissions_rx,
-            mock_chain_store,
-            bitcoin::Network::Regtest,
-            validation_tx,
-        );
+        let worker = EmissionWorker::new(emissions_rx, mock_chain_store, validation_tx);
         let worker_handle = tokio::spawn(worker.run());
 
         emissions_tx
@@ -248,12 +240,7 @@ mod tests {
             .expect_add_pplns_share()
             .returning(|_| Ok(()));
 
-        let worker = EmissionWorker::new(
-            emissions_rx,
-            mock_chain_store,
-            bitcoin::Network::Regtest,
-            validation_tx,
-        );
+        let worker = EmissionWorker::new(emissions_rx, mock_chain_store, validation_tx);
         let worker_handle = tokio::spawn(worker.run());
 
         emissions_tx
@@ -286,12 +273,7 @@ mod tests {
             .times(1)
             .returning(|_| Ok(()));
 
-        let worker = EmissionWorker::new(
-            emissions_rx,
-            mock_chain_store,
-            bitcoin::Network::Regtest,
-            validation_tx,
-        );
+        let worker = EmissionWorker::new(emissions_rx, mock_chain_store, validation_tx);
         let worker_handle = tokio::spawn(worker.run());
 
         // First emission: error path (no commitment, store fails)
@@ -330,12 +312,7 @@ mod tests {
 
         let mock_chain_store = ChainStoreHandle::default();
 
-        let worker = EmissionWorker::new(
-            emissions_rx,
-            mock_chain_store,
-            bitcoin::Network::Regtest,
-            validation_tx,
-        );
+        let worker = EmissionWorker::new(emissions_rx, mock_chain_store, validation_tx);
         let worker_handle = tokio::spawn(worker.run());
 
         drop(emissions_tx);

--- a/p2poolv2_lib/src/node/emission_worker.rs
+++ b/p2poolv2_lib/src/node/emission_worker.rs
@@ -64,13 +64,13 @@ impl EmissionWorker {
             // Pass a reference to chain store handle to avoid clones on each loop
             match handle_stratum_share(emission, &self.chain_store_handle).await {
                 Ok(Some(share_block)) => {
-                    // Enqueue the block for validation. The validation worker
+                    // Send the block directly to the validation worker,
+                    // avoiding a redundant store read. The validation worker
                     // will emit OrganiseEvent::Block and broadcast to peers
                     // after the block passes validation.
-                    let block_hash = share_block.block_hash();
                     if let Err(e) = self
                         .validation_tx
-                        .send(ValidationEvent::ValidateBlock(block_hash))
+                        .send(ValidationEvent::ValidateShareBlock(share_block))
                         .await
                     {
                         error!("Failed to send block to validation worker: {e}");
@@ -222,9 +222,9 @@ mod tests {
         assert!(
             matches!(
                 validation_event,
-                Ok(Some(ValidationEvent::ValidateBlock(_)))
+                Ok(Some(ValidationEvent::ValidateShareBlock(_)))
             ),
-            "Expected ValidationEvent::ValidateBlock"
+            "Expected ValidationEvent::ValidateShareBlock"
         );
 
         worker_handle.await.unwrap();
@@ -294,9 +294,9 @@ mod tests {
         assert!(
             matches!(
                 validation_rx.try_recv(),
-                Ok(ValidationEvent::ValidateBlock(_))
+                Ok(ValidationEvent::ValidateShareBlock(_))
             ),
-            "Expected ValidationEvent::ValidateBlock from second emission"
+            "Expected ValidationEvent::ValidateShareBlock from second emission"
         );
 
         assert!(

--- a/p2poolv2_lib/src/node/emission_worker.rs
+++ b/p2poolv2_lib/src/node/emission_worker.rs
@@ -20,7 +20,7 @@
 //! event loop, improving P2P responsiveness. Storage is delegated to the
 //! ChainStoreHandle for serialized database writes.
 
-use crate::node::organise_worker::{OrganiseEvent, OrganiseSender};
+use crate::node::validation_worker::{ValidationEvent, ValidationSender};
 #[cfg(test)]
 #[mockall_double::double]
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
@@ -33,12 +33,14 @@ use tracing::{debug, error, info};
 /// Worker that processes emissions from the stratum server.
 ///
 /// Runs in a separate tokio task to avoid blocking the main swarm event loop
-/// during CPU-intensive share processing operations.
+/// during CPU-intensive share processing operations. After storing, blocks are
+/// sent to the validation worker which handles organise events and peer
+/// broadcast after validation succeeds.
 pub struct EmissionWorker {
     emissions_rx: EmissionReceiver,
     chain_store_handle: ChainStoreHandle,
     network: bitcoin::Network,
-    organise_tx: OrganiseSender,
+    validation_tx: ValidationSender,
 }
 
 impl EmissionWorker {
@@ -47,13 +49,13 @@ impl EmissionWorker {
         emissions_rx: EmissionReceiver,
         chain_store_handle: ChainStoreHandle,
         network: bitcoin::Network,
-        organise_tx: OrganiseSender,
+        validation_tx: ValidationSender,
     ) -> Self {
         Self {
             emissions_rx,
             chain_store_handle,
             network,
-            organise_tx,
+            validation_tx,
         }
     }
 
@@ -65,13 +67,16 @@ impl EmissionWorker {
             // Pass a reference to chain store handle to avoid clones on each loop
             match handle_stratum_share(emission, &self.chain_store_handle).await {
                 Ok(Some(share_block)) => {
-                    // Send block to organise worker for confirmed promotion.
+                    // Enqueue the block for validation. The validation worker
+                    // will emit OrganiseEvent::Block and broadcast to peers
+                    // after the block passes validation.
+                    let block_hash = share_block.block_hash();
                     if let Err(e) = self
-                        .organise_tx
-                        .send(OrganiseEvent::Block(share_block))
+                        .validation_tx
+                        .send(ValidationEvent::ValidateBlock(block_hash))
                         .await
                     {
-                        error!("Failed to send block to organise worker: {e}");
+                        error!("Failed to send block to validation worker: {e}");
                     }
                 }
                 Ok(None) => {
@@ -90,7 +95,7 @@ impl EmissionWorker {
 mod tests {
     use super::*;
     use crate::accounting::payout::simple_pplns::SimplePplnsShare;
-    use crate::node::organise_worker::create_organise_channel;
+    use crate::node::validation_worker::create_validation_channel;
     use crate::shares::extranonce::Extranonce;
     use crate::store::writer::StoreError;
     use crate::stratum::emission::Emission;
@@ -197,9 +202,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_run_with_p2p_share_sends_organise_event() {
+    async fn test_run_with_p2p_share_sends_validation_event() {
         let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
-        let (organise_tx, mut organise_rx) = create_organise_channel();
+        let (validation_tx, mut validation_rx) = create_validation_channel();
 
         let mut mock_chain_store = ChainStoreHandle::default();
         mock_chain_store
@@ -210,7 +215,7 @@ mod tests {
             emissions_rx,
             mock_chain_store,
             bitcoin::Network::Regtest,
-            organise_tx,
+            validation_tx,
         );
         let worker_handle = tokio::spawn(worker.run());
 
@@ -220,10 +225,14 @@ mod tests {
             .unwrap();
         drop(emissions_tx);
 
-        let organise_event = tokio::time::timeout(Duration::from_secs(2), organise_rx.recv()).await;
+        let validation_event =
+            tokio::time::timeout(Duration::from_secs(2), validation_rx.recv()).await;
         assert!(
-            matches!(organise_event, Ok(Some(OrganiseEvent::Block(_)))),
-            "Expected OrganiseEvent::Block"
+            matches!(
+                validation_event,
+                Ok(Some(ValidationEvent::ValidateBlock(_)))
+            ),
+            "Expected ValidationEvent::ValidateBlock"
         );
 
         worker_handle.await.unwrap();
@@ -232,7 +241,7 @@ mod tests {
     #[tokio::test]
     async fn test_run_without_commitment_sends_nothing() {
         let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
-        let (organise_tx, mut organise_rx) = create_organise_channel();
+        let (validation_tx, mut validation_rx) = create_validation_channel();
 
         let mut mock_chain_store = ChainStoreHandle::default();
         mock_chain_store
@@ -243,7 +252,7 @@ mod tests {
             emissions_rx,
             mock_chain_store,
             bitcoin::Network::Regtest,
-            organise_tx,
+            validation_tx,
         );
         let worker_handle = tokio::spawn(worker.run());
 
@@ -256,15 +265,15 @@ mod tests {
         worker_handle.await.unwrap();
 
         assert!(
-            organise_rx.try_recv().is_err(),
-            "No OrganiseEvent expected for PPLNS-only share"
+            validation_rx.try_recv().is_err(),
+            "No ValidationEvent expected for PPLNS-only share"
         );
     }
 
     #[tokio::test]
     async fn test_run_continues_after_handle_error() {
         let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
-        let (organise_tx, mut organise_rx) = create_organise_channel();
+        let (validation_tx, mut validation_rx) = create_validation_channel();
 
         let mut mock_chain_store = ChainStoreHandle::default();
         // First call fails, second call succeeds
@@ -281,7 +290,7 @@ mod tests {
             emissions_rx,
             mock_chain_store,
             bitcoin::Network::Regtest,
-            organise_tx,
+            validation_tx,
         );
         let worker_handle = tokio::spawn(worker.run());
 
@@ -299,22 +308,25 @@ mod tests {
 
         worker_handle.await.unwrap();
 
-        // Only the second emission should produce an organise event
+        // Only the second emission should produce a validation event
         assert!(
-            matches!(organise_rx.try_recv(), Ok(OrganiseEvent::Block(_))),
-            "Expected OrganiseEvent::Block from second emission"
+            matches!(
+                validation_rx.try_recv(),
+                Ok(ValidationEvent::ValidateBlock(_))
+            ),
+            "Expected ValidationEvent::ValidateBlock from second emission"
         );
 
         assert!(
-            organise_rx.try_recv().is_err(),
-            "No more organise events expected"
+            validation_rx.try_recv().is_err(),
+            "No more validation events expected"
         );
     }
 
     #[tokio::test]
     async fn test_run_stops_when_channel_closes() {
         let (emissions_tx, emissions_rx) = mpsc::channel::<Emission>(10);
-        let (organise_tx, _organise_rx) = create_organise_channel();
+        let (validation_tx, _validation_rx) = create_validation_channel();
 
         let mock_chain_store = ChainStoreHandle::default();
 
@@ -322,7 +334,7 @@ mod tests {
             emissions_rx,
             mock_chain_store,
             bitcoin::Network::Regtest,
-            organise_tx,
+            validation_tx,
         );
         let worker_handle = tokio::spawn(worker.run());
 

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/block_receiver.rs
@@ -261,10 +261,10 @@ impl BlockReceiver {
 
         if let Err(error) = self
             .validation_tx
-            .send(ValidationEvent::ValidateBlock(*block_hash))
+            .send(ValidationEvent::ValidateBlockHash(*block_hash))
             .await
         {
-            error!("Failed to send ValidateBlock for {block_hash}: {error}");
+            error!("Failed to send ValidateBlockHash for {block_hash}: {error}");
             return Err(error.into());
         }
 
@@ -788,7 +788,10 @@ mod tests {
 
         let validation_event = validation_rx.try_recv().unwrap();
         match validation_event {
-            ValidationEvent::ValidateBlock(hash) => assert_eq!(hash, child_hash),
+            ValidationEvent::ValidateBlockHash(hash) => assert_eq!(hash, child_hash),
+            ValidationEvent::ValidateShareBlock(_) => {
+                panic!("Expected ValidateBlockHash, got ValidateShareBlock")
+            }
         }
     }
 
@@ -938,7 +941,10 @@ mod tests {
 
         let event = validation_rx.try_recv().unwrap();
         match event {
-            ValidationEvent::ValidateBlock(hash) => assert_eq!(hash, child_hash),
+            ValidationEvent::ValidateBlockHash(hash) => assert_eq!(hash, child_hash),
+            ValidationEvent::ValidateShareBlock(_) => {
+                panic!("Expected ValidateBlockHash, got ValidateShareBlock")
+            }
         }
     }
 
@@ -1116,13 +1122,19 @@ mod tests {
             .try_recv()
             .expect("expected first validation event");
         match event1 {
-            ValidationEvent::ValidateBlock(hash) => assert_eq!(hash, parent_hash),
+            ValidationEvent::ValidateBlockHash(hash) => assert_eq!(hash, parent_hash),
+            ValidationEvent::ValidateShareBlock(_) => {
+                panic!("Expected ValidateBlockHash, got ValidateShareBlock")
+            }
         }
         let event2 = validation_rx
             .try_recv()
             .expect("expected second validation event");
         match event2 {
-            ValidationEvent::ValidateBlock(hash) => assert_eq!(hash, child_hash),
+            ValidationEvent::ValidateBlockHash(hash) => assert_eq!(hash, child_hash),
+            ValidationEvent::ValidateShareBlock(_) => {
+                panic!("Expected ValidateBlockHash, got ValidateShareBlock")
+            }
         }
     }
 

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_blocks.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_blocks.rs
@@ -70,7 +70,7 @@ pub async fn handle_share_block(
         if !chain_store_handle.has_status(&block_hash, Status::Confirmed) {
             debug!("Share block {block_hash} in store but not confirmed, re-sending to validation");
             if let Err(send_error) = validation_tx
-                .send(ValidationEvent::ValidateBlock(block_hash))
+                .send(ValidationEvent::ValidateBlockHash(block_hash))
                 .await
             {
                 error!("Failed to re-send block to validation worker: {send_error}");
@@ -283,7 +283,10 @@ mod tests {
             .try_recv()
             .expect("Expected validation event for unconfirmed stored block");
         match event {
-            ValidationEvent::ValidateBlock(hash) => assert_eq!(hash, block_hash),
+            ValidationEvent::ValidateBlockHash(hash) => assert_eq!(hash, block_hash),
+            ValidationEvent::ValidateShareBlock(_) => {
+                panic!("Expected ValidateBlockHash, got ValidateShareBlock")
+            }
         }
     }
 

--- a/p2poolv2_lib/src/node/validation_worker.rs
+++ b/p2poolv2_lib/src/node/validation_worker.rs
@@ -35,6 +35,7 @@ use crate::pool_difficulty::PoolDifficulty;
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 #[cfg(not(test))]
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
+use crate::shares::share_block::ShareBlock;
 use crate::shares::validation::{DefaultShareValidator, ShareValidator};
 use crate::utils::cpu::available_cpus;
 use bitcoin::BlockHash;
@@ -49,8 +50,10 @@ const VALIDATION_CHANNEL_CAPACITY: usize = 8192;
 
 /// Events for the validation worker.
 pub enum ValidationEvent {
-    /// Validate a stored ShareBlock by its hash.
-    ValidateBlock(BlockHash),
+    /// Validate a stored ShareBlock by its hash (reads from store).
+    ValidateBlockHash(BlockHash),
+    /// Validate a ShareBlock already in memory (avoids redundant store read).
+    ValidateShareBlock(ShareBlock),
 }
 
 /// Sender half of the validation channel.
@@ -137,43 +140,50 @@ impl ValidationWorker {
         ));
 
         while let Some(event) = self.validation_rx.recv().await {
-            match event {
-                ValidationEvent::ValidateBlock(block_hash) => {
-                    let permit = match self.semaphore.clone().acquire_owned().await {
-                        Ok(permit) => permit,
-                        Err(_) => {
-                            error!("Validation semaphore closed");
-                            return Err(ValidationWorkerError {
-                                message: "Validation semaphore closed".to_string(),
-                            });
-                        }
-                    };
-                    let chain_store_handle = self.chain_store_handle.clone();
-                    let organise_tx = self.organise_tx.clone();
-                    let swarm_tx = self.swarm_tx.clone();
-                    let validator = Arc::clone(&share_validator);
+            let (block_hash, prefetched_block) = match event {
+                ValidationEvent::ValidateBlockHash(hash) => (hash, None),
+                ValidationEvent::ValidateShareBlock(share_block) => {
+                    (share_block.block_hash(), Some(share_block))
+                }
+            };
 
-                    tokio::spawn(async move {
-                        let _permit = permit;
-                        validate_and_emit(
-                            block_hash,
-                            validator,
-                            chain_store_handle,
-                            organise_tx,
-                            swarm_tx,
-                        )
-                        .await;
+            let permit = match self.semaphore.clone().acquire_owned().await {
+                Ok(permit) => permit,
+                Err(_) => {
+                    error!("Validation semaphore closed");
+                    return Err(ValidationWorkerError {
+                        message: "Validation semaphore closed".to_string(),
                     });
                 }
-            }
+            };
+            let chain_store_handle = self.chain_store_handle.clone();
+            let organise_tx = self.organise_tx.clone();
+            let swarm_tx = self.swarm_tx.clone();
+            let validator = Arc::clone(&share_validator);
+
+            tokio::spawn(async move {
+                let _permit = permit;
+                validate_and_emit(
+                    block_hash,
+                    prefetched_block,
+                    validator,
+                    chain_store_handle,
+                    organise_tx,
+                    swarm_tx,
+                )
+                .await;
+            });
         }
         info!("Validation worker stopped - channel closed");
         Ok(())
     }
 }
 
-/// Read a share block from the store, validate it, and emit events
-/// on success.
+/// Validate a share block and emit events on success.
+///
+/// When `prefetched_block` is `Some`, uses the provided block directly
+/// (avoids a redundant store read for locally mined shares). Otherwise
+/// reads the block from the chain store by hash.
 ///
 /// Sends `OrganiseEvent::Block` for chain promotion. Only broadcasts
 /// to peers when the chain is current, suppressing relay of historic
@@ -184,17 +194,21 @@ impl ValidationWorker {
 /// with `BlockValid` status.
 async fn validate_and_emit(
     block_hash: BlockHash,
+    prefetched_block: Option<ShareBlock>,
     share_validator: Arc<DefaultShareValidator>,
     chain_store_handle: ChainStoreHandle,
     organise_tx: OrganiseSender,
     swarm_tx: mpsc::Sender<SwarmSend<ResponseChannel<Message>>>,
 ) {
-    let share_block = match chain_store_handle.get_share(&block_hash) {
-        Some(share_block) => share_block,
-        None => {
-            error!("Share block {block_hash} not found in store for validation");
-            return;
-        }
+    let share_block = match prefetched_block {
+        Some(block) => block,
+        None => match chain_store_handle.get_share(&block_hash) {
+            Some(share_block) => share_block,
+            None => {
+                error!("Share block {block_hash} not found in store for validation");
+                return;
+            }
+        },
     };
 
     if let Err(validation_error) =
@@ -277,7 +291,7 @@ mod tests {
         let worker_handle = tokio::spawn(worker.run());
 
         validation_tx
-            .send(ValidationEvent::ValidateBlock(block_hash))
+            .send(ValidationEvent::ValidateBlockHash(block_hash))
             .await
             .unwrap();
 
@@ -326,7 +340,7 @@ mod tests {
         let worker_handle = tokio::spawn(worker.run());
 
         validation_tx
-            .send(ValidationEvent::ValidateBlock(block_hash))
+            .send(ValidationEvent::ValidateBlockHash(block_hash))
             .await
             .unwrap();
 
@@ -375,7 +389,7 @@ mod tests {
         let worker_handle = tokio::spawn(worker.run());
 
         validation_tx
-            .send(ValidationEvent::ValidateBlock(block_hash))
+            .send(ValidationEvent::ValidateBlockHash(block_hash))
             .await
             .unwrap();
 
@@ -426,7 +440,7 @@ mod tests {
         let worker_handle = tokio::spawn(worker.run());
 
         validation_tx
-            .send(ValidationEvent::ValidateBlock(block_hash))
+            .send(ValidationEvent::ValidateBlockHash(block_hash))
             .await
             .unwrap();
 
@@ -493,7 +507,7 @@ mod tests {
         let worker_handle = tokio::spawn(worker.run());
 
         validation_tx
-            .send(ValidationEvent::ValidateBlock(block_hash))
+            .send(ValidationEvent::ValidateBlockHash(block_hash))
             .await
             .unwrap();
 

--- a/p2poolv2_lib/src/node/validation_worker.rs
+++ b/p2poolv2_lib/src/node/validation_worker.rs
@@ -238,8 +238,15 @@ async fn validate_and_emit(
     // Broadcast block after validation, if later confirmation fails,
     // the peers should have this block anyway.
     if chain_store_handle.is_current() {
-        if let Err(send_error) = swarm_tx.send(SwarmSend::BroadcastBlock(share_block)).await {
-            error!("Failed to send broadcast for validated block {block_hash}: {send_error}");
+        #[cfg(not(feature = "sim"))]
+        {
+            if let Err(send_error) = swarm_tx.send(SwarmSend::BroadcastBlock(share_block)).await {
+                error!("Failed to send broadcast for validated block {block_hash}: {send_error}");
+            }
+        }
+        #[cfg(feature = "sim")]
+        {
+            crate::sim_overrides::spawn_delayed_broadcast(swarm_tx, share_block);
         }
     } else {
         debug!("Skipping broadcast for {block_hash} - chain not current");

--- a/p2poolv2_lib/src/node/validation_worker.rs
+++ b/p2poolv2_lib/src/node/validation_worker.rs
@@ -534,4 +534,57 @@ mod tests {
 
         worker_handle.abort();
     }
+
+    #[tokio::test]
+    async fn test_validate_share_block_skips_store_read() {
+        let (validation_tx, validation_rx) = create_validation_channel();
+        let mut mock_chain_handle = MockChainStoreHandle::new();
+
+        let share_block = TestShareBlockBuilder::new().build();
+        let block_hash = share_block.block_hash();
+
+        let mut mock_clone = MockChainStoreHandle::new();
+        mock_clone.expect_get_share().never();
+        mock_clone.expect_has_status().returning(|_, _| true);
+        mock_clone.expect_is_current().returning(|| true);
+        mock_chain_handle
+            .expect_clone()
+            .return_once(move || mock_clone);
+
+        let (organise_tx, mut organise_rx) = organise_worker::create_organise_channel();
+        let (swarm_tx, mut swarm_rx) = mpsc::channel(32);
+
+        let worker = ValidationWorker::new(
+            validation_rx,
+            mock_chain_handle,
+            organise_tx,
+            swarm_tx,
+            1,
+            b"P2Poolv2".to_vec(),
+            PoolDifficulty::default(),
+        );
+
+        let worker_handle = tokio::spawn(worker.run());
+
+        validation_tx
+            .send(ValidationEvent::ValidateShareBlock(share_block))
+            .await
+            .unwrap();
+
+        let organise_event = tokio::time::timeout(Duration::from_secs(2), organise_rx.recv()).await;
+        if let Ok(Some(OrganiseEvent::Block(received_block))) = organise_event {
+            assert_eq!(received_block.block_hash(), block_hash);
+        } else {
+            panic!("Expected OrganiseEvent::Block for prefetched share block");
+        }
+
+        let swarm_event = tokio::time::timeout(Duration::from_secs(2), swarm_rx.recv()).await;
+        if let Ok(Some(SwarmSend::BroadcastBlock(broadcast_block))) = swarm_event {
+            assert_eq!(broadcast_block.block_hash(), block_hash);
+        } else {
+            panic!("Expected SwarmSend::BroadcastBlock for prefetched share block");
+        }
+
+        worker_handle.abort();
+    }
 }


### PR DESCRIPTION
This avoids double sends and using peer block knowledge tracker for avoiding double sends. The peer knowlegde now again tracks what a peer definitely knows - when a node receives an inv or shareblock from the peer.

We can revisit this if we notice we are losing too much time validating shares.

Closes #573 