### PR TITLE
Add nightly sim run as an integration test

### DIFF
--- a/.github/workflows/sim-nightly.yml
+++ b/.github/workflows/sim-nightly.yml
@@ -43,12 +43,14 @@ jobs:
           bitcoind --version
 
       - name: Run sim integration test
+        env:
+          NODE_COUNT: ${{ github.event.inputs.node_count || '10' }}
+          CONVERGENCE_WAIT_SECONDS: ${{ github.event.inputs.duration_seconds || '300' }}
+          IDEAL_BLOCK_TIME: '5'
+          SHARES_PER_BLOCK: '1000'
         run: |
-          NODE_COUNT="${{ github.event.inputs.node_count || '10' }}" \
-          CONVERGENCE_WAIT_SECONDS="${{ github.event.inputs.duration_seconds || '300' }}" \
-          IDEAL_BLOCK_TIME=5 \
-          SHARES_PER_BLOCK=1000 \
           set -o pipefail
+          mkdir -p /tmp/p2pool-sim
           ./load-tests/sim/nightly.sh 2>&1 | tee /tmp/p2pool-sim/nightly-output.log
 
       - name: Upload logs on failure

--- a/.github/workflows/sim-nightly.yml
+++ b/.github/workflows/sim-nightly.yml
@@ -1,0 +1,60 @@
+name: Sim Integration Test
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # every day at 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      node_count:
+        description: 'Number of sim nodes'
+        required: false
+        default: '10'
+      duration_seconds:
+        description: 'Swarm run duration in seconds'
+        required: false
+        default: '300'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  sim:
+    name: Sim Swarm (10 nodes, 5 min)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install bitcoind
+        env:
+          BITCOIN_VERSION: "30.0"
+        run: |
+          wget -q "https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz"
+          tar -xzf "bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz"
+          sudo install -m 0755 "bitcoin-${BITCOIN_VERSION}/bin/bitcoind" /usr/local/bin/
+          sudo install -m 0755 "bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli" /usr/local/bin/
+          bitcoind --version
+
+      - name: Run sim integration test
+        run: |
+          NODE_COUNT="${{ github.event.inputs.node_count || '10' }}" \
+          CONVERGENCE_WAIT_SECONDS="${{ github.event.inputs.duration_seconds || '300' }}" \
+          IDEAL_BLOCK_TIME=5 \
+          SHARES_PER_BLOCK=1000 \
+          set -o pipefail
+          ./load-tests/sim/nightly.sh 2>&1 | tee /tmp/p2pool-sim/nightly-output.log
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-logs
+          path: /tmp/p2pool-sim/
+          retention-days: 7

--- a/load-tests/sim/nightly.sh
+++ b/load-tests/sim/nightly.sh
@@ -13,7 +13,7 @@
 #   NODE_COUNT                 number of sim nodes           (default 20)
 #   CONVERGENCE_WAIT_SECONDS   seconds to let swarm run      (default 60)
 #   UNCLE_RATE_THRESHOLD       max uncle rate % to pass      (default 25)
-#   BITCOIND_DATADIR           regtest data directory        (default /tmp/p2pool-regtest)
+#   BITCOIND_DATADIR           regtest data directory        (default /tmp/bitcoind-p2poolv2)
 #   BITCOIND_BIN               path to bitcoind binary       (auto-detected)
 #   BITCOIN_CLI_BIN            path to bitcoin-cli binary    (auto-detected)
 #
@@ -40,7 +40,7 @@ Env vars (nightly-specific):
   NODE_COUNT                 number of sim nodes           (default 20)
   CONVERGENCE_WAIT_SECONDS   seconds to let swarm run      (default 60)
   UNCLE_RATE_THRESHOLD       max uncle rate % to pass      (default 25)
-  BITCOIND_DATADIR           regtest data directory        (default /tmp/p2pool-regtest)
+  BITCOIND_DATADIR           regtest data directory        (default /tmp/bitcoind-p2poolv2)
   BITCOIND_BIN               path to bitcoind binary       (auto-detected)
   BITCOIN_CLI_BIN            path to bitcoin-cli binary    (auto-detected)
 
@@ -73,7 +73,7 @@ fi
 NODE_COUNT="${NODE_COUNT:-20}"
 CONVERGENCE_WAIT_SECONDS="${CONVERGENCE_WAIT_SECONDS:-60}"
 UNCLE_RATE_THRESHOLD="${UNCLE_RATE_THRESHOLD:-25}"
-BITCOIND_DATADIR="${BITCOIND_DATADIR:-/tmp/p2pool-regtest}"
+BITCOIND_DATADIR="${BITCOIND_DATADIR:-/tmp/bitcoind-p2poolv2}"
 RPC_URL="${RPC_URL:-http://127.0.0.1:19443}"
 RPC_USER="${RPC_USER:-p2pool}"
 RPC_PASS="${RPC_PASS:-p2pool}"
@@ -154,7 +154,8 @@ ensure_bitcoind_running() {
     return
   fi
 
-  log_message "Starting regtest bitcoind..."
+  log_message "Starting fresh regtest bitcoind..."
+  rm -rf "$BITCOIND_DATADIR"
   mkdir -p "$BITCOIND_DATADIR"
   "$BITCOIND_BIN" -regtest \
     -datadir="$BITCOIND_DATADIR" \
@@ -236,7 +237,7 @@ verify_all_chains() {
     log_message "Building verify_chain ($profile)..."
     local profile_flag=""
     [ "$profile" = "release" ] && profile_flag="--release"
-    ( cd "$REPO_ROOT" && cargo build -p p2poolv2_node --bin verify_chain $profile_flag )
+    ( cd "$REPO_ROOT" && cargo build -p p2poolv2_node --bin verify_chain --features debug-tools $profile_flag )
   fi
 
   VERIFY_CHAIN_FAILURES=0
@@ -246,7 +247,7 @@ verify_all_chains() {
     local store="$RUN_DIR/store-$i.db"
     VERIFY_CHAIN_TOTAL=$((VERIFY_CHAIN_TOTAL + 1))
     if [ ! -d "$store" ]; then
-      log_message "  node $i: store not found at $store (SKIP)"
+      log_message "  node $i: FAIL (store not found at $store)"
       VERIFY_CHAIN_FAILURES=$((VERIFY_CHAIN_FAILURES + 1))
       continue
     fi

--- a/load-tests/sim/nightly.sh
+++ b/load-tests/sim/nightly.sh
@@ -84,6 +84,7 @@ DIAL_FANOUT="${DIAL_FANOUT:-3}"
 export RUN_DIR RPC_URL RPC_USER RPC_PASS ZMQ SHARES_PER_BLOCK DIAL_FANOUT
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 STARTED_BITCOIND=0
 SWARM_RUNNING=0
 METRICS_OUTPUT=""
@@ -222,6 +223,42 @@ stop_swarm() {
   fi
 }
 
+verify_all_chains() {
+  local profile="${PROFILE:-release}"
+  local verify_bin
+  if [ "$profile" = "release" ]; then
+    verify_bin="$REPO_ROOT/target/release/verify_chain"
+  else
+    verify_bin="$REPO_ROOT/target/debug/verify_chain"
+  fi
+
+  if [ ! -x "$verify_bin" ]; then
+    log_message "Building verify_chain ($profile)..."
+    local profile_flag=""
+    [ "$profile" = "release" ] && profile_flag="--release"
+    ( cd "$REPO_ROOT" && cargo build -p p2poolv2_node --bin verify_chain $profile_flag )
+  fi
+
+  VERIFY_CHAIN_FAILURES=0
+  VERIFY_CHAIN_TOTAL=0
+  log_message "Running verify_chain on all ${NODE_COUNT} node stores..."
+  for i in $(seq 0 $((NODE_COUNT - 1))); do
+    local store="$RUN_DIR/store-$i.db"
+    VERIFY_CHAIN_TOTAL=$((VERIFY_CHAIN_TOTAL + 1))
+    if [ ! -d "$store" ]; then
+      log_message "  node $i: store not found at $store (SKIP)"
+      VERIFY_CHAIN_FAILURES=$((VERIFY_CHAIN_FAILURES + 1))
+      continue
+    fi
+    if "$verify_bin" "$store" > "$RUN_DIR/verify-$i.log" 2>&1; then
+      log_message "  node $i: PASS"
+    else
+      log_message "  node $i: FAIL (see $RUN_DIR/verify-$i.log)"
+      VERIFY_CHAIN_FAILURES=$((VERIFY_CHAIN_FAILURES + 1))
+    fi
+  done
+}
+
 stop_bitcoind_if_started() {
   if [ "$STARTED_BITCOIND" -eq 1 ]; then
     log_message "Stopping bitcoind (started by this script)..."
@@ -344,6 +381,12 @@ evaluate_results() {
     failed=1
   fi
 
+  local verify_result="PASS"
+  if [ "${VERIFY_CHAIN_FAILURES:-0}" -gt 0 ]; then
+    verify_result="FAIL"
+    failed=1
+  fi
+
   echo "=== NIGHTLY SIM RESULTS ==="
   printf "  nodes alive:        %-4s  (%s/%s)\n" \
     "$alive_result" "$ALIVE_COUNT" "$ALIVE_TOTAL"
@@ -357,6 +400,8 @@ evaluate_results() {
     "$rejections_result" "$ASERT_MISMATCH_COUNT" "$MERKLE_PAYOUT_COUNT"
   printf "  uncle rate:         %-4s  (%s%% < %s%%)\n" \
     "$uncle_result" "$UNCLE_RATE" "$UNCLE_RATE_THRESHOLD"
+  printf "  verify_chain:       %-4s  (%s/%s passed)\n" \
+    "$verify_result" "$((VERIFY_CHAIN_TOTAL - VERIFY_CHAIN_FAILURES))" "$VERIFY_CHAIN_TOTAL"
 
   if [ "$failed" -eq 0 ]; then
     echo "RESULT: PASS"
@@ -384,5 +429,6 @@ wait_for_convergence
 check_all_nodes_alive || true
 collect_metrics
 stop_swarm
+verify_all_chains
 
 evaluate_results


### PR DESCRIPTION
On failures we get the logs and the errors as artifacts on github ci, so we can dig into the reasons for failure.