### PR TITLE
Send getheaders on block rcvd with parent missing

### DIFF
--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -35,6 +35,7 @@ use receivers::getdata::handle_getdata_block;
 use receivers::getheaders::handle_getheaders;
 use receivers::handshake::handle_handshake;
 use receivers::inventory::handle_inventory;
+use receivers::request_missing_blocks::request_headers_for_missing_blocks;
 use receivers::share_blocks::handle_share_block;
 use receivers::share_headers::handle_share_headers;
 use std::error::Error;
@@ -125,6 +126,7 @@ pub async fn handle_request<C: Send + Sync, T: TimeProvider + Send + Sync>(
                 error!("Failed to send ShareBlock ack to peer {}: {err}", ctx.peer);
                 return Err(format!("Failed to send ShareBlock ack: {err}").into());
             }
+            let parent_hash = share_block.header.prev_share_blockhash;
             handle_share_block(
                 share_block,
                 &ctx.chain_store_handle,
@@ -132,6 +134,13 @@ pub async fn handle_request<C: Send + Sync, T: TimeProvider + Send + Sync>(
                 &ctx.block_receiver_handle,
                 &ctx.block_fetcher_handle,
                 ctx.share_validator.as_ref(),
+            )
+            .await?;
+            request_headers_for_missing_blocks(
+                &[parent_hash],
+                ctx.peer,
+                ctx.chain_store_handle,
+                ctx.swarm_tx,
             )
             .await
         }
@@ -236,6 +245,7 @@ mod tests {
     use crate::utils::time_provider::TestTimeProvider;
     use bitcoin::hashes::Hash as _;
     use bitcoin::{BlockHash, CompactTarget};
+    use mockall::predicate::*;
     use std::sync::Arc;
     use std::time::SystemTime;
     use tokio::sync::mpsc;
@@ -695,6 +705,8 @@ mod tests {
         chain_store_handle
             .expect_has_status()
             .returning(|_, _| true);
+        // Chain not current, so request_headers_for_missing_blocks is a no-op
+        chain_store_handle.expect_is_current().returning(|| false);
 
         let ctx = RequestContext {
             peer: peer_id,
@@ -718,6 +730,77 @@ mod tests {
                 assert_eq!(channel, 1u32);
             }
             _ => panic!("Expected SwarmSend::Response with Ack"),
+        }
+
+        assert!(
+            swarm_rx.try_recv().is_err(),
+            "No additional messages expected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_request_share_block_missing_parent_sends_getheaders() {
+        let peer_id = libp2p::PeerId::random();
+        let (swarm_tx, mut swarm_rx) = mpsc::channel(32);
+        let response_channel = 5u32;
+        let mut chain_store_handle = ChainStoreHandle::default();
+        let time_provider = TestTimeProvider::new(SystemTime::now());
+        let (block_fetcher_handle, validation_tx, block_receiver_handle) = test_handles();
+
+        let share_block = valid_share_block_from_fixture();
+        let parent_hash = share_block.header.prev_share_blockhash;
+
+        // Block already confirmed -- simplest path through handle_share_block
+        chain_store_handle
+            .expect_share_block_exists()
+            .returning(|_| true);
+        chain_store_handle
+            .expect_has_status()
+            .returning(|_, _| true);
+
+        // Chain is current and parent is missing -- should trigger getheaders
+        chain_store_handle.expect_is_current().returning(|| true);
+        let missing = vec![parent_hash];
+        chain_store_handle
+            .expect_get_missing_blockhashes()
+            .with(eq(vec![parent_hash]))
+            .returning(move |_| missing.clone());
+        chain_store_handle
+            .expect_build_locator()
+            .return_once(|_| Ok(vec![BlockHash::all_zeros()]));
+
+        let ctx = RequestContext {
+            peer: peer_id,
+            request: Message::ShareBlock(share_block),
+            chain_store_handle,
+            response_channel,
+            swarm_tx,
+            time_provider,
+            block_fetcher_handle,
+            validation_tx,
+            block_receiver_handle,
+            share_validator: Arc::new(MockDefaultShareValidator::default()),
+        };
+
+        let result = handle_request(ctx).await;
+        assert!(result.is_ok());
+
+        let ack_message = swarm_rx.recv().await.unwrap();
+        match ack_message {
+            SwarmSend::Response(channel, Message::Ack) => {
+                assert_eq!(channel, 5u32);
+            }
+            _ => panic!("Expected SwarmSend::Response with Ack"),
+        }
+
+        let getheaders_message = swarm_rx.recv().await.unwrap();
+        match getheaders_message {
+            SwarmSend::Request(sent_peer, Message::GetShareHeaders(locator, stop_hash)) => {
+                assert_eq!(sent_peer, peer_id);
+                assert_eq!(locator, vec![BlockHash::all_zeros()]);
+                assert_eq!(stop_hash, BlockHash::all_zeros());
+            }
+            _ => panic!("Expected SwarmSend::Request with GetShareHeaders"),
         }
 
         assert!(

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/inventory.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/inventory.rs
@@ -16,7 +16,7 @@
 
 use crate::node::SwarmSend;
 use crate::node::messages::{InventoryMessage, Message};
-use crate::node::p2p_message_handlers::senders::send_getheaders;
+use crate::node::p2p_message_handlers::receivers::request_missing_blocks::request_headers_for_missing_blocks;
 #[cfg(test)]
 #[mockall_double::double]
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
@@ -57,22 +57,8 @@ pub async fn handle_inventory<C: Send + Sync>(
     match inventory {
         InventoryMessage::BlockHashes(blockhashes) => {
             debug!("Received block hashes locator: {:?}", blockhashes);
-
-            if !chain_store_handle.is_current() {
-                debug!("Chain not current, ignoring inv from peer {peer}");
-                return Ok(());
-            }
-
-            let missing_blocks = chain_store_handle.get_missing_blockhashes(&blockhashes);
-
-            if !missing_blocks.is_empty() {
-                debug!(
-                    "Have {} missing blocks from peer {}, sending getheaders",
-                    missing_blocks.len(),
-                    peer
-                );
-                send_getheaders(peer, chain_store_handle, swarm_tx, 0).await?;
-            }
+            request_headers_for_missing_blocks(&blockhashes, peer, chain_store_handle, swarm_tx)
+                .await?;
         }
         InventoryMessage::TransactionHashes(transaction_hashes) => {
             debug!(

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/mod.rs
@@ -20,6 +20,7 @@ pub mod getdata;
 pub mod getheaders;
 pub mod handshake;
 pub mod inventory;
+pub mod request_missing_blocks;
 pub mod share_blocks;
 pub mod share_headers;
 

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/request_missing_blocks.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/request_missing_blocks.rs
@@ -1,0 +1,156 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::node::SwarmSend;
+use crate::node::p2p_message_handlers::senders::send_getheaders;
+#[cfg(test)]
+#[mockall_double::double]
+use crate::shares::chain::chain_store_handle::ChainStoreHandle;
+#[cfg(not(test))]
+use crate::shares::chain::chain_store_handle::ChainStoreHandle;
+use bitcoin::BlockHash;
+use std::error::Error;
+use tokio::sync::mpsc;
+use tracing::debug;
+
+/// Check whether any of the given blockhashes are missing from the
+/// store and, when the candidate chain is current, send a getheaders
+/// request to the peer to sync the missing headers.
+///
+/// Returns early without sending when the chain is not current
+/// (initial sync in progress) or when all blockhashes are already
+/// known.
+pub async fn request_headers_for_missing_blocks<C>(
+    blockhashes: &[BlockHash],
+    peer: libp2p::PeerId,
+    chain_store_handle: ChainStoreHandle,
+    swarm_tx: mpsc::Sender<SwarmSend<C>>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if !chain_store_handle.is_current() {
+        debug!("Chain not current, skipping getheaders for missing blocks from peer {peer}");
+        return Ok(());
+    }
+
+    let missing_blocks = chain_store_handle.get_missing_blockhashes(blockhashes);
+    if missing_blocks.is_empty() {
+        return Ok(());
+    }
+
+    debug!(
+        "Have {} missing blocks from peer {}, sending getheaders",
+        missing_blocks.len(),
+        peer
+    );
+    send_getheaders(peer, chain_store_handle, swarm_tx, 0).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::messages::Message;
+    use crate::test_utils::TestShareBlockBuilder;
+    use bitcoin::hashes::Hash;
+    use mockall::predicate::*;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn test_missing_blocks_and_chain_current_sends_getheaders() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        let peer_id = libp2p::PeerId::random();
+
+        let block = TestShareBlockBuilder::new().build();
+        let block_hash = block.block_hash();
+        let blockhashes = vec![block_hash];
+        let missing = vec![block_hash];
+
+        chain_store_handle.expect_is_current().returning(|| true);
+        chain_store_handle
+            .expect_get_missing_blockhashes()
+            .with(eq(blockhashes.clone()))
+            .returning(move |_| missing.clone());
+        chain_store_handle
+            .expect_build_locator()
+            .return_once(|_| Ok(vec![BlockHash::all_zeros()]));
+
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<()>>(10);
+
+        let result =
+            request_headers_for_missing_blocks(&blockhashes, peer_id, chain_store_handle, swarm_tx)
+                .await;
+        assert!(result.is_ok());
+
+        let message = swarm_rx.recv().await.unwrap();
+        match message {
+            SwarmSend::Request(sent_peer, Message::GetShareHeaders(locator, stop_hash)) => {
+                assert_eq!(sent_peer, peer_id);
+                assert_eq!(locator, vec![BlockHash::all_zeros()]);
+                assert_eq!(stop_hash, BlockHash::all_zeros());
+            }
+            _ => panic!("Expected SwarmSend::Request with GetShareHeaders"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_missing_blocks_chain_not_current_no_getheaders() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        let peer_id = libp2p::PeerId::random();
+
+        let block = TestShareBlockBuilder::new().build();
+        let block_hash = block.block_hash();
+        let blockhashes = vec![block_hash];
+
+        chain_store_handle.expect_is_current().returning(|| false);
+
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<()>>(10);
+
+        let result =
+            request_headers_for_missing_blocks(&blockhashes, peer_id, chain_store_handle, swarm_tx)
+                .await;
+        assert!(result.is_ok());
+
+        assert!(
+            swarm_rx.try_recv().is_err(),
+            "No messages should be sent when chain is not current"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_all_blocks_known_no_getheaders() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        let peer_id = libp2p::PeerId::random();
+
+        let block = TestShareBlockBuilder::new().build();
+        let block_hash = block.block_hash();
+        let blockhashes = vec![block_hash];
+
+        chain_store_handle.expect_is_current().returning(|| true);
+        chain_store_handle
+            .expect_get_missing_blockhashes()
+            .returning(|_| Vec::with_capacity(0));
+
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<()>>(10);
+
+        let result =
+            request_headers_for_missing_blocks(&blockhashes, peer_id, chain_store_handle, swarm_tx)
+                .await;
+        assert!(result.is_ok());
+
+        assert!(
+            swarm_rx.try_recv().is_err(),
+            "No messages should be sent when all blocks are known"
+        );
+    }
+}


### PR DESCRIPTION
When Inv is received, we look for missing parent and send getheaders if parent is not available.

We were erroneously skipping this when we handled unsolicited ShareBlock. This PR fixes that.

The bug got detected early by nighty integration testing.