### PR TITLE
Sync from pruned node - Part 1: Update GetHeaders and ShareHeaders behaviour

### DIFF
--- a/docs/simulation/RUNBOOK.md
+++ b/docs/simulation/RUNBOOK.md
@@ -246,7 +246,7 @@ miner's share contribution in the window.
 
 > Breadth: the number of payees = distinct miners with weight in the PPLNS
 > window. In sim builds, the PPLNS window uses `MAX_PPLNS_WINDOW_SHARES`
-> (133056) as the window depth, so all active miners appear in the coinbase
+> (120960) as the window depth, so all active miners appear in the coinbase
 > once the chain has enough shares. With 20 nodes you'll see ~17-20 payees
 > per block once the chain is deeper than the window.
 

--- a/p2poolv2_lib/benches/pplns_window.rs
+++ b/p2poolv2_lib/benches/pplns_window.rs
@@ -30,7 +30,7 @@ use p2poolv2_lib::test_utils::{
 };
 
 /// Total confirmed shares to fill the window (MAX_PPLNS_WINDOW_SHARES).
-const TOTAL_CONFIRMED_SHARES: usize = 133056;
+const TOTAL_CONFIRMED_SHARES: usize = 120960;
 
 /// Every Nth confirmed share references one uncle, yielding ~10% uncles.
 const UNCLE_INTERVAL: usize = 10;

--- a/p2poolv2_lib/src/accounting/payout/sharechain_pplns/pplns_window.rs
+++ b/p2poolv2_lib/src/accounting/payout/sharechain_pplns/pplns_window.rs
@@ -36,8 +36,16 @@ use tracing::debug;
 
 /// Maximum number of confirmed shares in the PPLNS window.
 /// At 6 shares per minute over 2 weeks: 6 * 60 * 24 * 14 = 120,960.
-/// Provide a 10% buffer 120,960 * 1.1 = 133056
-pub const MAX_PPLNS_WINDOW_SHARES: usize = 133056;
+pub const MAX_PPLNS_WINDOW_SHARES: usize = 120960;
+
+/// Number of blocks from the chain tip that must be retained by each node.
+/// Equals 2x the PPLNS window: one window for full tx validation and one
+/// window for PoW-only validation that provides output availability.
+pub const PRUNE_DEPTH: usize = 2 * MAX_PPLNS_WINDOW_SHARES;
+
+/// Pruning runs every PRUNE_INTERVAL blocks (approximately 1 hour at
+/// 10s/block: 60 * 6 = 360).
+pub const PRUNE_INTERVAL: usize = 360;
 
 /// Scale factor applied to all difficulty contributions.
 /// Allows integer representation of 90%/10% uncle/nephew weighting.

--- a/p2poolv2_lib/src/node/behaviour/request_response.rs
+++ b/p2poolv2_lib/src/node/behaviour/request_response.rs
@@ -28,7 +28,7 @@ pub struct P2PoolRequestResponseProtocol(String);
 
 impl P2PoolRequestResponseProtocol {
     pub fn new() -> Self {
-        Self("/p2pool/1.0.0".to_string())
+        Self("/p2pool/1.1.0".to_string())
     }
 }
 

--- a/p2poolv2_lib/src/node/messages.rs
+++ b/p2poolv2_lib/src/node/messages.rs
@@ -72,7 +72,9 @@ pub enum Message {
     /// Share chain headers with the share chain height of the first
     /// header. The receiver uses this to assign heights during
     /// validation. For pruned sync the first header's parent may not
-    /// be in the receiver's store.
+    /// be in the receiver's store in such cases the second field is
+    /// the starting height used to signal pruned sync. Otherwise
+    /// starting height is set to 1.
     ShareHeaders(Vec<ShareHeader>, u32),
     ShareBlock(ShareBlock),
     GetData(GetData),

--- a/p2poolv2_lib/src/node/messages.rs
+++ b/p2poolv2_lib/src/node/messages.rs
@@ -69,7 +69,11 @@ pub enum Message {
     NotFound(GetData),
     GetShareHeaders(Vec<BlockHash>, BlockHash),
     GetShareBlocks(Vec<BlockHash>, BlockHash),
-    ShareHeaders(Vec<ShareHeader>),
+    /// Share chain headers with the share chain height of the first
+    /// header. The receiver uses this to assign heights during
+    /// validation. For pruned sync the first header's parent may not
+    /// be in the receiver's store.
+    ShareHeaders(Vec<ShareHeader>, u32),
     ShareBlock(ShareBlock),
     GetData(GetData),
     Transaction(bitcoin::Transaction),
@@ -161,7 +165,7 @@ impl Message {
             Message::NotFound(_) => "NotFound",
             Message::GetShareHeaders(_, _) => "GetShareHeaders",
             Message::GetShareBlocks(_, _) => "GetShareBlocks",
-            Message::ShareHeaders(_) => "ShareHeaders",
+            Message::ShareHeaders(_, _) => "ShareHeaders",
             Message::ShareBlock(_) => "ShareBlock",
             Message::GetData(_) => "GetData",
             Message::Transaction(_) => "Transaction",
@@ -248,9 +252,10 @@ impl Encodable for Message {
                 len += stop.consensus_encode(w)?;
                 Ok(len)
             }
-            Message::ShareHeaders(headers) => {
+            Message::ShareHeaders(headers, starting_height) => {
                 let mut len = SHARE_HEADERS.consensus_encode(w)?;
                 len += ShareHeaderSerializationWrapper(headers).consensus_encode(w)?;
+                len += starting_height.consensus_encode(w)?;
                 Ok(len)
             }
             Message::ShareBlock(block) => {
@@ -299,6 +304,7 @@ impl Decodable for Message {
             )),
             SHARE_HEADERS => Ok(Message::ShareHeaders(
                 ShareHeaderDeserializationWrapper::consensus_decode(r)?.0,
+                u32::consensus_decode(r)?,
             )),
             SHARE_BLOCK => Ok(Message::ShareBlock(ShareBlock::consensus_decode(r)?)),
             GET_DATA => Ok(Message::GetData(GetData::consensus_decode(r)?)),
@@ -528,6 +534,48 @@ mod tests {
                 assert_eq!(decoded_stop, stop);
             }
             _ => panic!("Expected GetShareHeaders variant"),
+        }
+    }
+
+    #[test]
+    fn test_message_share_headers_roundtrip() {
+        use crate::test_utils::TestShareBlockBuilder;
+
+        let header = TestShareBlockBuilder::new().build().header;
+        let starting_height = 1u32;
+        let msg = Message::ShareHeaders(vec![header.clone()], starting_height);
+        let mut encoded = Vec::new();
+        msg.consensus_encode(&mut encoded).unwrap();
+
+        let decoded = Message::consensus_decode(&mut &encoded[..]).unwrap();
+        match decoded {
+            Message::ShareHeaders(decoded_headers, decoded_starting_height) => {
+                assert_eq!(decoded_headers.len(), 1);
+                assert_eq!(decoded_headers[0], header);
+                assert_eq!(decoded_starting_height, starting_height);
+            }
+            _ => panic!("Expected ShareHeaders variant"),
+        }
+    }
+
+    #[test]
+    fn test_message_share_headers_pruned_roundtrip() {
+        use crate::test_utils::TestShareBlockBuilder;
+
+        let header = TestShareBlockBuilder::new().build().header;
+        let starting_height = 200_000u32;
+        let msg = Message::ShareHeaders(vec![header.clone()], starting_height);
+        let mut encoded = Vec::new();
+        msg.consensus_encode(&mut encoded).unwrap();
+
+        let decoded = Message::consensus_decode(&mut &encoded[..]).unwrap();
+        match decoded {
+            Message::ShareHeaders(decoded_headers, decoded_starting_height) => {
+                assert_eq!(decoded_headers.len(), 1);
+                assert_eq!(decoded_headers[0], header);
+                assert_eq!(decoded_starting_height, starting_height);
+            }
+            _ => panic!("Expected ShareHeaders variant"),
         }
     }
 

--- a/p2poolv2_lib/src/node/messages.rs
+++ b/p2poolv2_lib/src/node/messages.rs
@@ -69,12 +69,12 @@ pub enum Message {
     NotFound(GetData),
     GetShareHeaders(Vec<BlockHash>, BlockHash),
     GetShareBlocks(Vec<BlockHash>, BlockHash),
-    /// Share chain headers with the share chain height of the first
-    /// header. The receiver uses this to assign heights during
-    /// validation. For pruned sync the first header's parent may not
-    /// be in the receiver's store in such cases the second field is
-    /// the starting height used to signal pruned sync. Otherwise
-    /// starting height is set to 1.
+    /// Share chain headers plus a `starting_height` hint.
+    ///
+    /// `starting_height == 1` indicates normal sync (full context available).
+    /// `starting_height > 1` indicates pruned sync, and is the actual share-chain
+    /// height of the first header in this message so the receiver can assign
+    /// heights during boundary validation.
     ShareHeaders(Vec<ShareHeader>, u32),
     ShareBlock(ShareBlock),
     GetData(GetData),

--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -280,7 +280,7 @@ mod tests {
 
         chain_store_handle
             .expect_get_headers_for_locator()
-            .returning(move |_, _, _| Ok(response_headers.clone()));
+            .returning(move |_, _, _| Ok((response_headers.clone(), 1)));
 
         let ctx = RequestContext {
             peer: peer_id,
@@ -328,7 +328,7 @@ mod tests {
         // Set up mock expectations
         chain_store_handle
             .expect_get_blockhashes_for_locator()
-            .returning(move |_, _, _| Ok(vec![block1.block_hash(), block2.block_hash()]));
+            .returning(move |_, _, _| Ok((vec![block1.block_hash(), block2.block_hash()], 1)));
 
         let ctx = RequestContext {
             peer: peer_id,
@@ -668,7 +668,7 @@ mod tests {
         // Set up mock expectations for processing headers
         chain_store_handle
             .expect_get_headers_for_locator()
-            .returning(|_, _, _| Ok(vec![]));
+            .returning(|_, _, _| Ok((vec![], 1)));
 
         let ctx = RequestContext {
             peer: peer_id,

--- a/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/mod.rs
@@ -173,9 +173,10 @@ pub async fn handle_response<C: Send + Sync>(
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     debug!("Received response {} from peer: {}", response, peer);
     match response {
-        Message::ShareHeaders(share_headers) => handle_share_headers(
+        Message::ShareHeaders(share_headers, starting_height) => handle_share_headers(
             peer,
             share_headers,
+            starting_height,
             chain_store_handle,
             swarm_tx,
             block_fetcher_handle,
@@ -298,7 +299,7 @@ mod tests {
         assert!(result.is_ok());
 
         // Verify swarm message
-        if let Some(SwarmSend::Response(channel, Message::ShareHeaders(headers))) =
+        if let Some(SwarmSend::Response(channel, Message::ShareHeaders(headers, _))) =
             swarm_rx.recv().await
         {
             assert_eq!(channel, response_channel);
@@ -671,7 +672,7 @@ mod tests {
 
         let ctx = RequestContext {
             peer: peer_id,
-            request: Message::ShareHeaders(share_headers),
+            request: Message::ShareHeaders(share_headers, 1),
             chain_store_handle,
             response_channel: response_channel_tx,
             swarm_tx,
@@ -854,7 +855,7 @@ mod tests {
         let (block_fetcher_handle, validation_tx, block_receiver_handle) = test_handles();
         let result = handle_response(
             peer_id,
-            Message::ShareHeaders(share_headers),
+            Message::ShareHeaders(share_headers, 1),
             chain_store_handle,
             swarm_tx,
             block_fetcher_handle,

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/getblocks.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/getblocks.rs
@@ -41,7 +41,7 @@ pub async fn handle_getblocks<C: Send + Sync>(
     swarm_tx: mpsc::Sender<SwarmSend<C>>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     debug!("Received GetBlocks: {:?}", locator);
-    let response_block_hashes =
+    let (response_block_hashes, _starting_height) =
         chain_store_handle.get_blockhashes_for_locator(&locator, &stop_block_hash, MAX_BLOCKS)?;
     let inventory_message =
         Message::Inventory(InventoryMessage::BlockHashes(response_block_hashes));
@@ -86,7 +86,7 @@ mod tests {
         // Set up mock expectations
         chain_store_handle
             .expect_get_blockhashes_for_locator()
-            .returning(move |_, _, _| Ok(response_block_hashes.clone()));
+            .returning(move |_, _, _| Ok((response_block_hashes.clone(), 1)));
 
         // Call the handler
         handle_getblocks(

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/getheaders.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/getheaders.rs
@@ -44,7 +44,9 @@ pub async fn handle_getheaders<C: Send + Sync>(
         &stop_block_hash,
         MAX_HEADERS_IN_RESPONSE,
     )?;
-    let headers_message = Message::ShareHeaders(response_headers);
+    // TODO(Step 3): get_headers_for_locator will return the starting
+    // height alongside headers so we pass the correct value here.
+    let headers_message = Message::ShareHeaders(response_headers, 0);
     // Send response and handle errors by logging them before returning
     debug!("Sending Headers {headers_message:?}");
     if let Err(err) = swarm_tx
@@ -96,7 +98,7 @@ mod tests {
         .await;
 
         // Verify swarm message
-        if let Some(SwarmSend::Response(channel, Message::ShareHeaders(headers))) =
+        if let Some(SwarmSend::Response(channel, Message::ShareHeaders(headers, _))) =
             swarm_rx.recv().await
         {
             assert_eq!(channel, response_channel);

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/getheaders.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/getheaders.rs
@@ -39,14 +39,12 @@ pub async fn handle_getheaders<C: Send + Sync>(
     swarm_tx: mpsc::Sender<SwarmSend<C>>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     debug!("Received GetHeaders: {:?}", block_hashes);
-    let response_headers = chain_store_handle.get_headers_for_locator(
+    let (response_headers, starting_height) = chain_store_handle.get_headers_for_locator(
         &block_hashes,
         &stop_block_hash,
         MAX_HEADERS_IN_RESPONSE,
     )?;
-    // TODO(Step 3): get_headers_for_locator will return the starting
-    // height alongside headers so we pass the correct value here.
-    let headers_message = Message::ShareHeaders(response_headers, 0);
+    let headers_message = Message::ShareHeaders(response_headers, starting_height);
     // Send response and handle errors by logging them before returning
     debug!("Sending Headers {headers_message:?}");
     if let Err(err) = swarm_tx
@@ -86,7 +84,7 @@ mod tests {
         // Set up mock expectations
         chain_store_handle
             .expect_get_headers_for_locator()
-            .returning(move |_, _, _| Ok(response_headers.clone()));
+            .returning(move |_, _, _| Ok((response_headers.clone(), 1)));
 
         let _result = handle_getheaders(
             block_hashes,
@@ -125,7 +123,7 @@ mod tests {
         // Set up mock expectations
         chain_store_handle
             .expect_get_headers_for_locator()
-            .returning(move |_, _, _| Ok(Vec::new()));
+            .returning(move |_, _, _| Ok((Vec::new(), 1)));
 
         // Drop the receiver to simulate send failure
         drop(swarm_rx);

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -330,7 +330,7 @@ fn validate_header_chain(
         .max()
         .unwrap_or(Work::from_hex("0x00").unwrap());
 
-    let (batch_hashes, cumulative_chain_work) = validate_dag_connectivity_and_difficulty(
+    let cumulative_chain_work = validate_dag_connectivity_and_difficulty(
         share_headers,
         share_validator,
         pool_difficulty,
@@ -338,13 +338,6 @@ fn validate_header_chain(
         chain_store_handle,
         lowest_anchor_height,
         &missing_parent_hashes,
-        starting_height,
-    )?;
-    verify_all_uncles_available(
-        share_headers,
-        &batch_hashes,
-        chain_store_handle,
-        lowest_anchor_height,
         starting_height,
     )?;
     validate_cumulative_work(best_anchor_work, cumulative_chain_work)?;
@@ -377,14 +370,6 @@ fn get_share_time_and_height(
     Ok(result)
 }
 
-/// Validate that the batch forms a connected DAG with valid difficulty.
-///
-/// Every header's parent must be either already processed in this batch
-/// or present in the store. Every header must pass minimum difficulty
-/// and ASERT target validation.
-///
-/// Returns the set of all blockhashes in the batch and the cumulative
-/// work across all headers.
 /// Check whether a header is in the boundary window where missing
 /// parents and uncles are tolerated during pruned sync.
 fn is_in_boundary_window(header_height: u32, starting_height: u32) -> bool {
@@ -438,6 +423,19 @@ fn check_asert_difficulty(
     Ok(())
 }
 
+/// Validate that the batch forms a connected DAG with valid difficulty.
+///
+/// Every header's parent must be either already processed in this batch
+/// or present in the store. Every header must pass minimum difficulty
+/// and ASERT target validation.
+///
+/// During pruned sync (missing_parent_hashes is non-empty), headers whose
+/// parent is a missing boundary parent skip ASERT validation within the
+/// boundary window (height <= starting_height + MAX_UNCLES_DEPTH). The
+/// time_height_cache is pre-seeded with entries for missing parents so
+/// subsequent headers can compute their heights.
+///
+/// Returns the cumulative work across all headers.
 fn validate_dag_connectivity_and_difficulty(
     share_headers: &[ShareHeader],
     share_validator: &(dyn ShareValidator + Send + Sync),
@@ -447,7 +445,7 @@ fn validate_dag_connectivity_and_difficulty(
     lowest_anchor_height: u32,
     missing_parent_hashes: &HashSet<BlockHash>,
     starting_height: u32,
-) -> Result<(HashSet<BlockHash>, Work), HeaderSyncError> {
+) -> Result<Work, HeaderSyncError> {
     let mut known_hashes: HashSet<BlockHash> =
         HashSet::with_capacity(share_headers.len() + anchor_hashes.len());
     known_hashes.extend(anchor_hashes);
@@ -487,13 +485,22 @@ fn validate_dag_connectivity_and_difficulty(
 
         check_dense_height(&mut blocks_per_height, header_height)?;
 
+        verify_uncles_available(
+            header,
+            header_height,
+            &known_hashes,
+            chain_store_handle,
+            lowest_anchor_height,
+            starting_height,
+        )?;
+
         let header_hash = header.block_hash();
         time_height_cache.insert(header_hash, (header.time, header_height));
         known_hashes.insert(header_hash);
         cumulative_work = cumulative_work + header.get_work();
     }
 
-    Ok((known_hashes, cumulative_work))
+    Ok(cumulative_work)
 }
 
 /// Reject batches where a single height has too many blocks.
@@ -515,38 +522,38 @@ fn check_dense_height(
     Ok(())
 }
 
-/// Verify every uncle hash declared by any header in the batch exists
-/// either as another header in this batch or in the store. Catches
-/// phantom uncle references that no peer ever sent.
+/// Verify every uncle hash declared by a single header exists either
+/// in the batch (known_hashes) or in the store.
 ///
-/// During pruned sync, uncles referenced by headers in the boundary
-/// window (height <= starting_height + MAX_UNCLES_DEPTH) may be below
-/// the prune boundary and are tolerated as missing.
-fn verify_all_uncles_available(
-    share_headers: &[ShareHeader],
-    batch_hashes: &HashSet<BlockHash>,
+/// During pruned sync, if the header is in the boundary window
+/// (height <= starting_height + MAX_UNCLES_DEPTH), missing uncles
+/// are tolerated as being below the prune boundary. Headers above
+/// the boundary window must have all uncles present.
+fn verify_uncles_available(
+    header: &ShareHeader,
+    header_height: u32,
+    known_hashes: &HashSet<BlockHash>,
     chain_store_handle: &ChainStoreHandle,
     lowest_anchor_height: u32,
     starting_height: u32,
 ) -> Result<(), HeaderSyncError> {
-    for header in share_headers {
-        for uncle_hash in &header.uncles {
-            if batch_hashes.contains(uncle_hash)
-                || chain_store_handle.get_block_metadata(uncle_hash).is_ok()
-            {
-                // Uncle found, nothing to check.
-            } else if is_in_boundary_window(lowest_anchor_height + 1, starting_height) {
-                debug!(
-                    "Pruned sync: tolerating missing uncle {} for header {}",
-                    uncle_hash,
-                    header.block_hash(),
-                );
-            } else {
-                return Err(HeaderSyncError::MissingUncle {
-                    uncle_hash: *uncle_hash,
-                    lowest_anchor_height,
-                });
-            }
+    for uncle_hash in &header.uncles {
+        if known_hashes.contains(uncle_hash)
+            || chain_store_handle.get_block_metadata(uncle_hash).is_ok()
+        {
+            // Uncle found.
+        } else if is_in_boundary_window(header_height, starting_height) {
+            debug!(
+                "Pruned sync: tolerating missing uncle {} for header {} at height {}",
+                uncle_hash,
+                header.block_hash(),
+                header_height,
+            );
+        } else {
+            return Err(HeaderSyncError::MissingUncle {
+                uncle_hash: *uncle_hash,
+                lowest_anchor_height,
+            });
         }
     }
     Ok(())
@@ -1962,7 +1969,7 @@ mod tests {
     async fn test_pruned_sync_tolerates_missing_uncle_below_starting_height() {
         // A header at starting_height references an uncle that is below
         // the prune boundary. The uncle hash is not in the batch or store.
-        // verify_all_uncles_available should tolerate this.
+        // verify_uncles_available should tolerate this.
         let starting_height = 5000u32;
 
         // Use a fabricated hash for the missing uncle below the prune boundary
@@ -2177,18 +2184,16 @@ mod tests {
         let anchor_hashes: HashSet<BlockHash> = [parent_hash].into_iter().collect();
         let missing_parent_hashes: HashSet<BlockHash> = [parent_hash].into_iter().collect();
 
-        let chain_store_handle = ChainStoreHandle::default();
+        let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("not in store".to_string())));
 
         let mut mock_validator = MockDefaultShareValidator::default();
         mock_validator
             .expect_validate_header_minimum_difficulty()
             .returning(|_| Ok(()));
-        let mut pool_difficulty = PoolDifficulty::default();
-        // Should NOT be called for boundary header
-        pool_difficulty
-            .expect_calculate_target_clamped()
-            .times(0)
-            .returning(|_, _| CompactTarget::from_consensus(MAX_POOL_TARGET));
+        let pool_difficulty = PoolDifficulty::default();
 
         let result = validate_dag_connectivity_and_difficulty(
             &[header.clone()],
@@ -2202,8 +2207,7 @@ mod tests {
         );
 
         assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
-        let (batch_hashes, cumulative_work) = result.unwrap();
-        assert!(batch_hashes.contains(&header.block_hash()));
+        let cumulative_work = result.unwrap();
         assert!(cumulative_work > Work::from_hex("0x00").unwrap());
     }
 
@@ -2339,9 +2343,7 @@ mod tests {
         );
 
         assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
-        let (batch_hashes, cumulative_work) = result.unwrap();
-        assert!(batch_hashes.contains(&header_a.block_hash()));
-        assert!(batch_hashes.contains(&header_b.block_hash()));
+        let cumulative_work = result.unwrap();
         let single_work = header_a.get_work();
         assert!(cumulative_work >= single_work + single_work);
     }
@@ -2358,16 +2360,17 @@ mod tests {
         let mut header = build_valid_test_header();
         header.uncles = vec![missing_uncle_hash];
 
-        let batch_hashes: HashSet<BlockHash> = [header.block_hash()].into_iter().collect();
+        let known_hashes: HashSet<BlockHash> = [header.block_hash()].into_iter().collect();
 
         let mut chain_store_handle = ChainStoreHandle::default();
         chain_store_handle
             .expect_get_block_metadata()
             .returning(|_| Err(StoreError::NotFound("pruned".to_string())));
 
-        let result = verify_all_uncles_available(
-            &[header],
-            &batch_hashes,
+        let result = verify_uncles_available(
+            &header,
+            starting_height,
+            &known_hashes,
             &chain_store_handle,
             lowest_anchor_height,
             starting_height,
@@ -2387,15 +2390,16 @@ mod tests {
         let mut header = build_valid_test_header();
         header.uncles = vec![uncle.block_hash()];
 
-        let batch_hashes: HashSet<BlockHash> = [header.block_hash(), uncle.block_hash()]
+        let known_hashes: HashSet<BlockHash> = [header.block_hash(), uncle.block_hash()]
             .into_iter()
             .collect();
 
         let chain_store_handle = ChainStoreHandle::default();
 
-        let result = verify_all_uncles_available(
-            &[header],
-            &batch_hashes,
+        let result = verify_uncles_available(
+            &header,
+            starting_height,
+            &known_hashes,
             &chain_store_handle,
             lowest_anchor_height,
             starting_height,
@@ -2415,16 +2419,17 @@ mod tests {
         let mut header = build_valid_test_header();
         header.uncles = vec![missing_uncle_hash];
 
-        let batch_hashes: HashSet<BlockHash> = [header.block_hash()].into_iter().collect();
+        let known_hashes: HashSet<BlockHash> = [header.block_hash()].into_iter().collect();
 
         let mut chain_store_handle = ChainStoreHandle::default();
         chain_store_handle
             .expect_get_block_metadata()
             .returning(|_| Err(StoreError::NotFound("not found".to_string())));
 
-        let result = verify_all_uncles_available(
-            &[header],
-            &batch_hashes,
+        let result = verify_uncles_available(
+            &header,
+            starting_height,
+            &known_hashes,
             &chain_store_handle,
             lowest_anchor_height,
             starting_height,

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -223,9 +223,12 @@ pub async fn handle_share_headers<C: Send + Sync>(
     }
 
     // Phase 1: Validate the header chain in memory
-    if let Err(sync_error) =
-        validate_header_chain(&share_headers, &chain_store_handle, share_validator, starting_height)
-    {
+    if let Err(sync_error) = validate_header_chain(
+        &share_headers,
+        &chain_store_handle,
+        share_validator,
+        starting_height,
+    ) {
         if sync_error.is_retryable() {
             let tip_height = chain_store_handle
                 .get_tip_height()

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -644,8 +644,11 @@ fn find_anchors_pruned_sync(
 /// Find all chain anchors: external parents from the batch that exist
 /// in our store, plus any missing parents below the prune boundary.
 ///
-/// Returns anchors and the set of missing parent hashes (empty for
-/// full sync).
+/// Always tries the full sync path first. Falls back to the pruned
+/// sync path only when external parents are genuinely missing from
+/// the store AND starting_height > 1. This prevents a malicious peer
+/// from using starting_height to bypass validation when we already
+/// have the parent data.
 fn find_chain_anchors(
     share_headers: &[ShareHeader],
     chain_store_handle: &ChainStoreHandle,
@@ -653,14 +656,14 @@ fn find_chain_anchors(
 ) -> Result<(Vec<(BlockHash, BlockMetadata)>, HashSet<BlockHash>), HeaderSyncError> {
     let (_batch_hashes, external_parents) = collect_external_parents(share_headers);
 
-    if starting_height <= 1 {
-        find_anchors_full_sync(external_parents, chain_store_handle)
-    } else {
-        Ok(find_anchors_pruned_sync(
+    match find_anchors_full_sync(external_parents.clone(), chain_store_handle) {
+        Ok(result) => Ok(result),
+        Err(_) if starting_height > 1 => Ok(find_anchors_pruned_sync(
             external_parents,
             chain_store_handle,
             starting_height,
-        ))
+        )),
+        Err(full_sync_error) => Err(full_sync_error),
     }
 }
 
@@ -2442,5 +2445,117 @@ mod tests {
                 .to_string()
                 .contains("not delivered in batch and not in store"),
         );
+    }
+
+    #[tokio::test]
+    async fn test_malicious_starting_height_does_not_bypass_validation_when_parent_exists() {
+        // A malicious peer sends starting_height = 200000 even though
+        // the receiver has the parent in its store at height 5. Before
+        // the defense-in-depth fix, find_anchors_pruned_sync would run
+        // and create a synthetic anchor at height 199999, potentially
+        // poisoning stored heights. After the fix, find_anchors_full_sync
+        // succeeds (parent found in store) and the pruned path is never
+        // reached, so no synthetic metadata is created.
+        let malicious_starting_height = 200_000u32;
+
+        let header = build_valid_test_header();
+        let parent_hash = header.prev_share_blockhash;
+
+        // header_b chains off header, so header is an internal parent
+        // and parent_hash is the only external parent.
+        let mut header_b = build_valid_test_header();
+        header_b.prev_share_blockhash = header.block_hash();
+
+        let headers = vec![header, header_b];
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+
+        // Parent IS in the store at the real height (5), so the full
+        // sync path should succeed without falling through to pruned.
+        let real_parent_hash = parent_hash;
+        chain_store_handle
+            .expect_get_block_metadata_batch()
+            .returning(move |hashes| {
+                hashes
+                    .iter()
+                    .filter(|hash| **hash == real_parent_hash)
+                    .map(|hash| {
+                        (
+                            *hash,
+                            BlockMetadata {
+                                expected_height: Some(5),
+                                chain_work: Work::from_hex("0x00").unwrap(),
+                                status: Status::Confirmed,
+                            },
+                        )
+                    })
+                    .collect()
+            });
+
+        // get_block_metadata for parent connectivity check (store has it)
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(|_| {
+                Ok(BlockMetadata {
+                    expected_height: Some(5),
+                    chain_work: Work::from_hex("0x00").unwrap(),
+                    status: Status::Confirmed,
+                })
+            });
+
+        // get_share_header for time lookup (falls through from cache miss)
+        let template_header = build_valid_test_header();
+        chain_store_handle
+            .expect_get_share_header()
+            .returning(move |_| Ok(template_header.clone()));
+
+        let genesis_header = build_valid_test_header();
+        chain_store_handle
+            .expect_get_genesis_header()
+            .returning(move || Ok(genesis_header.clone()));
+
+        let mut mock_validator = MockDefaultShareValidator::default();
+        setup_minimum_difficulty_mock(&mut mock_validator);
+
+        // store_missing_parent_metadata must NOT be called -- if the
+        // pruned path were taken, it would try to store metadata at
+        // height 199999 for the parent that already exists at height 5.
+        chain_store_handle
+            .expect_store_missing_parent_metadata()
+            .times(0)
+            .returning(|_, _| Ok(()));
+
+        chain_store_handle
+            .expect_organise_header()
+            .returning(|_| Ok(None));
+        chain_store_handle
+            .expect_find_fork_point_height()
+            .returning(|_| Ok(Some(5)));
+        chain_store_handle
+            .expect_get_candidate_blocks_missing_data()
+            .returning(|_| Ok(Vec::new()));
+
+        let (swarm_tx, _swarm_rx) = mpsc::channel::<SwarmSend<oneshot::Sender<Message>>>(32);
+        let (block_fetcher_handle, _block_fetcher_rx) =
+            block_fetcher::create_block_fetcher_channel();
+
+        // Run handle_share_headers which calls validate_header_chain
+        // and then conditionally calls store_missing_parent_metadata.
+        let peer_id = libp2p::PeerId::random();
+        let result = handle_share_headers(
+            peer_id,
+            headers,
+            malicious_starting_height,
+            chain_store_handle,
+            swarm_tx,
+            block_fetcher_handle,
+            &mock_validator,
+        )
+        .await;
+
+        assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
+        // store_missing_parent_metadata was never called (times(0)),
+        // confirming the pruned path was not taken and no metadata
+        // was written at the malicious height.
     }
 }

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -518,8 +518,6 @@ fn check_dense_height(
 /// Verify every uncle hash declared by any header in the batch exists
 /// either as another header in this batch or in the store. Catches
 /// phantom uncle references that no peer ever sent.
-/// Verify every uncle hash declared by any header in the batch exists
-/// either as another header in this batch or in the store.
 ///
 /// During pruned sync, uncles referenced by headers in the boundary
 /// window (height <= starting_height + MAX_UNCLES_DEPTH) may be below

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -197,6 +197,7 @@ impl From<crate::shares::validation::ValidationError> for HeaderSyncError {
 pub async fn handle_share_headers<C: Send + Sync>(
     peer_id: libp2p::PeerId,
     share_headers: Vec<ShareHeader>,
+    starting_height: u32,
     chain_store_handle: ChainStoreHandle,
     swarm_tx: mpsc::Sender<SwarmSend<C>>,
     block_fetcher_handle: BlockFetcherHandle,
@@ -223,7 +224,7 @@ pub async fn handle_share_headers<C: Send + Sync>(
 
     // Phase 1: Validate the header chain in memory
     if let Err(sync_error) =
-        validate_header_chain(&share_headers, &chain_store_handle, share_validator)
+        validate_header_chain(&share_headers, &chain_store_handle, share_validator, starting_height)
     {
         if sync_error.is_retryable() {
             let tip_height = chain_store_handle
@@ -274,6 +275,7 @@ fn validate_header_chain(
     share_headers: &[ShareHeader],
     chain_store_handle: &ChainStoreHandle,
     share_validator: &(dyn ShareValidator + Send + Sync),
+    _starting_height: u32,
 ) -> Result<(), HeaderSyncError> {
     let pool_difficulty = share_validator.pool_difficulty();
 
@@ -705,6 +707,7 @@ mod tests {
         let result = handle_share_headers(
             peer_id,
             share_headers,
+            1,
             chain_store_handle,
             swarm_tx,
             block_fetcher_handle,
@@ -733,6 +736,7 @@ mod tests {
         let result = handle_share_headers(
             peer_id,
             share_headers,
+            1,
             chain_store_handle,
             swarm_tx,
             block_fetcher_handle,
@@ -778,6 +782,7 @@ mod tests {
         let result = handle_share_headers(
             peer_id,
             share_headers,
+            1,
             chain_store_handle,
             swarm_tx,
             block_fetcher_handle,
@@ -832,6 +837,7 @@ mod tests {
         let result = handle_share_headers(
             peer_id,
             share_headers,
+            1,
             chain_store_handle,
             swarm_tx,
             block_fetcher_handle,
@@ -879,6 +885,7 @@ mod tests {
         let result = handle_share_headers(
             peer_id,
             share_headers,
+            1,
             chain_store_handle,
             swarm_tx,
             block_fetcher_handle,
@@ -908,7 +915,7 @@ mod tests {
         let mut mock_validator = MockDefaultShareValidator::default();
         setup_minimum_difficulty_mock(&mut mock_validator);
 
-        let result = validate_header_chain(&[child], &chain_store_handle, &mock_validator);
+        let result = validate_header_chain(&[child], &chain_store_handle, &mock_validator, 1);
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
     }
 
@@ -934,7 +941,7 @@ mod tests {
         setup_minimum_difficulty_mock(&mut mock_validator);
 
         let headers = vec![share_a, share_b];
-        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
+        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator, 1);
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
     }
 
@@ -970,7 +977,7 @@ mod tests {
 
         // Order: share_a, uncle, share_b (as get_descendant_blockhashes produces)
         let headers = vec![share_a, uncle, share_b];
-        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
+        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator, 1);
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
     }
 
@@ -995,7 +1002,7 @@ mod tests {
         let mut mock_validator = MockDefaultShareValidator::default();
         setup_minimum_difficulty_mock(&mut mock_validator);
 
-        let result = validate_header_chain(&[child], &chain_store_handle, &mock_validator);
+        let result = validate_header_chain(&[child], &chain_store_handle, &mock_validator, 1);
         assert!(result.is_err());
         assert!(
             result
@@ -1066,7 +1073,7 @@ mod tests {
         setup_minimum_difficulty_mock(&mut mock_validator);
 
         let headers = vec![share_a, share_c];
-        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
+        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator, 1);
         assert!(result.is_err());
         assert!(
             result
@@ -1114,7 +1121,7 @@ mod tests {
         setup_minimum_difficulty_mock(&mut mock_validator);
 
         let headers = vec![share_a, share_b, share_c, share_d];
-        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
+        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator, 1);
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
     }
 
@@ -1155,7 +1162,7 @@ mod tests {
         setup_minimum_difficulty_mock(&mut mock_validator);
 
         let headers = vec![share_a, share_b, uncle, share_c];
-        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
+        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator, 1);
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
     }
 
@@ -1226,7 +1233,7 @@ mod tests {
         let headers = vec![
             share_b, share_c, share_d, share_e, share_f, share_g, share_h,
         ];
-        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
+        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator, 1);
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
     }
 
@@ -1299,7 +1306,7 @@ mod tests {
 
         // Batch order: A, fork_parent, B, U, C
         let headers = vec![share_a, fork_parent, share_b, uncle_u, share_c];
-        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
+        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator, 1);
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
     }
 
@@ -1373,7 +1380,7 @@ mod tests {
         setup_minimum_difficulty_mock(&mut mock_validator);
 
         let headers = vec![share_a, share_b];
-        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
+        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator, 1);
         assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
     }
 
@@ -1466,6 +1473,7 @@ mod tests {
         let result = handle_share_headers(
             peer_id,
             vec![share],
+            1,
             chain_store_handle,
             swarm_tx,
             block_fetcher_handle,
@@ -1508,6 +1516,7 @@ mod tests {
         let result = handle_share_headers(
             peer_id,
             share_headers,
+            1,
             chain_store_handle,
             swarm_tx,
             block_fetcher_handle,
@@ -1565,7 +1574,7 @@ mod tests {
         setup_minimum_difficulty_mock(&mut mock_validator);
 
         let headers = vec![share_a, share_b];
-        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator);
+        let result = validate_header_chain(&headers, &chain_store_handle, &mock_validator, 1);
         assert!(result.is_err());
         assert!(
             result

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -32,8 +32,8 @@ use crate::shares::share_block::{
     MAX_POOL_TARGET, MIN_CUMULATIVE_CHAIN_WORK_MULTIPLIER, ShareHeader,
 };
 use crate::shares::validation::ShareValidator;
-use crate::store::block_tx_metadata::BlockMetadata;
-use crate::store::dag_store::MAX_BLOCKS_PER_HEIGHT;
+use crate::store::block_tx_metadata::{BlockMetadata, Status};
+use crate::store::dag_store::{MAX_BLOCKS_PER_HEIGHT, MAX_UNCLES_DEPTH};
 use crate::store::writer::StoreError;
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, CompactTarget, Target, Work};
@@ -223,30 +223,26 @@ pub async fn handle_share_headers<C: Send + Sync>(
     }
 
     // Phase 1: Validate the header chain in memory
-    if let Err(sync_error) = validate_header_chain(
+    let missing_parent_hashes = match validate_header_chain(
         &share_headers,
         &chain_store_handle,
         share_validator,
         starting_height,
     ) {
-        if sync_error.is_retryable() {
-            let tip_height = chain_store_handle
-                .get_tip_height()
-                .ok()
-                .flatten()
-                .unwrap_or(0);
-            let depth = sync_error.retry_depth(tip_height).unwrap_or(0);
-            debug!(
-                "Retryable header sync error, sending getheaders with depth {depth}: {sync_error}"
-            );
-            send_getheaders(peer_id, chain_store_handle, swarm_tx, depth).await?;
-            return Ok(());
+        Ok(missing_parents) => missing_parents,
+        Err(sync_error) => {
+            return handle_validation_error(sync_error, peer_id, chain_store_handle, swarm_tx)
+                .await;
         }
-        if matches!(sync_error, HeaderSyncError::DenseHeight { .. }) {
-            error!("Disconnecting peer {peer_id}: {sync_error}");
-            let _ = swarm_tx.send(SwarmSend::Disconnect(peer_id)).await;
-        }
-        return Err(sync_error.into());
+    };
+
+    // Store metadata for missing parents so organise_header can
+    // find them when computing heights for boundary headers.
+    for parent_hash in &missing_parent_hashes {
+        let parent_height = starting_height - 1;
+        chain_store_handle
+            .store_missing_parent_metadata(*parent_hash, parent_height)
+            .await?;
     }
 
     // Phase 2: Organise validated headers into the candidate chain
@@ -267,6 +263,34 @@ pub async fn handle_share_headers<C: Send + Sync>(
     .await
 }
 
+/// Handle a validation error from validate_header_chain.
+///
+/// Retryable errors trigger a deeper getheaders request. DenseHeight
+/// errors disconnect the peer. All other errors propagate up.
+async fn handle_validation_error<C: Send + Sync>(
+    sync_error: HeaderSyncError,
+    peer_id: libp2p::PeerId,
+    chain_store_handle: ChainStoreHandle,
+    swarm_tx: mpsc::Sender<SwarmSend<C>>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    if sync_error.is_retryable() {
+        let tip_height = chain_store_handle
+            .get_tip_height()
+            .ok()
+            .flatten()
+            .unwrap_or(0);
+        let depth = sync_error.retry_depth(tip_height).unwrap_or(0);
+        debug!("Retryable header sync error, sending getheaders with depth {depth}: {sync_error}");
+        send_getheaders(peer_id, chain_store_handle, swarm_tx, depth).await?;
+        return Ok(());
+    }
+    if matches!(sync_error, HeaderSyncError::DenseHeight { .. }) {
+        error!("Disconnecting peer {peer_id}: {sync_error}");
+        let _ = swarm_tx.send(SwarmSend::Disconnect(peer_id)).await;
+    }
+    Err(sync_error.into())
+}
+
 /// Validate the received header batch as a connected DAG.
 ///
 /// The batch contains a mix of main chain and uncle headers. Validation
@@ -274,17 +298,25 @@ pub async fn handle_share_headers<C: Send + Sync>(
 /// either earlier in the batch or in the store), that every header meets
 /// ASERT difficulty, that all declared uncle hashes are available, and
 /// that cumulative work exceeds the minimum threshold.
+/// Returns the set of missing parent hashes that need metadata stored
+/// before organise_header can process boundary headers. Empty for
+/// non-pruned sync.
 fn validate_header_chain(
     share_headers: &[ShareHeader],
     chain_store_handle: &ChainStoreHandle,
     share_validator: &(dyn ShareValidator + Send + Sync),
-    _starting_height: u32,
-) -> Result<(), HeaderSyncError> {
+    starting_height: u32,
+) -> Result<HashSet<BlockHash>, HeaderSyncError> {
     let pool_difficulty = share_validator.pool_difficulty();
 
-    let anchors = find_chain_anchors(share_headers, chain_store_handle)?;
+    let (anchors, missing_parent_hashes) =
+        find_chain_anchors(share_headers, chain_store_handle, starting_height)?;
     let anchor_hashes: HashSet<BlockHash> = anchors.iter().map(|(hash, _)| *hash).collect();
-    debug!("Found {} anchor(s) for header batch", anchors.len());
+    debug!(
+        "Found {} anchor(s) for header batch ({} missing parents)",
+        anchors.len(),
+        missing_parent_hashes.len(),
+    );
 
     let lowest_anchor_height = anchors
         .iter()
@@ -305,12 +337,15 @@ fn validate_header_chain(
         &anchor_hashes,
         chain_store_handle,
         lowest_anchor_height,
+        &missing_parent_hashes,
+        starting_height,
     )?;
     verify_all_uncles_available(
         share_headers,
         &batch_hashes,
         chain_store_handle,
         lowest_anchor_height,
+        starting_height,
     )?;
     validate_cumulative_work(best_anchor_work, cumulative_chain_work)?;
 
@@ -318,7 +353,7 @@ fn validate_header_chain(
         "Validated {} headers, cumulative chain work: {cumulative_chain_work}",
         share_headers.len(),
     );
-    Ok(())
+    Ok(missing_parent_hashes)
 }
 
 /// Get the blockhash's timestamp and height, checking the batch-local
@@ -350,6 +385,59 @@ fn get_share_time_and_height(
 ///
 /// Returns the set of all blockhashes in the batch and the cumulative
 /// work across all headers.
+/// Check whether a header is in the boundary window where missing
+/// parents and uncles are tolerated during pruned sync.
+fn is_in_boundary_window(header_height: u32, starting_height: u32) -> bool {
+    starting_height > 1 && header_height <= starting_height + MAX_UNCLES_DEPTH as u32
+}
+
+/// Build the initial time/height cache. For pruned sync, seeds entries
+/// for missing parents using starting_height - 1 and the first
+/// header's time. Returns an empty cache for full sync.
+fn build_time_height_cache(
+    share_headers: &[ShareHeader],
+    missing_parent_hashes: &HashSet<BlockHash>,
+    starting_height: u32,
+) -> HashMap<BlockHash, (u32, u32)> {
+    let mut cache = HashMap::with_capacity(share_headers.len() + missing_parent_hashes.len());
+    if !missing_parent_hashes.is_empty() {
+        let first_header_time = share_headers[0].time;
+        let parent_height = starting_height - 1;
+        for parent_hash in missing_parent_hashes {
+            cache.insert(*parent_hash, (first_header_time, parent_height));
+        }
+    }
+    cache
+}
+
+/// Check ASERT difficulty for a header. Skips the check when the
+/// header's parent is a missing boundary parent during pruned sync.
+/// Min PoW is always checked separately before this function.
+fn check_asert_difficulty(
+    header: &ShareHeader,
+    header_height: u32,
+    parent_time: u32,
+    parent_height: u32,
+    pool_difficulty: &PoolDifficulty,
+    missing_parent_hashes: &HashSet<BlockHash>,
+    starting_height: u32,
+) -> Result<(), HeaderSyncError> {
+    let parent_is_missing = missing_parent_hashes.contains(&header.prev_share_blockhash);
+    if parent_is_missing && is_in_boundary_window(header_height, starting_height) {
+        return Ok(());
+    }
+
+    let expected_bits = pool_difficulty.calculate_target_clamped(parent_time, parent_height);
+    if header.bits != expected_bits {
+        return Err(HeaderSyncError::AsertMismatch {
+            block_hash: header.block_hash(),
+            declared: header.bits.to_consensus(),
+            expected: expected_bits.to_consensus(),
+        });
+    }
+    Ok(())
+}
+
 fn validate_dag_connectivity_and_difficulty(
     share_headers: &[ShareHeader],
     share_validator: &(dyn ShareValidator + Send + Sync),
@@ -357,14 +445,16 @@ fn validate_dag_connectivity_and_difficulty(
     anchor_hashes: &HashSet<BlockHash>,
     chain_store_handle: &ChainStoreHandle,
     lowest_anchor_height: u32,
+    missing_parent_hashes: &HashSet<BlockHash>,
+    starting_height: u32,
 ) -> Result<(HashSet<BlockHash>, Work), HeaderSyncError> {
     let mut known_hashes: HashSet<BlockHash> =
         HashSet::with_capacity(share_headers.len() + anchor_hashes.len());
     known_hashes.extend(anchor_hashes);
 
     let mut cumulative_work = Work::from_hex("0x00").unwrap();
-    let mut time_height_cache: HashMap<BlockHash, (u32, u32)> =
-        HashMap::with_capacity(share_headers.len() + 1);
+    let mut time_height_cache =
+        build_time_height_cache(share_headers, missing_parent_hashes, starting_height);
     let mut blocks_per_height: HashMap<u32, usize> = HashMap::with_capacity(64);
 
     for header in share_headers {
@@ -384,16 +474,17 @@ fn validate_dag_connectivity_and_difficulty(
         let (parent_time, parent_height) =
             get_share_time_and_height(&parent_hash, &mut time_height_cache, chain_store_handle)?;
 
-        let expected_bits = pool_difficulty.calculate_target_clamped(parent_time, parent_height);
-        if header.bits != expected_bits {
-            return Err(HeaderSyncError::AsertMismatch {
-                block_hash: header.block_hash(),
-                declared: header.bits.to_consensus(),
-                expected: expected_bits.to_consensus(),
-            });
-        }
-
         let header_height = parent_height + 1;
+        check_asert_difficulty(
+            header,
+            header_height,
+            parent_time,
+            parent_height,
+            pool_difficulty,
+            missing_parent_hashes,
+            starting_height,
+        )?;
+
         check_dense_height(&mut blocks_per_height, header_height)?;
 
         let header_hash = header.block_hash();
@@ -408,7 +499,7 @@ fn validate_dag_connectivity_and_difficulty(
 /// Reject batches where a single height has too many blocks.
 ///
 /// In normal operation a height has at most a few blocks (confirmed +
-/// uncles). A dense height indicates a misbehaving or attacking peer.
+/// uncles). A dense height indicates a misbehaving or malicious peer.
 fn check_dense_height(
     blocks_per_height: &mut HashMap<u32, usize>,
     height: u32,
@@ -427,17 +518,32 @@ fn check_dense_height(
 /// Verify every uncle hash declared by any header in the batch exists
 /// either as another header in this batch or in the store. Catches
 /// phantom uncle references that no peer ever sent.
+/// Verify every uncle hash declared by any header in the batch exists
+/// either as another header in this batch or in the store.
+///
+/// During pruned sync, uncles referenced by headers in the boundary
+/// window (height <= starting_height + MAX_UNCLES_DEPTH) may be below
+/// the prune boundary and are tolerated as missing.
 fn verify_all_uncles_available(
     share_headers: &[ShareHeader],
     batch_hashes: &HashSet<BlockHash>,
     chain_store_handle: &ChainStoreHandle,
     lowest_anchor_height: u32,
+    starting_height: u32,
 ) -> Result<(), HeaderSyncError> {
     for header in share_headers {
         for uncle_hash in &header.uncles {
-            if !batch_hashes.contains(uncle_hash)
-                && chain_store_handle.get_block_metadata(uncle_hash).is_err()
+            if batch_hashes.contains(uncle_hash)
+                || chain_store_handle.get_block_metadata(uncle_hash).is_ok()
             {
+                // Uncle found, nothing to check.
+            } else if is_in_boundary_window(lowest_anchor_height + 1, starting_height) {
+                debug!(
+                    "Pruned sync: tolerating missing uncle {} for header {}",
+                    uncle_hash,
+                    header.block_hash(),
+                );
+            } else {
                 return Err(HeaderSyncError::MissingUncle {
                     uncle_hash: *uncle_hash,
                     lowest_anchor_height,
@@ -448,18 +554,8 @@ fn verify_all_uncles_available(
     Ok(())
 }
 
-/// Find all chain anchors: external parents from the batch that exist
-/// in our store.
-///
-/// Collects all `prev_share_blockhash` values that are NOT themselves
-/// hashes of headers in this batch (i.e., external parents from the
-/// store). With height-based batches, multiple blocks may have
-/// external parents at the previous batch boundary on different
-/// branches.
-fn find_chain_anchors(
-    share_headers: &[ShareHeader],
-    chain_store_handle: &ChainStoreHandle,
-) -> Result<Vec<(BlockHash, BlockMetadata)>, HeaderSyncError> {
+/// Collect external parent hashes not present in this batch.
+fn collect_external_parents(share_headers: &[ShareHeader]) -> (HashSet<BlockHash>, Vec<BlockHash>) {
     let batch_hashes: HashSet<BlockHash> = share_headers
         .iter()
         .map(|header| header.block_hash())
@@ -473,6 +569,17 @@ fn find_chain_anchors(
         .into_iter()
         .collect();
 
+    (batch_hashes, external_parents)
+}
+
+/// Find chain anchors for a full sync (starting_height <= 1).
+///
+/// All external parents must exist in the store. Returns an error if
+/// any are missing.
+fn find_anchors_full_sync(
+    external_parents: Vec<BlockHash>,
+    chain_store_handle: &ChainStoreHandle,
+) -> Result<(Vec<(BlockHash, BlockMetadata)>, HashSet<BlockHash>), HeaderSyncError> {
     let metadata_results = chain_store_handle.get_block_metadata_batch(&external_parents);
 
     if metadata_results.len() != external_parents.len() {
@@ -492,7 +599,64 @@ fn find_chain_anchors(
         });
     }
 
-    Ok(metadata_results)
+    Ok((metadata_results, HashSet::new()))
+}
+
+/// Find chain anchors for a pruned sync (starting_height > 1).
+///
+/// External parents missing from the store are expected -- they are
+/// below the prune boundary. For these, anchor entries are created
+/// with height = starting_height - 1. The returned HashSet contains
+/// the missing parent hashes that need metadata stored before
+/// organise_header can process boundary headers.
+fn find_anchors_pruned_sync(
+    external_parents: Vec<BlockHash>,
+    chain_store_handle: &ChainStoreHandle,
+    starting_height: u32,
+) -> (Vec<(BlockHash, BlockMetadata)>, HashSet<BlockHash>) {
+    let mut metadata_results = chain_store_handle.get_block_metadata_batch(&external_parents);
+
+    let found: HashSet<BlockHash> = metadata_results.iter().map(|(hash, _)| *hash).collect();
+    let missing: Vec<BlockHash> = external_parents
+        .into_iter()
+        .filter(|hash| !found.contains(hash))
+        .collect();
+
+    let missing_parent_hashes: HashSet<BlockHash> = missing.iter().copied().collect();
+    let parent_height = starting_height - 1;
+    for missing_hash in &missing {
+        let anchor_metadata = BlockMetadata {
+            expected_height: Some(parent_height),
+            chain_work: Work::from_hex("0x00").unwrap(),
+            status: Status::HeaderValid,
+        };
+        metadata_results.push((*missing_hash, anchor_metadata));
+    }
+
+    (metadata_results, missing_parent_hashes)
+}
+
+/// Find all chain anchors: external parents from the batch that exist
+/// in our store, plus any missing parents below the prune boundary.
+///
+/// Returns anchors and the set of missing parent hashes (empty for
+/// full sync).
+fn find_chain_anchors(
+    share_headers: &[ShareHeader],
+    chain_store_handle: &ChainStoreHandle,
+    starting_height: u32,
+) -> Result<(Vec<(BlockHash, BlockMetadata)>, HashSet<BlockHash>), HeaderSyncError> {
+    let (_batch_hashes, external_parents) = collect_external_parents(share_headers);
+
+    if starting_height <= 1 {
+        find_anchors_full_sync(external_parents, chain_store_handle)
+    } else {
+        Ok(find_anchors_pruned_sync(
+            external_parents,
+            chain_store_handle,
+            starting_height,
+        ))
+    }
 }
 
 /// Verify cumulative chain work exceeds the minimum threshold.
@@ -1584,6 +1748,696 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("External parent(s) not found in store"),
+        );
+    }
+
+    #[test]
+    fn test_validate_header_chain_pruned_sync_accepts_missing_parent_in_boundary_window() {
+        // When starting_height > 1 and header is within the boundary
+        // window (height <= starting_height + MAX_UNCLES_DEPTH), missing
+        // parents are tolerated and ASERT is skipped for those headers.
+        let starting_height = 5000u32;
+
+        // header_a at starting_height, parent is pruned (not in store)
+        let header_a = build_valid_test_header();
+        let missing_parent_hash = header_a.prev_share_blockhash;
+
+        // header_b at starting_height + 1, parent = header_a (in batch)
+        let mut header_b = build_valid_test_header();
+        header_b.prev_share_blockhash = header_a.block_hash();
+
+        let headers = vec![header_a, header_b];
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+
+        // External parent not found in store (pruned)
+        chain_store_handle
+            .expect_get_block_metadata_batch()
+            .returning(|_| Vec::new());
+
+        // No block metadata in store for any hash
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("pruned".to_string())));
+
+        let genesis_header = build_valid_test_header();
+        chain_store_handle
+            .expect_get_genesis_header()
+            .returning(move || Ok(genesis_header.clone()));
+
+        let mut mock_validator = MockDefaultShareValidator::default();
+        setup_minimum_difficulty_mock(&mut mock_validator);
+
+        let result = validate_header_chain(
+            &headers,
+            &chain_store_handle,
+            &mock_validator,
+            starting_height,
+        );
+
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+        let missing_parents = result.unwrap();
+        assert_eq!(missing_parents.len(), 1);
+        assert!(missing_parents.contains(&missing_parent_hash));
+    }
+
+    #[test]
+    fn test_validate_header_chain_pruned_sync_enforces_asert_for_non_boundary_headers() {
+        // In pruned sync, ASERT is skipped for boundary headers (whose
+        // parents are missing). But headers whose parents ARE in the
+        // batch must pass full ASERT validation. header_b has wrong bits
+        // and should be rejected.
+        let starting_height = 5000u32;
+
+        // header_a at starting_height, parent is pruned -- ASERT skipped
+        let header_a = build_valid_test_header();
+
+        // header_b at starting_height + 1, parent = header_a (in batch)
+        // Set bits to a WRONG value to trigger ASERT mismatch
+        let mut header_b = build_valid_test_header();
+        header_b.prev_share_blockhash = header_a.block_hash();
+        header_b.bits = CompactTarget::from_consensus(0x1b300000);
+
+        let headers = vec![header_a, header_b];
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+
+        chain_store_handle
+            .expect_get_block_metadata_batch()
+            .returning(|_| Vec::new());
+
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("pruned".to_string())));
+
+        let genesis_header = build_valid_test_header();
+        chain_store_handle
+            .expect_get_genesis_header()
+            .returning(move || Ok(genesis_header.clone()));
+
+        let mut mock_validator = MockDefaultShareValidator::default();
+        mock_validator
+            .expect_validate_header_minimum_difficulty()
+            .returning(|_| Ok(()));
+        let mut pool_difficulty = PoolDifficulty::default();
+        // ASERT expects MAX_POOL_TARGET but header_b declares 0x1b300000
+        pool_difficulty
+            .expect_calculate_target_clamped()
+            .returning(|_, _| CompactTarget::from_consensus(MAX_POOL_TARGET));
+        mock_validator
+            .expect_pool_difficulty()
+            .return_const(pool_difficulty);
+
+        let result = validate_header_chain(
+            &headers,
+            &chain_store_handle,
+            &mock_validator,
+            starting_height,
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ASERT mismatch"),);
+    }
+
+    #[tokio::test]
+    async fn test_pruned_sync_stores_missing_parent_metadata_and_organises_headers() {
+        let peer_id = libp2p::PeerId::random();
+        let starting_height = 5000u32;
+
+        // Build two headers: header_a at starting_height, header_b at starting_height + 1
+        let mut header_a = build_valid_test_header();
+        // header_a's parent is below the prune boundary (not in store)
+        let missing_parent_hash = header_a.prev_share_blockhash;
+
+        let mut header_b = build_valid_test_header();
+        header_b.prev_share_blockhash = header_a.block_hash();
+
+        let share_headers = vec![header_a.clone(), header_b.clone()];
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+
+        // get_block_metadata_batch: missing_parent_hash is NOT found (pruned)
+        chain_store_handle
+            .expect_get_block_metadata_batch()
+            .returning(|_hashes| Vec::new());
+
+        // get_block_metadata: header_a's parent is not in store, but
+        // header_a itself is found via the time_height_cache path.
+        // The first call (parent connectivity check) should succeed
+        // because the parent is in anchor_hashes (known_hashes).
+        // Subsequent calls for time/height fall back to cache.
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("not in store (pruned)".to_string())));
+
+        // Genesis header for PoolDifficulty::build
+        let template_header = build_valid_test_header();
+        let genesis_header = template_header.clone();
+        chain_store_handle
+            .expect_get_genesis_header()
+            .returning(move || Ok(genesis_header.clone()));
+
+        // share_header lookup not needed since time_height_cache is
+        // pre-seeded for missing parents and populated for batch headers
+
+        // store_missing_parent_metadata should be called once with
+        // the missing parent hash and height = starting_height - 1
+        chain_store_handle
+            .expect_store_missing_parent_metadata()
+            .withf({
+                let expected_parent_hash = missing_parent_hash;
+                let expected_parent_height = starting_height - 1;
+                move |hash, height| {
+                    *hash == expected_parent_hash && *height == expected_parent_height
+                }
+            })
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        // organise_header called for both headers
+        chain_store_handle
+            .expect_organise_header()
+            .times(2)
+            .returning(|_| Ok(None));
+
+        // After organise, fewer than MAX_HEADERS_IN_RESPONSE triggers
+        // block fetch path
+        chain_store_handle
+            .expect_find_fork_point_height()
+            .returning(move |_| Ok(Some(starting_height)));
+        chain_store_handle
+            .expect_get_candidate_blocks_missing_data()
+            .returning(|_| Ok(Vec::new()));
+
+        let (swarm_tx, _swarm_rx) = mpsc::channel::<SwarmSend<oneshot::Sender<Message>>>(32);
+        let (block_fetcher_handle, _block_fetcher_rx) =
+            block_fetcher::create_block_fetcher_channel();
+
+        let mut mock_validator = MockDefaultShareValidator::default();
+        mock_validator
+            .expect_validate_header_minimum_difficulty()
+            .returning(|_| Ok(()));
+        let mut pool_difficulty = PoolDifficulty::default();
+        // ASERT is skipped for header_a (boundary), but called for header_b, so there is only one call
+        pool_difficulty
+            .expect_calculate_target_clamped()
+            .returning(|_, _| CompactTarget::from_consensus(MAX_POOL_TARGET));
+        mock_validator
+            .expect_pool_difficulty()
+            .return_const(pool_difficulty);
+
+        let result = handle_share_headers(
+            peer_id,
+            share_headers,
+            starting_height,
+            chain_store_handle,
+            swarm_tx,
+            block_fetcher_handle,
+            &mock_validator,
+        )
+        .await;
+
+        assert!(result.is_ok(), "Expected Ok, got: {}", result.unwrap_err());
+    }
+
+    #[tokio::test]
+    async fn test_pruned_sync_tolerates_missing_uncle_below_starting_height() {
+        // A header at starting_height references an uncle that is below
+        // the prune boundary. The uncle hash is not in the batch or store.
+        // verify_all_uncles_available should tolerate this.
+        let starting_height = 5000u32;
+
+        // Use a fabricated hash for the missing uncle below the prune boundary
+        let missing_uncle_hash = TestShareBlockBuilder::new().build().block_hash();
+
+        let mut header_a = build_valid_test_header();
+        header_a.uncles = vec![missing_uncle_hash];
+        let missing_parent_hash = header_a.prev_share_blockhash;
+
+        let headers = vec![header_a];
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+
+        // External parent not found in store (pruned)
+        chain_store_handle
+            .expect_get_block_metadata_batch()
+            .returning(|_| Vec::new());
+
+        // Neither parent nor uncle found in store
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("pruned".to_string())));
+
+        let genesis_header = build_valid_test_header();
+        chain_store_handle
+            .expect_get_genesis_header()
+            .returning(move || Ok(genesis_header.clone()));
+
+        let mut mock_validator = MockDefaultShareValidator::default();
+        mock_validator
+            .expect_validate_header_minimum_difficulty()
+            .returning(|_| Ok(()));
+        let mut pool_difficulty = PoolDifficulty::default();
+        pool_difficulty
+            .expect_calculate_target_clamped()
+            .returning(|_, _| CompactTarget::from_consensus(MAX_POOL_TARGET));
+        mock_validator
+            .expect_pool_difficulty()
+            .return_const(pool_difficulty);
+
+        let result = validate_header_chain(
+            &headers,
+            &chain_store_handle,
+            &mock_validator,
+            starting_height,
+        );
+
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+        let missing_parents = result.unwrap();
+        assert!(missing_parents.contains(&missing_parent_hash));
+    }
+
+    #[tokio::test]
+    async fn test_pruned_sync_tolerates_uncle_with_parent_below_starting_height() {
+        // An uncle block IS in the batch but its own prev_share_blockhash
+        // is below the prune boundary. This is case 3: missing uncle parents.
+        //
+        // Structure:
+        //   header_a at starting_height, parent_a pruned
+        //   uncle at starting_height, parent_b pruned (sibling of header_a)
+        //   header_above at starting_height + 1, parent = header_a,
+        //     uncle = uncle (ancestor's sibling)
+        let starting_height = 5000u32;
+
+        // header_a at starting_height, parent pruned
+        let header_a = build_valid_test_header();
+        let parent_a_hash = header_a.prev_share_blockhash;
+
+        // uncle at starting_height, different pruned parent
+        let uncle = build_valid_test_header();
+        let parent_b_hash = uncle.prev_share_blockhash;
+
+        // header_above at starting_height + 1, parent = header_a,
+        // references uncle as ancestor's sibling
+        let mut header_above = build_valid_test_header();
+        header_above.prev_share_blockhash = header_a.block_hash();
+        header_above.uncles = vec![uncle.block_hash()];
+
+        let headers = vec![header_a, uncle, header_above];
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+
+        // External parents (parent_a, parent_b) not found in store
+        chain_store_handle
+            .expect_get_block_metadata_batch()
+            .returning(|_| Vec::new());
+
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("pruned".to_string())));
+
+        let genesis_header = build_valid_test_header();
+        chain_store_handle
+            .expect_get_genesis_header()
+            .returning(move || Ok(genesis_header.clone()));
+
+        let mut mock_validator = MockDefaultShareValidator::default();
+        mock_validator
+            .expect_validate_header_minimum_difficulty()
+            .returning(|_| Ok(()));
+        let mut pool_difficulty = PoolDifficulty::default();
+        pool_difficulty
+            .expect_calculate_target_clamped()
+            .returning(|_, _| CompactTarget::from_consensus(MAX_POOL_TARGET));
+        mock_validator
+            .expect_pool_difficulty()
+            .return_const(pool_difficulty);
+
+        let result = validate_header_chain(
+            &headers,
+            &chain_store_handle,
+            &mock_validator,
+            starting_height,
+        );
+
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+        let missing_parents = result.unwrap();
+        assert!(missing_parents.contains(&parent_a_hash));
+        assert!(missing_parents.contains(&parent_b_hash));
+    }
+
+    #[tokio::test]
+    async fn test_handle_validation_error_retryable_sends_getheaders() {
+        let peer_id = libp2p::PeerId::random();
+        let mut chain_store_handle = ChainStoreHandle::default();
+
+        chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(500)));
+        chain_store_handle
+            .expect_build_locator()
+            .returning(|_| Ok(vec![BlockHash::all_zeros()]));
+
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<oneshot::Sender<Message>>>(32);
+
+        let error = HeaderSyncError::MissingExternalParents {
+            missing: vec![BlockHash::all_zeros()],
+            lowest_anchor_height: 100,
+        };
+
+        let result = handle_validation_error(error, peer_id, chain_store_handle, swarm_tx).await;
+
+        assert!(result.is_ok());
+        // Should have sent a GetShareHeaders request
+        if let Some(SwarmSend::Request(sent_peer, Message::GetShareHeaders(_, _))) =
+            swarm_rx.recv().await
+        {
+            assert_eq!(sent_peer, peer_id);
+        } else {
+            panic!("Expected GetShareHeaders request");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_validation_error_dense_height_disconnects_peer() {
+        let peer_id = libp2p::PeerId::random();
+        let chain_store_handle = ChainStoreHandle::default();
+
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<oneshot::Sender<Message>>>(32);
+
+        let error = HeaderSyncError::DenseHeight {
+            height: 42,
+            count: 100,
+        };
+
+        let result = handle_validation_error(error, peer_id, chain_store_handle, swarm_tx).await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds MAX_BLOCKS_PER_HEIGHT"),
+        );
+        // Should have sent a Disconnect
+        if let Some(SwarmSend::Disconnect(disconnected_peer)) = swarm_rx.recv().await {
+            assert_eq!(disconnected_peer, peer_id);
+        } else {
+            panic!("Expected Disconnect");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_validation_error_asert_mismatch_returns_error_without_disconnect() {
+        let peer_id = libp2p::PeerId::random();
+        let chain_store_handle = ChainStoreHandle::default();
+
+        let (swarm_tx, mut swarm_rx) = mpsc::channel::<SwarmSend<oneshot::Sender<Message>>>(32);
+
+        let error = HeaderSyncError::AsertMismatch {
+            block_hash: BlockHash::all_zeros(),
+            declared: 0x1b384bd7,
+            expected: 0x1b300000,
+        };
+
+        let result = handle_validation_error(error, peer_id, chain_store_handle, swarm_tx).await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ASERT mismatch"),);
+        // No disconnect for non-DenseHeight errors
+        assert!(swarm_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_dag_validation_pruned_sync_skips_asert_for_boundary_header() {
+        // Header whose parent is a missing boundary parent should skip
+        // ASERT and accumulate work normally.
+        let starting_height = 5000u32;
+        let header = build_valid_test_header();
+        let parent_hash = header.prev_share_blockhash;
+
+        let anchor_hashes: HashSet<BlockHash> = [parent_hash].into_iter().collect();
+        let missing_parent_hashes: HashSet<BlockHash> = [parent_hash].into_iter().collect();
+
+        let chain_store_handle = ChainStoreHandle::default();
+
+        let mut mock_validator = MockDefaultShareValidator::default();
+        mock_validator
+            .expect_validate_header_minimum_difficulty()
+            .returning(|_| Ok(()));
+        let mut pool_difficulty = PoolDifficulty::default();
+        // Should NOT be called for boundary header
+        pool_difficulty
+            .expect_calculate_target_clamped()
+            .times(0)
+            .returning(|_, _| CompactTarget::from_consensus(MAX_POOL_TARGET));
+
+        let result = validate_dag_connectivity_and_difficulty(
+            &[header.clone()],
+            &mock_validator,
+            &pool_difficulty,
+            &anchor_hashes,
+            &chain_store_handle,
+            starting_height - 1,
+            &missing_parent_hashes,
+            starting_height,
+        );
+
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+        let (batch_hashes, cumulative_work) = result.unwrap();
+        assert!(batch_hashes.contains(&header.block_hash()));
+        assert!(cumulative_work > Work::from_hex("0x00").unwrap());
+    }
+
+    #[test]
+    fn test_dag_validation_pruned_sync_enforces_asert_for_chained_header() {
+        // Header whose parent IS in the batch (not a missing parent)
+        // must pass ASERT. Wrong bits should cause AsertMismatch.
+        let starting_height = 5000u32;
+        let header_a = build_valid_test_header();
+        let parent_hash = header_a.prev_share_blockhash;
+
+        let mut header_b = build_valid_test_header();
+        header_b.prev_share_blockhash = header_a.block_hash();
+        // Set wrong bits to trigger ASERT mismatch
+        header_b.bits = CompactTarget::from_consensus(0x1b300000);
+
+        let anchor_hashes: HashSet<BlockHash> = [parent_hash].into_iter().collect();
+        let missing_parent_hashes: HashSet<BlockHash> = [parent_hash].into_iter().collect();
+
+        let chain_store_handle = ChainStoreHandle::default();
+
+        let mut mock_validator = MockDefaultShareValidator::default();
+        mock_validator
+            .expect_validate_header_minimum_difficulty()
+            .returning(|_| Ok(()));
+        let mut pool_difficulty = PoolDifficulty::default();
+        // ASERT expects MAX_POOL_TARGET, header_b declares 0x1b300000
+        pool_difficulty
+            .expect_calculate_target_clamped()
+            .returning(|_, _| CompactTarget::from_consensus(MAX_POOL_TARGET));
+
+        let result = validate_dag_connectivity_and_difficulty(
+            &[header_a, header_b],
+            &mock_validator,
+            &pool_difficulty,
+            &anchor_hashes,
+            &chain_store_handle,
+            starting_height - 1,
+            &missing_parent_hashes,
+            starting_height,
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ASERT mismatch"));
+    }
+
+    #[test]
+    fn test_dag_validation_rejects_missing_parent_in_full_sync() {
+        // In full sync (starting_height <= 1), a header whose parent is
+        // not in anchor_hashes and not in the store should be rejected.
+        let header = build_valid_test_header();
+
+        // Empty anchors -- parent not known
+        let anchor_hashes: HashSet<BlockHash> = HashSet::new();
+        let missing_parent_hashes: HashSet<BlockHash> = HashSet::new();
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("not found".to_string())));
+
+        let mut mock_validator = MockDefaultShareValidator::default();
+        mock_validator
+            .expect_validate_header_minimum_difficulty()
+            .returning(|_| Ok(()));
+        let pool_difficulty = PoolDifficulty::default();
+
+        let result = validate_dag_connectivity_and_difficulty(
+            &[header],
+            &mock_validator,
+            &pool_difficulty,
+            &anchor_hashes,
+            &chain_store_handle,
+            0,
+            &missing_parent_hashes,
+            1,
+        );
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("not in batch or store"),
+        );
+    }
+
+    #[test]
+    fn test_dag_validation_accumulates_work_across_chain() {
+        // Two headers chained together should accumulate work from both.
+        let header_a = build_valid_test_header();
+        let parent_hash = header_a.prev_share_blockhash;
+
+        let mut header_b = build_valid_test_header();
+        header_b.prev_share_blockhash = header_a.block_hash();
+
+        let anchor_hashes: HashSet<BlockHash> = [parent_hash].into_iter().collect();
+        let missing_parent_hashes: HashSet<BlockHash> = HashSet::new();
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(|_| {
+                Ok(BlockMetadata {
+                    expected_height: Some(0),
+                    chain_work: Work::from_hex("0x00").unwrap(),
+                    status: Status::Confirmed,
+                })
+            });
+        let template_header = build_valid_test_header();
+        chain_store_handle
+            .expect_get_share_header()
+            .returning(move |_| Ok(template_header.clone()));
+
+        let mut mock_validator = MockDefaultShareValidator::default();
+        mock_validator
+            .expect_validate_header_minimum_difficulty()
+            .returning(|_| Ok(()));
+        let mut pool_difficulty = PoolDifficulty::default();
+        pool_difficulty
+            .expect_calculate_target_clamped()
+            .returning(|_, _| CompactTarget::from_consensus(MAX_POOL_TARGET));
+
+        let result = validate_dag_connectivity_and_difficulty(
+            &[header_a.clone(), header_b.clone()],
+            &mock_validator,
+            &pool_difficulty,
+            &anchor_hashes,
+            &chain_store_handle,
+            0,
+            &missing_parent_hashes,
+            1,
+        );
+
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+        let (batch_hashes, cumulative_work) = result.unwrap();
+        assert!(batch_hashes.contains(&header_a.block_hash()));
+        assert!(batch_hashes.contains(&header_b.block_hash()));
+        let single_work = header_a.get_work();
+        assert!(cumulative_work >= single_work + single_work);
+    }
+
+    #[test]
+    fn test_verify_uncles_pruned_sync_tolerates_missing_uncle_in_boundary_window() {
+        // During pruned sync, a header references an uncle that is not
+        // in the batch or store. The header is in the boundary window
+        // so the missing uncle is tolerated.
+        let starting_height = 5000u32;
+        let lowest_anchor_height = starting_height - 1;
+
+        let missing_uncle_hash = TestShareBlockBuilder::new().nonce(999).build().block_hash();
+        let mut header = build_valid_test_header();
+        header.uncles = vec![missing_uncle_hash];
+
+        let batch_hashes: HashSet<BlockHash> = [header.block_hash()].into_iter().collect();
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("pruned".to_string())));
+
+        let result = verify_all_uncles_available(
+            &[header],
+            &batch_hashes,
+            &chain_store_handle,
+            lowest_anchor_height,
+            starting_height,
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_verify_uncles_pruned_sync_accepts_uncle_present_in_batch() {
+        // Uncle hash is present in the batch -- always accepted
+        // regardless of starting_height.
+        let starting_height = 5000u32;
+        let lowest_anchor_height = starting_height - 1;
+
+        let uncle = build_valid_test_header();
+        let mut header = build_valid_test_header();
+        header.uncles = vec![uncle.block_hash()];
+
+        let batch_hashes: HashSet<BlockHash> = [header.block_hash(), uncle.block_hash()]
+            .into_iter()
+            .collect();
+
+        let chain_store_handle = ChainStoreHandle::default();
+
+        let result = verify_all_uncles_available(
+            &[header],
+            &batch_hashes,
+            &chain_store_handle,
+            lowest_anchor_height,
+            starting_height,
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_verify_uncles_full_sync_rejects_missing_uncle() {
+        // During full sync (starting_height <= 1), a missing uncle is
+        // not tolerated and returns MissingUncle error.
+        let starting_height = 1u32;
+        let lowest_anchor_height = 0u32;
+
+        let missing_uncle_hash = TestShareBlockBuilder::new().nonce(999).build().block_hash();
+        let mut header = build_valid_test_header();
+        header.uncles = vec![missing_uncle_hash];
+
+        let batch_hashes: HashSet<BlockHash> = [header.block_hash()].into_iter().collect();
+
+        let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_get_block_metadata()
+            .returning(|_| Err(StoreError::NotFound("not found".to_string())));
+
+        let result = verify_all_uncles_available(
+            &[header],
+            &batch_hashes,
+            &chain_store_handle,
+            lowest_anchor_height,
+            starting_height,
+        );
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("not delivered in batch and not in store"),
         );
     }
 }

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -513,7 +513,7 @@ mod tests {
                 TestShareBlockBuilder::new().build().header,
             ];
             mock.expect_get_headers_for_locator()
-                .returning(move |_, _, _| Ok(headers.clone()));
+                .returning(move |_, _, _| Ok((headers.clone(), 1)));
             mock
         });
 
@@ -534,7 +534,8 @@ mod tests {
         assert!(result.is_ok());
 
         // The per-peer task processes asynchronously, wait for response
-        if let Some(SwarmSend::Response(_, Message::ShareHeaders(headers, _))) = swarm_rx.recv().await
+        if let Some(SwarmSend::Response(_, Message::ShareHeaders(headers, _))) =
+            swarm_rx.recv().await
         {
             assert_eq!(headers.len(), 2);
         } else {

--- a/p2poolv2_lib/src/node/request_response_handler/mod.rs
+++ b/p2poolv2_lib/src/node/request_response_handler/mod.rs
@@ -421,7 +421,7 @@ mod tests {
         let share_headers = vec![header1, header2];
 
         let result = handler
-            .dispatch_response(peer_id, Message::ShareHeaders(share_headers))
+            .dispatch_response(peer_id, Message::ShareHeaders(share_headers, 1))
             .await;
 
         assert!(result.is_ok());
@@ -534,7 +534,7 @@ mod tests {
         assert!(result.is_ok());
 
         // The per-peer task processes asynchronously, wait for response
-        if let Some(SwarmSend::Response(_, Message::ShareHeaders(headers))) = swarm_rx.recv().await
+        if let Some(SwarmSend::Response(_, Message::ShareHeaders(headers, _))) = swarm_rx.recv().await
         {
             assert_eq!(headers.len(), 2);
         } else {

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -567,6 +567,19 @@ impl ChainStoreHandle {
         self.store_handle.store().is_candidate(blockhash)
     }
 
+    /// Store metadata for a missing parent hash during pruned sync.
+    /// This allows organise_header to find parent metadata when
+    /// computing heights for boundary headers.
+    pub async fn store_missing_parent_metadata(
+        &self,
+        blockhash: BlockHash,
+        height: u32,
+    ) -> Result<(), StoreError> {
+        self.store_handle
+            .store_missing_parent_metadata(blockhash, height)
+            .await
+    }
+
     /// Get metadata for blockhash.
     pub fn get_block_metadata(&self, hash: &BlockHash) -> Result<BlockMetadata, StoreError> {
         self.store_handle.store().get_block_metadata(hash)
@@ -826,6 +839,7 @@ mockall::mock! {
         pub fn is_confirmed_or_confirmed_uncle(&self, blockhash: &BlockHash) -> bool;
         pub fn get_btcaddresses_for_user_ids(&self, user_ids: &[u64]) -> Result<Vec<(u64, String)>, StoreError>;
         pub async fn init_or_setup_genesis(&self, genesis_block: ShareBlock) -> Result<(), StoreError>;
+        pub async fn store_missing_parent_metadata(&self, blockhash: BlockHash, height: u32) -> Result<(), StoreError>;
         pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;
         pub async fn organise_block(&self) -> Result<Option<u32>, StoreError>;
         pub async fn promote_block(&self, header: ShareHeader) -> Result<Option<u32>, StoreError>;

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -206,25 +206,25 @@ impl ChainStoreHandle {
             .ok_or(StoreError::NotFound(share_hash.to_string()))
     }
 
-    /// Get headers for a locator.
+    /// Get headers and starting height for a locator.
     pub fn get_headers_for_locator(
         &self,
         block_hashes: &[BlockHash],
         stop_block_hash: &BlockHash,
         limit: usize,
-    ) -> Result<Vec<ShareHeader>, StoreError> {
+    ) -> Result<(Vec<ShareHeader>, u32), StoreError> {
         self.store_handle
             .store()
             .get_headers_for_locator(block_hashes, stop_block_hash, limit)
     }
 
-    /// Get blockhashes for a locator.
+    /// Get blockhashes and starting height for a locator.
     pub fn get_blockhashes_for_locator(
         &self,
         locator: &[BlockHash],
         stop_block_hash: &BlockHash,
         max_blockhashes: usize,
-    ) -> Result<Vec<BlockHash>, StoreError> {
+    ) -> Result<(Vec<BlockHash>, u32), StoreError> {
         self.store_handle.store().get_blockhashes_for_locator(
             locator,
             stop_block_hash,
@@ -797,8 +797,8 @@ mockall::mock! {
         pub fn get_shares_at_height(&self, height: u32) -> Result<HashMap<BlockHash, ShareBlock>, StoreError>;
         pub fn get_share_headers(&self, share_hashes: &[BlockHash]) -> Result<Vec<(BlockHash, ShareHeader)>, StoreError>;
         pub fn get_share_header(&self, share_hash: &BlockHash) -> Result<ShareHeader, StoreError>;
-        pub fn get_headers_for_locator(&self, block_hashes: &[BlockHash], stop_block_hash: &BlockHash, limit: usize) -> Result<Vec<ShareHeader>, StoreError>;
-        pub fn get_blockhashes_for_locator(&self, locator: &[BlockHash], stop_block_hash: &BlockHash, max_blockhashes: usize) -> Result<Vec<BlockHash>, StoreError>;
+        pub fn get_headers_for_locator(&self, block_hashes: &[BlockHash], stop_block_hash: &BlockHash, limit: usize) -> Result<(Vec<ShareHeader>, u32), StoreError>;
+        pub fn get_blockhashes_for_locator(&self, locator: &[BlockHash], stop_block_hash: &BlockHash, max_blockhashes: usize) -> Result<(Vec<BlockHash>, u32), StoreError>;
         pub fn get_tip_height(&self) -> Result<Option<u32>, StoreError>;
         pub fn get_candidate_tip_height(&self) -> Result<Option<u32>, StoreError>;
         pub fn build_locator(&self, depth: u32) -> Result<Vec<BlockHash>, StoreError>;

--- a/p2poolv2_lib/src/shares/share_block/mod.rs
+++ b/p2poolv2_lib/src/shares/share_block/mod.rs
@@ -329,7 +329,7 @@ impl ShareBlock {
     pub fn build_genesis_for_network(
         network: bitcoin::Network,
     ) -> Result<Self, Box<dyn Error + Send + Sync>> {
-        tracing::debug!("USING NETWORK {network}");
+        tracing::debug!("Using network {network}");
         assert!(
             network == bitcoin::Network::Signet
                 || network == bitcoin::Network::Bitcoin

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -207,7 +207,7 @@ impl Store {
                     .map(|hash| self.get_height_for_blockhash(hash))
                     .unwrap_or(0);
                 // Height 0 means genesis (full sync), use 1 like the
-                // locator-match path. Only heights > 0 signal a pruned
+                // locator-match path. Only heights > 1 signal a pruned
                 // sync boundary.
                 let starting_height = std::cmp::max(1, first_block_height);
                 return Ok((hashes, starting_height));
@@ -3838,7 +3838,7 @@ mod tests {
 
     /// When no locator matches on a short chain (shorter than
     /// PRUNE_DEPTH), the fallback returns genesis descendants with
-    /// starting_height = 0.
+    /// starting_height = 1.
     #[test]
     fn test_get_blockhashes_for_locator_no_match_short_chain_returns_genesis() {
         let temp_dir = tempdir().unwrap();

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -16,6 +16,7 @@
 
 use super::block_tx_metadata::{BlockMetadata, Status};
 use super::{ColumnFamily, Store, writer::StoreError};
+use crate::accounting::payout::sharechain_pplns::pplns_window::PRUNE_DEPTH;
 use crate::shares::chain::chain_store_handle::{COMMON_ANCESTOR_DEPTH, ConfirmedHeaderResult};
 use crate::shares::share_block::{ShareBlock, ShareHeader};
 use crate::shares::validation::MAX_UNCLES;
@@ -177,26 +178,32 @@ impl Store {
     }
 
     /// Get blockhashes to satisfy the locator query.
-    /// Returns a list of blockhashes from the earliest block from the block hashes
-    /// We assume the list of blocks in the locator is ordered by height, so we stop when we find the first block in the locator
-    /// Find blockhashes up to the stop blockhash, or the limit provided
+    /// Returns blockhashes from the first matching locator entry and the
+    /// share chain height of the first returned block.
+    ///
+    /// When a locator match is found, walks descendants forward from
+    /// that point. When no locator matches, falls back to the lowest
+    /// retained height (tip - PRUNE_DEPTH, clamped to 0) and walks descendants from there.
     pub fn get_blockhashes_for_locator(
         &self,
         locator: &[BlockHash],
         stop_blockhash: &BlockHash,
         limit: usize,
-    ) -> Result<Vec<BlockHash>, StoreError> {
+    ) -> Result<(Vec<BlockHash>, u32), StoreError> {
         let start_blockhash = self.first_known_for_locator(locator);
-        // If no blockhash found, return vector with genesis block
         let start_blockhash = match start_blockhash {
             Some(hash) => hash,
-            None => match self.get_genesis_blockhash() {
-                Some(hash) => return Ok(vec![hash]),
-                None => return Ok(vec![]),
-            },
+            None => {
+                let start_hash = self.lowest_retained_blockhash()?;
+                let hashes = self.get_descendant_blockhashes(&start_hash, stop_blockhash, limit)?;
+                let starting_height = self.get_height_for_blockhash(&start_hash);
+                return Ok((hashes, starting_height));
+            }
         };
 
-        self.get_descendant_blockhashes(&start_blockhash, stop_blockhash, limit)
+        let hashes = self.get_descendant_blockhashes(&start_blockhash, stop_blockhash, limit)?;
+        let starting_height = self.get_height_for_first_block(&hashes);
+        Ok((hashes, starting_height))
     }
 
     /// Find the first locator hash that we know about.
@@ -223,17 +230,44 @@ impl Store {
         None
     }
 
-    /// Get headers to satisfy the locator query.
+    /// Get the blockhash at the lowest retained height.
+    ///
+    /// Computes lowest_retained = tip - PRUNE_DEPTH, clamped to 0.
+    /// At height 0 this returns the genesis block which is always present.
+    fn lowest_retained_blockhash(&self) -> Result<BlockHash, StoreError> {
+        let top_height = self.get_top_confirmed_height().unwrap_or(0);
+        let lowest_retained = top_height.saturating_sub(PRUNE_DEPTH as u32);
+        self.get_confirmed_at_height(lowest_retained)
+    }
+
+    /// Get the share chain height of a blockhash from its metadata.
+    fn get_height_for_blockhash(&self, blockhash: &BlockHash) -> u32 {
+        self.get_block_metadata(blockhash)
+            .ok()
+            .and_then(|metadata| metadata.expected_height)
+            .unwrap_or(0)
+    }
+
+    /// Get the share chain height of the first block in a list.
+    fn get_height_for_first_block(&self, blockhashes: &[BlockHash]) -> u32 {
+        match blockhashes.first() {
+            Some(hash) => self.get_height_for_blockhash(hash),
+            None => 0,
+        }
+    }
+
+    /// Get headers and starting height to satisfy the locator query.
     pub fn get_headers_for_locator(
         &self,
         locator: &[BlockHash],
         stop_blockhash: &BlockHash,
         limit: usize,
-    ) -> Result<Vec<ShareHeader>, StoreError> {
-        let blockhashes = self.get_blockhashes_for_locator(locator, stop_blockhash, limit)?;
+    ) -> Result<(Vec<ShareHeader>, u32), StoreError> {
+        let (blockhashes, starting_height) =
+            self.get_blockhashes_for_locator(locator, stop_blockhash, limit)?;
         let headers = self.get_share_headers(&blockhashes)?;
         let ordered: Vec<ShareHeader> = headers.into_iter().map(|(_, header)| header).collect();
-        Ok(ordered)
+        Ok((ordered, starting_height))
     }
 
     /// Get descendants headers of a share
@@ -911,7 +945,7 @@ mod tests {
         let locator = store.get_blockhashes_for_height(0);
 
         // Call handle_getblocks
-        let result = store
+        let (result, _starting_height) = store
             .get_headers_for_locator(locator.as_slice(), &stop_block, 10)
             .unwrap();
 
@@ -956,7 +990,7 @@ mod tests {
                 .unwrap();
 
         // Call get_headers_for_locator with non-existent stop block
-        let result = store
+        let (result, _starting_height) = store
             .get_headers_for_locator(&locator, &non_existent_stop_block, 10)
             .unwrap();
         assert_eq!(result.len(), 2);
@@ -1003,7 +1037,7 @@ mod tests {
         let locator = store.get_blockhashes_for_height(0);
 
         // Call handle_getblocks
-        let result = store
+        let (result, _starting_height) = store
             .get_blockhashes_for_locator(locator.as_slice(), &stop_block, 10)
             .unwrap();
 
@@ -3553,7 +3587,7 @@ mod tests {
         // height is max(1-3,0)+1 = 1. Returns all blocks at h:1
         // (uncle, share_a) and h:2 (share_b).
         let locator = vec![uncle.block_hash()];
-        let result = store
+        let (result, _starting_height) = store
             .get_blockhashes_for_locator(&locator, &BlockHash::all_zeros(), 10)
             .unwrap();
 

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -178,12 +178,14 @@ impl Store {
     }
 
     /// Get blockhashes to satisfy the locator query.
-    /// Returns blockhashes from the first matching locator entry and the
-    /// share chain height of the first returned block.
+    /// Returns blockhashes and a starting_height for the response.
     ///
-    /// When a locator match is found, walks descendants forward from
-    /// that point. When no locator matches, falls back to the lowest
-    /// retained height (tip - PRUNE_DEPTH, clamped to 0) and walks descendants from there.
+    /// When a locator match is found, walks descendants forward and
+    /// returns starting_height = 1 (normal sync, full context available).
+    /// When no locator matches, falls back to the lowest retained height
+    /// (tip - PRUNE_DEPTH, clamped to 0) and returns the actual height
+    /// of the first block. starting_height > 1 signals the first batch
+    /// of a pruned sync where boundary rules apply.
     pub fn get_blockhashes_for_locator(
         &self,
         locator: &[BlockHash],
@@ -196,14 +198,17 @@ impl Store {
             None => {
                 let start_hash = self.lowest_retained_blockhash()?;
                 let hashes = self.get_descendant_blockhashes(&start_hash, stop_blockhash, limit)?;
-                let starting_height = self.get_height_for_blockhash(&start_hash);
+                let start_hash_height = self.get_height_for_blockhash(&start_hash);
+                // Height 0 means genesis (full sync), use 1 like the
+                // locator-match path. Only heights > 0 signal a pruned
+                // sync boundary.
+                let starting_height = std::cmp::max(1, start_hash_height);
                 return Ok((hashes, starting_height));
             }
         };
 
         let hashes = self.get_descendant_blockhashes(&start_blockhash, stop_blockhash, limit)?;
-        let starting_height = self.get_height_for_first_block(&hashes);
-        Ok((hashes, starting_height))
+        Ok((hashes, 1))
     }
 
     /// Find the first locator hash that we know about.
@@ -246,14 +251,6 @@ impl Store {
             .ok()
             .and_then(|metadata| metadata.expected_height)
             .unwrap_or(0)
-    }
-
-    /// Get the share chain height of the first block in a list.
-    fn get_height_for_first_block(&self, blockhashes: &[BlockHash]) -> u32 {
-        match blockhashes.first() {
-            Some(hash) => self.get_height_for_blockhash(hash),
-            None => 0,
-        }
     }
 
     /// Get headers and starting height to satisfy the locator query.
@@ -3587,7 +3584,7 @@ mod tests {
         // height is max(1-3,0)+1 = 1. Returns all blocks at h:1
         // (uncle, share_a) and h:2 (share_b).
         let locator = vec![uncle.block_hash()];
-        let (result, _starting_height) = store
+        let (result, starting_height) = store
             .get_blockhashes_for_locator(&locator, &BlockHash::all_zeros(), 10)
             .unwrap();
 
@@ -3595,6 +3592,8 @@ mod tests {
         assert!(result.contains(&uncle.block_hash()));
         assert!(result.contains(&share_a.block_hash()));
         assert!(result.contains(&share_b.block_hash()));
+        // Locator matched, so starting_height signals normal sync
+        assert_eq!(starting_height, 1);
     }
 
     /// first_known_for_locator returns the first known hash from the
@@ -3766,5 +3765,76 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].blockhash, share.block_hash());
         assert!(!entries[0].has_block_data);
+    }
+
+    /// When no locator matches on a short chain (shorter than
+    /// PRUNE_DEPTH), the fallback returns genesis descendants with
+    /// starting_height = 0.
+    #[test]
+    fn test_get_blockhashes_for_locator_no_match_short_chain_returns_genesis() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let share_a = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .work(2)
+            .nonce(1)
+            .build();
+        store.push_to_confirmed_chain(&share_a).unwrap();
+
+        // Locator with an unknown hash -- no match
+        let unknown_hash = TestShareBlockBuilder::new().nonce(999).build().block_hash();
+        let (result, starting_height) = store
+            .get_blockhashes_for_locator(&[unknown_hash], &BlockHash::all_zeros(), 100)
+            .unwrap();
+
+        // Short chain: lowest_retained = 0 (genesis), starting_height = 1
+        // (full sync, same as locator-match path)
+        assert_eq!(starting_height, 1);
+        // get_descendant_blockhashes starts from height 1 (genesis height
+        // 0, minus MAX_UNCLES_DEPTH overlap, plus 1), so share_a is returned
+        assert!(!result.is_empty());
+        assert!(result.contains(&share_a.block_hash()));
+    }
+
+    /// When a locator matches, starting_height is always 1 regardless
+    /// of the actual height of the first returned block.
+    #[test]
+    fn test_get_blockhashes_for_locator_match_returns_starting_height_one() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let share_a = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .work(2)
+            .nonce(1)
+            .build();
+        store.push_to_confirmed_chain(&share_a).unwrap();
+
+        let share_b = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share_a.block_hash().to_string())
+            .work(2)
+            .nonce(2)
+            .build();
+        store.push_to_confirmed_chain(&share_b).unwrap();
+
+        // Locator matches share_b
+        let (result, starting_height) = store
+            .get_blockhashes_for_locator(&[share_b.block_hash()], &BlockHash::all_zeros(), 100)
+            .unwrap();
+
+        // Locator matched, so starting_height = 1 (normal sync)
+        assert_eq!(starting_height, 1);
+        assert!(!result.is_empty());
     }
 }

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -211,24 +211,30 @@ impl Store {
         Ok((hashes, 1))
     }
 
-    /// Find the first locator hash that we know about.
+    /// Find the first locator hash that we know about and is within
+    /// the retained chain (at or above lowest retained height).
     ///
     /// Uses a single batch metadata lookup and then walks the locator
     /// in order to return the first hash with a valid status
-    /// (HeaderValid, Candidate, Confirmed, or BlockValid). Pending
-    /// and Invalid blocks are skipped.
-    ///
-    /// With height-based walking, get_descendant_blockhashes sends all
-    /// blocks at each height regardless of status, so matching any
-    /// valid block is correct. The locator is ordered newest-first, so
-    /// the first match gives the highest known height.
+    /// (HeaderValid, Candidate, Confirmed, or BlockValid) whose height
+    /// is at or above the lowest retained height. Blocks below the
+    /// prune boundary are ignored even if present in the store, so the
+    /// node behaves as a pruned node.
     fn first_known_for_locator(&self, locator: &[BlockHash]) -> Option<BlockHash> {
+        let lowest_retained = self
+            .get_top_confirmed_height()
+            .unwrap_or(0)
+            .saturating_sub(PRUNE_DEPTH as u32);
+
         let metadata_results: HashMap<BlockHash, BlockMetadata> =
             self.get_block_metadata_batch(locator).into_iter().collect();
         for blockhash in locator {
             if let Some(metadata) = metadata_results.get(blockhash) {
                 if metadata.status != Status::Pending && metadata.status != Status::Invalid {
-                    return Some(*blockhash);
+                    let height = metadata.expected_height.unwrap_or(0);
+                    if height >= lowest_retained {
+                        return Some(*blockhash);
+                    }
                 }
             }
         }
@@ -3665,6 +3671,62 @@ mod tests {
 
         // Locator with only confirmed entries returns the first one
         let locator = vec![share_a.block_hash(), genesis.block_hash()];
+        let result = store.first_known_for_locator(&locator);
+        assert_eq!(result, Some(share_a.block_hash()));
+    }
+
+    /// first_known_for_locator ignores blocks below the lowest retained
+    /// height (tip - PRUNE_DEPTH). Even if a block exists in the store,
+    /// it is treated as unknown if its height is below the prune boundary.
+    ///
+    /// This test builds a chain and then artificially sets the confirmed
+    /// tip height high enough that genesis falls below the prune boundary.
+    #[test]
+    fn test_first_known_for_locator_ignores_blocks_below_prune_boundary() {
+        use crate::accounting::payout::sharechain_pplns::pplns_window::PRUNE_DEPTH;
+
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let share_a = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .work(2)
+            .nonce(1)
+            .build();
+        store.push_to_confirmed_chain(&share_a).unwrap();
+
+        // Artificially set share_a's height to PRUNE_DEPTH + 100 so
+        // that lowest_retained = 100, making genesis (height 0) fall
+        // below the prune boundary.
+        let artificial_height = PRUNE_DEPTH as u32 + 100;
+        let mut batch = Store::get_write_batch();
+        let metadata = BlockMetadata {
+            expected_height: Some(artificial_height),
+            chain_work: share_a.header.get_work(),
+            status: Status::Confirmed,
+        };
+        store
+            .update_block_metadata(&share_a.block_hash(), &metadata, &mut batch)
+            .unwrap();
+        store.set_top_confirmed_height(artificial_height, &mut batch);
+        store.commit_batch(batch).unwrap();
+
+        // Genesis is at height 0, below lowest_retained (100).
+        // Locator with only genesis should return None.
+        let locator = vec![genesis.block_hash()];
+        let result = store.first_known_for_locator(&locator);
+        assert_eq!(
+            result, None,
+            "Genesis below prune boundary should not match"
+        );
+
+        // share_a is at artificial_height (above boundary), should match
+        let locator = vec![genesis.block_hash(), share_a.block_hash()];
         let result = store.first_known_for_locator(&locator);
         assert_eq!(result, Some(share_a.block_hash()));
     }

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -198,11 +198,18 @@ impl Store {
             None => {
                 let start_hash = self.lowest_retained_blockhash()?;
                 let hashes = self.get_descendant_blockhashes(&start_hash, stop_blockhash, limit)?;
-                let start_hash_height = self.get_height_for_blockhash(&start_hash);
+                // Use the height of the first returned block, not
+                // start_hash. get_descendant_blockhashes applies a
+                // MAX_UNCLES_DEPTH overlap so the first block may be
+                // at a lower height than start_hash.
+                let first_block_height = hashes
+                    .first()
+                    .map(|hash| self.get_height_for_blockhash(hash))
+                    .unwrap_or(0);
                 // Height 0 means genesis (full sync), use 1 like the
                 // locator-match path. Only heights > 0 signal a pruned
                 // sync boundary.
-                let starting_height = std::cmp::max(1, start_hash_height);
+                let starting_height = std::cmp::max(1, first_block_height);
                 return Ok((hashes, starting_height));
             }
         };
@@ -3898,5 +3905,67 @@ mod tests {
         // Locator matched, so starting_height = 1 (normal sync)
         assert_eq!(starting_height, 1);
         assert!(!result.is_empty());
+    }
+
+    /// When no locator matches on a tall chain (taller than PRUNE_DEPTH),
+    /// the fallback starts from lowest_retained. starting_height is the
+    /// height of the first returned block, which accounts for the
+    /// MAX_UNCLES_DEPTH overlap in get_descendant_blockhashes.
+    ///
+    /// We build genesis(h:0) -> share_a(h:1) -> share_b(h:2) normally,
+    /// then set top_confirmed_height to PRUNE_DEPTH + 1. This makes
+    /// lowest_retained = 1 = share_a's confirmed height, so the pruned
+    /// fallback path starts from share_a.
+    #[test]
+    fn test_get_blockhashes_for_locator_no_match_tall_chain_returns_pruned_start() {
+        use crate::accounting::payout::sharechain_pplns::pplns_window::PRUNE_DEPTH;
+
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let share_a = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .work(2)
+            .nonce(1)
+            .build();
+        store.push_to_confirmed_chain(&share_a).unwrap();
+
+        let share_b = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share_a.block_hash().to_string())
+            .work(2)
+            .nonce(2)
+            .build();
+        store.push_to_confirmed_chain(&share_b).unwrap();
+
+        // Artificially set top_confirmed_height to PRUNE_DEPTH + 1.
+        // lowest_retained = (PRUNE_DEPTH + 1) - PRUNE_DEPTH = 1.
+        // share_a is confirmed at height 1, so it becomes the start.
+        // Genesis at height 0 falls below the prune boundary.
+        let artificial_tip_height = PRUNE_DEPTH as u32 + 1;
+        let mut batch = Store::get_write_batch();
+        store.set_top_confirmed_height(artificial_tip_height, &mut batch);
+        store.commit_batch(batch).unwrap();
+
+        // Locator with only genesis -- below prune boundary, no match
+        let (result, _starting_height) = store
+            .get_blockhashes_for_locator(&[genesis.block_hash()], &BlockHash::all_zeros(), 100)
+            .unwrap();
+
+        // The key behavior: genesis was NOT matched as a locator even
+        // though it exists in the store, so the pruned fallback ran.
+        assert!(!result.is_empty());
+        assert!(result.contains(&share_a.block_hash()));
+
+        // Verify genesis was ignored by the locator match
+        let locator_result = store.first_known_for_locator(&[genesis.block_hash()]);
+        assert_eq!(
+            locator_result, None,
+            "Genesis should be below prune boundary"
+        );
     }
 }

--- a/p2poolv2_lib/src/store/writer/handle.rs
+++ b/p2poolv2_lib/src/store/writer/handle.rs
@@ -308,6 +308,25 @@ impl StoreHandle {
         reply_rx.await.map_err(|_| StoreError::ChannelClosed)?
     }
 
+    /// Store metadata for a missing parent hash during pruned sync.
+    /// This allows organise_header to find parent metadata when
+    /// computing heights for boundary headers.
+    pub async fn store_missing_parent_metadata(
+        &self,
+        blockhash: BlockHash,
+        height: u32,
+    ) -> Result<(), StoreError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.write_tx
+            .send(WriteCommand::StoreMissingParentMetadata {
+                blockhash,
+                height,
+                reply: reply_tx,
+            })
+            .map_err(|_| StoreError::ChannelClosed)?;
+        reply_rx.await.map_err(|_| StoreError::ChannelClosed)?
+    }
+
     /// Organise a header into the candidate chain.
     /// Returns the new candidate height if changed.
     pub async fn organise_header(&self, header: ShareHeader) -> Result<Option<u32>, StoreError> {

--- a/p2poolv2_lib/src/store/writer/mod.rs
+++ b/p2poolv2_lib/src/store/writer/mod.rs
@@ -30,7 +30,8 @@ pub use handle::StoreHandle;
 use crate::accounting::payout::simple_pplns::SimplePplnsShare;
 use crate::shares::share_block::{ShareBlock, ShareHeader};
 use crate::store::Store;
-use bitcoin::BlockHash;
+use crate::store::block_tx_metadata::{BlockMetadata, Status};
+use bitcoin::{BlockHash, Work};
 use std::error::Error;
 use std::fmt;
 use std::sync::Arc;
@@ -129,6 +130,15 @@ pub enum WriteCommand {
 
     /// Set genesis block hash (fire-and-forget)
     SetGenesisBlockHash { hash: BlockHash },
+
+    /// Store metadata for a missing parent during pruned sync.
+    /// This allows organise_header to find the parent when computing
+    /// heights for boundary headers.
+    StoreMissingParentMetadata {
+        blockhash: BlockHash,
+        height: u32,
+        reply: oneshot::Sender<Result<(), StoreError>>,
+    },
 
     /// Organise a header into the candidate chain.
     /// Returns the new candidate height.
@@ -253,6 +263,24 @@ impl StoreWriter {
             // Fire-and-forget commands (in-memory state updates)
             WriteCommand::SetGenesisBlockHash { hash } => {
                 self.store.set_genesis_blockhash(hash);
+            }
+
+            WriteCommand::StoreMissingParentMetadata {
+                blockhash,
+                height,
+                reply,
+            } => {
+                let mut batch = Store::get_write_batch();
+                let metadata = BlockMetadata {
+                    expected_height: Some(height),
+                    chain_work: Work::from_hex("0x00").unwrap(),
+                    status: Status::HeaderValid,
+                };
+                let result = self
+                    .store
+                    .update_block_metadata(&blockhash, &metadata, &mut batch)
+                    .and_then(|()| self.store.commit_batch(batch).map_err(StoreError::from));
+                let _ = reply.send(result);
             }
 
             WriteCommand::OrganiseHeader { header, reply } => {


### PR DESCRIPTION
This is the first steps in syncing from a pruned node. We are only dealing with getheaders and shareheaders here.

The serving node behaves like a pruned node, by only sending headers from above the pruned depth.

The receiving node has header validation changes such that in the pruned depth to pplns depth we only run ASERT checks and dag connectivity checks for those not in the prune boundary.

We make that happen by sending starting height from the serving node. The serving node can lie about the starting height and serve a different chain, but this is the exact behaviour without sending starting height. As soon as the syncing node connects to a new peer, it will learn about the other chain and reorg out the bad chain.