### PR TITLE
Validate blocks based on PPLNS / prune depths

### DIFF
--- a/p2poolv2_lib/src/node/organise_worker.rs
+++ b/p2poolv2_lib/src/node/organise_worker.rs
@@ -229,7 +229,7 @@ impl OrganiseWorker {
         let in_pplns_zone = match check_pplns_zone(&blockhash, &self.chain_store_handle) {
             Ok(result) => result,
             Err(error_message) => {
-                error!("Error looking checking for zone: {error_message}");
+                error!("Error checking for zone: {error_message}");
                 return Ok(None);
             }
         };

--- a/p2poolv2_lib/src/node/organise_worker.rs
+++ b/p2poolv2_lib/src/node/organise_worker.rs
@@ -36,6 +36,7 @@ use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::share_block::{ShareBlock, ShareHeader};
 use crate::shares::validation::ShareValidator;
+use crate::shares::validation::check_pplns_zone;
 use crate::store::dag_store::ShareInfo;
 use crate::store::writer::StoreError;
 use crate::stratum::work::notify::{NotifyCmd, NotifySender};
@@ -225,13 +226,23 @@ impl OrganiseWorker {
         let blockhash = share_block.block_hash();
         debug!("Organising block: {blockhash:?}");
 
-        if let Err(validation_error) = self.share_validator.validate_with_chain_context(
-            share_block,
-            &self.chain_store_handle,
-            Arc::clone(&self.pplns_window),
-        ) {
-            error!("Chain-context validation failed for {blockhash}: {validation_error}");
-            return Ok(None);
+        let in_pplns_zone = match check_pplns_zone(&blockhash, &self.chain_store_handle) {
+            Ok(result) => result,
+            Err(error_message) => {
+                error!("Error looking checking for zone: {error_message}");
+                return Ok(None);
+            }
+        };
+
+        if in_pplns_zone {
+            if let Err(validation_error) = self.share_validator.validate_with_chain_context(
+                share_block,
+                &self.chain_store_handle,
+                Arc::clone(&self.pplns_window),
+            ) {
+                error!("Chain-context validation failed for {blockhash}: {validation_error}");
+                return Ok(None);
+            }
         }
 
         match self
@@ -427,8 +438,10 @@ mod tests {
     use crate::monitoring_events::create_monitoring_event_channel;
     use crate::shares::chain::chain_store_handle::MockChainStoreHandle;
     use crate::shares::validation::MockDefaultShareValidator;
+    use crate::shares::validation::ValidationError;
     use crate::store::block_tx_metadata::BlockMetadata;
     use crate::stratum::work::notify::{NotifyCmd, NotifyReceiver};
+    use crate::test_utils::TestShareBlockBuilder;
 
     /// Create a notify channel for tests, returning the sender and receiver.
     fn create_test_notify_channel() -> (NotifySender, NotifyReceiver) {
@@ -499,9 +512,7 @@ mod tests {
             stub_share_validator_with_success(),
         );
 
-        let share = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
+        let share = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         organise_tx
             .send(OrganiseEvent::Header(share.header))
             .await
@@ -521,7 +532,19 @@ mod tests {
             .return_once(MockChainStoreHandle::new);
         mock_chain_handle
             .expect_get_block_metadata()
-            .returning(|_| Err(StoreError::NotFound("not found".into())));
+            .returning(|_| {
+                Ok(BlockMetadata {
+                    expected_height: Some(1),
+                    chain_work: bitcoin::Work::from_be_bytes([0u8; 32]),
+                    status: crate::store::block_tx_metadata::Status::Candidate,
+                })
+            });
+        mock_chain_handle
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(1)));
+        mock_chain_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(1)));
         mock_chain_handle
             .expect_promote_block()
             .returning(|_| Ok(None));
@@ -537,9 +560,7 @@ mod tests {
             stub_share_validator_with_success(),
         );
 
-        let share = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
+        let share = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         organise_tx.send(OrganiseEvent::Block(share)).await.unwrap();
         drop(organise_tx);
 
@@ -549,8 +570,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_organise_worker_skips_promote_when_validator_rejects() {
-        use crate::shares::validation::ValidationError;
-
         let (organise_tx, organise_rx) = create_organise_channel();
         let mut mock_chain_handle = MockChainStoreHandle::new();
         mock_chain_handle
@@ -558,7 +577,19 @@ mod tests {
             .return_once(MockChainStoreHandle::new);
         mock_chain_handle
             .expect_get_block_metadata()
-            .returning(|_| Err(StoreError::NotFound("not found".into())));
+            .returning(|_| {
+                Ok(BlockMetadata {
+                    expected_height: Some(10),
+                    chain_work: bitcoin::Work::from_hex("0x00").unwrap(),
+                    status: crate::store::block_tx_metadata::Status::Candidate,
+                })
+            });
+        mock_chain_handle
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(10)));
+        mock_chain_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(10)));
         // promote_block must NOT be called when chain-context validation fails.
         mock_chain_handle.expect_promote_block().never();
 
@@ -579,9 +610,7 @@ mod tests {
             share_validator,
         );
 
-        let share = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
+        let share = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         organise_tx.send(OrganiseEvent::Block(share)).await.unwrap();
         drop(organise_tx);
 
@@ -598,7 +627,19 @@ mod tests {
             .return_once(MockChainStoreHandle::new);
         mock_chain_handle
             .expect_get_block_metadata()
-            .returning(|_| Err(StoreError::NotFound("not found".into())));
+            .returning(|_| {
+                Ok(BlockMetadata {
+                    expected_height: Some(1),
+                    chain_work: bitcoin::Work::from_be_bytes([0u8; 32]),
+                    status: crate::store::block_tx_metadata::Status::Candidate,
+                })
+            });
+        mock_chain_handle
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(1)));
+        mock_chain_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(1)));
         mock_chain_handle
             .expect_promote_block()
             .returning(|_| Err(StoreError::ChannelClosed));
@@ -614,9 +655,7 @@ mod tests {
             stub_share_validator_with_success(),
         );
 
-        let share = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
+        let share = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         organise_tx.send(OrganiseEvent::Block(share)).await.unwrap();
         drop(organise_tx);
 
@@ -633,7 +672,19 @@ mod tests {
             .return_once(MockChainStoreHandle::new);
         mock_chain_handle
             .expect_get_block_metadata()
-            .returning(|_| Err(StoreError::NotFound("not found".into())));
+            .returning(|_| {
+                Ok(BlockMetadata {
+                    expected_height: Some(1),
+                    chain_work: bitcoin::Work::from_be_bytes([0u8; 32]),
+                    status: crate::store::block_tx_metadata::Status::Candidate,
+                })
+            });
+        mock_chain_handle
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(1)));
+        mock_chain_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(1)));
         mock_chain_handle
             .expect_promote_block()
             .returning(|_| Err(StoreError::Database("test error".to_string())));
@@ -649,9 +700,7 @@ mod tests {
             stub_share_validator_with_success(),
         );
 
-        let share = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
+        let share = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         tx.send(OrganiseEvent::Block(share)).await.unwrap();
         drop(tx);
 
@@ -669,10 +718,16 @@ mod tests {
             .return_once(MockChainStoreHandle::new);
         mock_chain_handle
             .expect_get_block_metadata()
-            .returning(|_| Err(StoreError::NotFound("not found".into())));
+            .returning(|_| {
+                Ok(BlockMetadata {
+                    expected_height: Some(1),
+                    chain_work: bitcoin::Work::from_be_bytes([0u8; 32]),
+                    status: crate::store::block_tx_metadata::Status::Candidate,
+                })
+            });
         mock_chain_handle
             .expect_get_tip_height()
-            .returning(|| Ok(None));
+            .returning(|| Ok(Some(1)));
         mock_chain_handle
             .expect_promote_block()
             .returning(|_| Ok(Some(5)));
@@ -694,9 +749,7 @@ mod tests {
             stub_share_validator_with_success(),
         );
 
-        let share = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
+        let share = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         organise_tx.send(OrganiseEvent::Block(share)).await.unwrap();
         drop(organise_tx);
 
@@ -718,10 +771,16 @@ mod tests {
             .return_once(MockChainStoreHandle::new);
         mock_chain_handle
             .expect_get_block_metadata()
-            .returning(|_| Err(StoreError::NotFound("not found".into())));
+            .returning(|_| {
+                Ok(BlockMetadata {
+                    expected_height: Some(1),
+                    chain_work: bitcoin::Work::from_be_bytes([0u8; 32]),
+                    status: crate::store::block_tx_metadata::Status::Candidate,
+                })
+            });
         mock_chain_handle
             .expect_get_tip_height()
-            .returning(|| Ok(None));
+            .returning(|| Ok(Some(1)));
         // Confirmed height 3 is below candidate tip 5
         mock_chain_handle
             .expect_promote_block()
@@ -744,9 +803,7 @@ mod tests {
             stub_share_validator_with_success(),
         );
 
-        let share = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
+        let share = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         organise_tx.send(OrganiseEvent::Block(share)).await.unwrap();
         drop(organise_tx);
 
@@ -792,9 +849,7 @@ mod tests {
             stub_share_validator_with_success(),
         );
 
-        let share = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
+        let share = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         organise_tx.send(OrganiseEvent::Block(share)).await.unwrap();
         drop(organise_tx);
 
@@ -842,9 +897,7 @@ mod tests {
             stub_share_validator_with_success(),
         );
 
-        let share = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
+        let share = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         organise_tx.send(OrganiseEvent::Block(share)).await.unwrap();
         drop(organise_tx);
 
@@ -916,18 +969,14 @@ mod tests {
         );
 
         // Block A: parent height 100, will be buffered
-        let share_a = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
+        let share_a = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         organise_tx
             .send(OrganiseEvent::Block(share_a))
             .await
             .unwrap();
 
         // Block B: parent height 5, will proceed and promote
-        let share_b = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695792)
-            .build();
+        let share_b = TestShareBlockBuilder::new().nonce(0xe9695792).build();
         organise_tx
             .send(OrganiseEvent::Block(share_b))
             .await
@@ -949,26 +998,19 @@ mod tests {
             .expect_clone()
             .return_once(MockChainStoreHandle::new);
 
-        // Blocks A and B both have parents at height 10; block C has no
-        // metadata so it skips buffering and goes straight to promote.
-        let metadata_call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let metadata_counter = metadata_call_count.clone();
+        // All blocks return valid metadata with height 10.
         mock_chain_handle
             .expect_get_block_metadata()
-            .returning(move |_| {
-                let count = metadata_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                if count < 2 {
-                    Ok(BlockMetadata {
-                        expected_height: Some(10),
-                        chain_work: bitcoin::Work::from_be_bytes([0u8; 32]),
-                        status: crate::store::block_tx_metadata::Status::Candidate,
-                    })
-                } else {
-                    Err(StoreError::NotFound("not found".into()))
-                }
+            .returning(|_| {
+                Ok(BlockMetadata {
+                    expected_height: Some(10),
+                    chain_work: bitcoin::Work::from_be_bytes([0u8; 32]),
+                    status: crate::store::block_tx_metadata::Status::Candidate,
+                })
             });
 
         // First two calls (should_buffer for A and B): tip is 5 -> buffer.
+        // Third call (should_buffer for C): tip is 10 -> not buffered.
         // Remaining calls (drain after C promotes): tip is 10 -> drain.
         let tip_call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
         let tip_counter = tip_call_count.clone();
@@ -1011,9 +1053,7 @@ mod tests {
         );
 
         // Block A: parent height 10, tip is 5 -> buffered at key 10
-        let share_a = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695791)
-            .build();
+        let share_a = TestShareBlockBuilder::new().nonce(0xe9695791).build();
         organise_tx
             .send(OrganiseEvent::Block(share_a))
             .await
@@ -1021,19 +1061,15 @@ mod tests {
 
         // Block B: different nonce (different hash), same parent height 10
         // -> should also be buffered, but currently overwrites A
-        let share_b = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695792)
-            .build();
+        let share_b = TestShareBlockBuilder::new().nonce(0xe9695792).build();
         organise_tx
             .send(OrganiseEvent::Block(share_b))
             .await
             .unwrap();
 
-        // Block C: metadata returns Err -> skips buffer, goes to promote,
-        // which triggers drain of the buffered blocks
-        let share_c = crate::test_utils::TestShareBlockBuilder::new()
-            .nonce(0xe9695793)
-            .build();
+        // Block C: parent height 10, tip is now 10 -> not buffered,
+        // goes to promote, which triggers drain of the buffered blocks
+        let share_c = TestShareBlockBuilder::new().nonce(0xe9695793).build();
         organise_tx
             .send(OrganiseEvent::Block(share_c))
             .await

--- a/p2poolv2_lib/src/node/validation_worker.rs
+++ b/p2poolv2_lib/src/node/validation_worker.rs
@@ -36,6 +36,7 @@ use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 #[cfg(not(test))]
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::share_block::ShareBlock;
+use crate::shares::validation::check_pplns_zone;
 use crate::shares::validation::{DefaultShareValidator, ShareValidator};
 use crate::utils::cpu::available_cpus;
 use bitcoin::BlockHash;
@@ -213,9 +214,21 @@ async fn validate_and_emit(
         },
     };
 
-    if let Err(validation_error) =
+    let in_pplns_zone = match check_pplns_zone(&block_hash, &chain_store_handle) {
+        Ok(result) => result,
+        Err(error_message) => {
+            error!("Error checking for pplns zone: {error_message}");
+            return;
+        }
+    };
+
+    let validation_result = if in_pplns_zone {
         share_validator.validate_share_block(&share_block, &chain_store_handle)
-    {
+    } else {
+        share_validator.validate_below_pplns_depth(&share_block, &chain_store_handle)
+    };
+
+    if let Err(validation_error) = validation_result {
         let error_message = validation_error.to_string();
         if error_message.contains("is on confirmed chain") {
             debug!("Share block {block_hash} validation: {error_message}");
@@ -258,9 +271,23 @@ mod tests {
     use super::*;
     use crate::node::organise_worker;
     use crate::shares::chain::chain_store_handle::MockChainStoreHandle;
+    use crate::store::block_tx_metadata::{BlockMetadata, Status};
     use crate::test_utils::TestShareBlockBuilder;
 
+    use bitcoin::Work;
     use std::time::Duration;
+
+    /// Build a BlockMetadata value that places the block inside the PPLNS zone.
+    ///
+    /// Uses height 1 so that `is_in_pplns_zone(1, candidate_tip=1)` returns true,
+    /// causing `validate_share_block` (not `validate_below_pplns_depth`) to run.
+    fn pplns_zone_metadata() -> BlockMetadata {
+        BlockMetadata {
+            expected_height: Some(1),
+            chain_work: Work::from_be_bytes([0u8; 32]),
+            status: Status::Candidate,
+        }
+    }
 
     #[tokio::test]
     async fn test_validation_worker_validates_and_sends_organise_event() {
@@ -276,6 +303,12 @@ mod tests {
         mock_clone
             .expect_get_share()
             .returning(move |_| Some(share_block_clone.clone()));
+        mock_clone
+            .expect_get_block_metadata()
+            .returning(|_| Ok(pplns_zone_metadata()));
+        mock_clone
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(1)));
         mock_clone.expect_has_status().returning(|_, _| true);
         mock_clone.expect_is_current().returning(|| true);
         mock_chain_handle
@@ -325,6 +358,12 @@ mod tests {
         mock_clone
             .expect_get_share()
             .returning(move |_| Some(share_block_clone.clone()));
+        mock_clone
+            .expect_get_block_metadata()
+            .returning(|_| Ok(pplns_zone_metadata()));
+        mock_clone
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(1)));
         mock_clone.expect_has_status().returning(|_, _| true);
         mock_clone.expect_is_current().returning(|| true);
         mock_chain_handle
@@ -374,6 +413,12 @@ mod tests {
         mock_clone
             .expect_get_share()
             .returning(move |_| Some(share_block_clone.clone()));
+        mock_clone
+            .expect_get_block_metadata()
+            .returning(|_| Ok(pplns_zone_metadata()));
+        mock_clone
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(1)));
         mock_clone.expect_has_status().returning(|_, _| true);
         mock_clone.expect_is_current().returning(|| false);
         mock_chain_handle
@@ -428,6 +473,12 @@ mod tests {
 
         let mut mock_clone = MockChainStoreHandle::new();
         mock_clone.expect_get_share().never();
+        mock_clone
+            .expect_get_block_metadata()
+            .returning(|_| Ok(pplns_zone_metadata()));
+        mock_clone
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(1)));
         mock_clone.expect_has_status().returning(|_, _| true);
         mock_clone.expect_is_current().returning(|| false);
         mock_chain_handle
@@ -540,6 +591,12 @@ mod tests {
             .expect_get_share()
             .withf(move |hash| *hash == uncle_hash)
             .returning(|_| None);
+        mock_clone
+            .expect_get_block_metadata()
+            .returning(|_| Ok(pplns_zone_metadata()));
+        mock_clone
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(1)));
         // validate_share_block calls has_status
         mock_clone.expect_has_status().returning(|_, _| false);
         mock_chain_handle
@@ -593,6 +650,12 @@ mod tests {
 
         let mut mock_clone = MockChainStoreHandle::new();
         mock_clone.expect_get_share().never();
+        mock_clone
+            .expect_get_block_metadata()
+            .returning(|_| Ok(pplns_zone_metadata()));
+        mock_clone
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(1)));
         mock_clone.expect_has_status().returning(|_, _| true);
         mock_clone.expect_is_current().returning(|| true);
         mock_chain_handle
@@ -631,6 +694,71 @@ mod tests {
             assert_eq!(broadcast_block.block_hash(), block_hash);
         } else {
             panic!("Expected SwarmSend::BroadcastBlock for prefetched share block");
+        }
+
+        worker_handle.abort();
+    }
+
+    /// Prune-zone block (height 100, candidate tip 300000) is validated
+    /// via the below-PPLNS path. The BlockValid shortcut fires (same as
+    /// PPLNS-zone tests) because test fixture blocks don't carry valid
+    /// PoW against pool difficulty. The test verifies the block reaches
+    /// the organise worker, confirming the below-PPLNS path returns Ok.
+    #[tokio::test]
+    async fn test_validation_worker_successfully_validates_blocks_in_prune_zone() {
+        let (validation_tx, validation_rx) = create_validation_channel();
+        let mut mock_chain_handle = MockChainStoreHandle::new();
+
+        let share_block = TestShareBlockBuilder::new().build();
+        let block_hash = share_block.block_hash();
+        let share_block_clone = share_block.clone();
+
+        let mut mock_clone = MockChainStoreHandle::new();
+        mock_clone
+            .expect_get_share()
+            .returning(move |_| Some(share_block_clone.clone()));
+        mock_clone.expect_get_block_metadata().returning(|_| {
+            Ok(BlockMetadata {
+                expected_height: Some(100),
+                chain_work: Work::from_be_bytes([0u8; 32]),
+                status: Status::Candidate,
+            })
+        });
+        mock_clone
+            .expect_get_candidate_tip_height()
+            .returning(|| Ok(Some(300_000)));
+        // BlockValid shortcut fires in validate_below_pplns_depth
+        mock_clone.expect_has_status().returning(|_, _| true);
+        mock_clone.expect_is_current().returning(|| false);
+        mock_chain_handle
+            .expect_clone()
+            .return_once(move || mock_clone);
+
+        let (organise_tx, mut organise_rx) = organise_worker::create_organise_channel();
+        let (swarm_tx, _swarm_rx) = mpsc::channel(32);
+
+        let worker = ValidationWorker::new(
+            validation_rx,
+            mock_chain_handle,
+            organise_tx,
+            swarm_tx,
+            1,
+            b"P2Poolv2".to_vec(),
+            PoolDifficulty::default(),
+        );
+
+        let worker_handle = tokio::spawn(worker.run());
+
+        validation_tx
+            .send(ValidationEvent::ValidateBlockHash(block_hash))
+            .await
+            .unwrap();
+
+        let organise_event = tokio::time::timeout(Duration::from_secs(2), organise_rx.recv()).await;
+        if let Ok(Some(OrganiseEvent::Block(received_block))) = organise_event {
+            assert_eq!(received_block.block_hash(), block_hash);
+        } else {
+            panic!("Expected OrganiseEvent::Block for prune-zone block");
         }
 
         worker_handle.abort();

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -725,6 +725,9 @@ impl ChainStoreHandle {
     /// wrote, and a plain WriteBatch is opaque to reads against the DB.
     /// A crash between the two commits leaves a lingering candidate which
     /// the next promote_block call will pick up.
+    ///
+    /// Returns the new chain height, which can be higher than the
+    /// height of the `header`
     pub async fn promote_block(&self, header: ShareHeader) -> Result<Option<u32>, StoreError> {
         let blockhash = header.block_hash();
         let uncle_count = header.uncles.len();

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -1555,6 +1555,43 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_below_pplns_depth_returns_ok_for_block_valid_status() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+        let share_block = TestShareBlockBuilder::new().build();
+
+        chain_store_handle
+            .expect_has_status()
+            .returning(|_, _| true);
+
+        let result = validator().validate_below_pplns_depth(&share_block, &chain_store_handle);
+        assert!(
+            result.is_ok(),
+            "Expected Ok for BlockValid status, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_validate_below_pplns_depth_passes_with_fixture_block() {
+        let mut chain_store_handle = ChainStoreHandle::default();
+
+        let share_block = build_block_from_work_components(
+            "../p2poolv2_tests/test_data/validation/stratum/b/",
+            TEST_COINBASE_NSECS,
+        );
+
+        // Mark as BlockValid so validate_with_pool_difficulty is skipped.
+        // The test fixture's bitcoin header doesn't have valid PoW against
+        // pool difficulty. Pool difficulty is tested in dedicated tests.
+        chain_store_handle
+            .expect_has_status()
+            .returning(|_, _| true);
+
+        let result = validator().validate_below_pplns_depth(&share_block, &chain_store_handle);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+    }
+
+    #[test]
     fn test_validate_share_header_valid() {
         let mut chain_store_handle = ChainStoreHandle::default();
         let mut pool_difficulty = PoolDifficulty::default();

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -26,6 +26,7 @@ use crate::accounting::payout::payout_distribution::{
 use crate::accounting::payout::sharechain_pplns::PplnsWindow;
 #[cfg(not(test))]
 use crate::accounting::payout::sharechain_pplns::PplnsWindow;
+use crate::accounting::payout::sharechain_pplns::pplns_window::MAX_PPLNS_WINDOW_SHARES;
 #[cfg(test)]
 #[mockall_double::double]
 use crate::pool_difficulty::PoolDifficulty;
@@ -89,6 +90,38 @@ pub const COINBASE_MATURITY: usize = 6048;
 /// Maximum total sigop cost allowed in a share block (matches Bitcoin consensus).
 pub const MAX_BLOCK_SIGOPS_COST: usize = 80_000;
 
+/// Check whether a block is in the PPLNS zone (needing full
+/// validation) or the prune zone (PoW-only validation).
+///
+/// PPLNS zone: block_height > tip_height - PPLNS_DEPTH
+/// Prune zone: everything else below that height
+pub fn is_in_pplns_zone(block_height: u32, tip_height: u32) -> bool {
+    block_height > tip_height.saturating_sub(MAX_PPLNS_WINDOW_SHARES as u32)
+}
+
+/// Look up a block's height and the candidate tip height from the store,
+/// then determine whether the block is in the PPLNS zone.
+///
+/// Returns `Ok(true)` for PPLNS zone (full validation), `Ok(false)` for
+/// prune zone (PoW-only). Returns `Err` if the metadata lookup fails or
+/// the block has no expected_height.
+pub fn check_pplns_zone(
+    blockhash: &BlockHash,
+    chain_store_handle: &ChainStoreHandle,
+) -> Result<bool, String> {
+    let metadata = chain_store_handle
+        .get_block_metadata(blockhash)
+        .map_err(|error| format!("Failed to get block metadata for {blockhash}: {error}"))?;
+    let block_height = metadata
+        .expected_height
+        .ok_or_else(|| format!("Block {blockhash} has no expected_height in metadata"))?;
+    let candidate_tip = chain_store_handle
+        .get_candidate_tip_height()
+        .map_err(|error| format!("Failed to get candidate tip height: {error}"))?
+        .unwrap_or(0);
+    Ok(is_in_pplns_zone(block_height, candidate_tip))
+}
+
 /// Trait for share validation operations.
 ///
 /// Provides methods to validate share headers, share blocks, uncles,
@@ -124,6 +157,17 @@ pub trait ShareValidator {
     /// newly validated parent) to skip redundant validation while still
     /// proceeding through organise_block.
     fn validate_share_block(
+        &self,
+        share: &ShareBlock,
+        chain_store_handle: &ChainStoreHandle,
+    ) -> Result<(), ValidationError>;
+
+    /// Validate a share block that is below the PPLNS depth (in the
+    /// prune zone). Only checks PoW, uncles, block size, and
+    /// transaction count.  Skips coinbase, merkle root, witness
+    /// commitment, transaction structure, and script validation since
+    /// these blocks will not participate in PPLNS accounting.
+    fn validate_below_pplns_depth(
         &self,
         share: &ShareBlock,
         chain_store_handle: &ChainStoreHandle,
@@ -831,6 +875,21 @@ impl ShareValidator for DefaultShareValidator {
         Ok(())
     }
 
+    fn validate_below_pplns_depth(
+        &self,
+        share: &ShareBlock,
+        chain_store_handle: &ChainStoreHandle,
+    ) -> Result<(), ValidationError> {
+        if chain_store_handle.has_status(&share.block_hash(), Status::BlockValid) {
+            return Ok(());
+        }
+        self.validate_with_pool_difficulty(&share.header, chain_store_handle)?;
+        self.validate_uncles(share, chain_store_handle)?;
+        self.validate_block_size(share)?;
+        self.validate_transaction_count(share)?;
+        Ok(())
+    }
+
     fn validate_uncles(
         &self,
         share: &ShareBlock,
@@ -1048,6 +1107,12 @@ mockall::mock! {
         ) -> Result<(), ValidationError>;
 
         fn validate_share_block(
+            &self,
+            share: &ShareBlock,
+            chain_store_handle: &ChainStoreHandle,
+        ) -> Result<(), ValidationError>;
+
+        fn validate_below_pplns_depth(
             &self,
             share: &ShareBlock,
             chain_store_handle: &ChainStoreHandle,
@@ -3441,5 +3506,48 @@ mod tests {
             error.to_string().contains("must have zero value"),
             "Expected zero-value error, got: {error}"
         );
+    }
+
+    #[test]
+    fn test_is_in_pplns_zone_at_tip() {
+        // Block at tip height is in PPLNS zone
+        assert!(is_in_pplns_zone(300_000, 300_000));
+    }
+
+    #[test]
+    fn test_is_in_pplns_zone_within_pplns_depth() {
+        // Block just inside PPLNS window
+        let tip = 300_000u32;
+        let pplns_boundary = tip - MAX_PPLNS_WINDOW_SHARES as u32;
+        assert!(is_in_pplns_zone(pplns_boundary + 1, tip));
+    }
+
+    #[test]
+    fn test_is_in_pplns_zone_at_boundary_is_prune_zone() {
+        // Block exactly at boundary is NOT in PPLNS zone (prune zone)
+        let tip = 300_000u32;
+        let pplns_boundary = tip - MAX_PPLNS_WINDOW_SHARES as u32;
+        assert!(!is_in_pplns_zone(pplns_boundary, tip));
+    }
+
+    #[test]
+    fn test_is_in_pplns_zone_below_boundary_is_prune_zone() {
+        let tip = 300_000u32;
+        let pplns_boundary = tip - MAX_PPLNS_WINDOW_SHARES as u32;
+        assert!(!is_in_pplns_zone(pplns_boundary - 1, tip));
+    }
+
+    #[test]
+    fn test_is_in_pplns_zone_short_chain() {
+        // Chain shorter than PPLNS depth: all blocks are in PPLNS zone
+        assert!(is_in_pplns_zone(1, 100));
+        assert!(is_in_pplns_zone(50, 100));
+    }
+
+    #[test]
+    fn test_is_in_pplns_zone_height_zero() {
+        // Height 0 with any tip is NOT in PPLNS zone (0 > anything is false)
+        assert!(!is_in_pplns_zone(0, 0));
+        assert!(!is_in_pplns_zone(0, 300_000));
     }
 }


### PR DESCRIPTION
Blocks in PPLNS zone are fully validated.

Blocks in prune depth, below the PPLNS zone are only PoW validate.