### PR TITLE
Add coinbase pplns depth spend rule

### DIFF
--- a/docs/architecture/pruning.md
+++ b/docs/architecture/pruning.md
@@ -1,0 +1,170 @@
+# Pruning Architecture
+
+This document describes how P2Poolv2 handles chain pruning: syncing
+efficiently, validating blocks in two zones, and enforcing output
+spendability rules.
+
+## Overview
+
+P2Poolv2 retains a rolling window of chain data. Old block bodies are
+pruned while headers are kept indefinitely. The system uses two depth
+constants:
+
+- **PPLNS_DEPTH** (120,960 blocks, ~14 days): blocks within this
+  window get full transaction validation and participate in payout
+  accounting.
+- **PRUNE_DEPTH** (241,920 blocks, ~28 days): blocks within this
+  window have their bodies retained. Blocks between PRUNE_DEPTH and
+  PPLNS_DEPTH get PoW-only body validation.
+
+## Header Sync
+
+Headers are always synced from genesis. The full header chain is
+retained permanently (~276 bytes per header, ~4 GB after 5 years).
+
+This provides:
+
+- Full ASERT difficulty validation for every header
+- Complete chain connectivity back to genesis
+- No trust in peer-provided metadata
+- Strongest possible security model
+
+A pruned header sync approach was evaluated and rejected. It required
+boundary windows, ASERT skip logic, synthetic parent metadata,
+defense-in-depth against malicious starting_height, and weakened the
+trust model by making chain fragments "float" with only cumulative
+work as a security guarantee. The marginal benefit (~20 min sync
+savings, ~4 GB storage) did not justify the complexity and attack
+surface.
+
+### Checkpoint-based sync (future)
+
+For faster initial sync, hard-coded checkpoints in the source (like
+genesis) can serve as sync start points. A new node uses the
+checkpoint hash as a getheaders locator. The peer responds normally
+and the first header's parent matches the checkpoint -- same trust as
+genesis. Once checkpoints are in place, headers below the latest
+checkpoint can also be pruned. Not in the MVP.
+
+## Block Body Fetch
+
+After header sync completes, block bodies are fetched only for blocks
+within PRUNE_DEPTH of the candidate tip.
+
+The scan start height in `missing_data_scan_start` is clamped upward
+to `candidate_tip - PRUNE_DEPTH` so blocks in the prune zone are
+never fetched. Their PoW was already validated during header sync.
+
+Relevant code: `store/organise/candidate.rs` (`missing_data_scan_start`).
+
+## Two-Zone Block Validation
+
+When block bodies arrive, validation depends on the block's zone
+relative to the candidate tip:
+
+### Prune zone (height <= tip - PPLNS_DEPTH)
+
+`validate_below_pplns_depth` runs:
+- Pool difficulty (PoW)
+- Uncle validity
+- Block size
+- Transaction count
+
+Skips: coinbase structure, merkle root, witness commitment,
+transaction structure, script verification, prevout validation, MTP,
+bitcoin coinbase payout verification.
+
+### PPLNS zone (height > tip - PPLNS_DEPTH)
+
+`validate_share_block` runs all checks. `validate_with_chain_context`
+runs MTP, bitcoin coinbase payout, and prevout validation before
+promotion to confirmed.
+
+### Zone determination
+
+`check_pplns_zone(blockhash, chain_store_handle)` looks up the
+block's height and candidate tip from the store. Returns `Ok(true)`
+for PPLNS zone, `Ok(false)` for prune zone.
+
+When metadata is not yet available (locally mined blocks, async store
+write race), defaults to PPLNS zone (full validation). Only real store
+errors (Database, ChannelClosed) are propagated.
+
+Relevant code:
+- `shares/validation/mod.rs` (`is_in_pplns_zone`, `check_pplns_zone`,
+  `validate_below_pplns_depth`)
+- `node/validation_worker.rs` (`validate_and_emit`)
+- `node/organise_worker.rs` (`validate_and_promote_block`)
+
+## Output Spendability (coinbase_root_height)
+
+Each `StoredTxOut` carries a `coinbase_root_height` field: the block
+height of the oldest coinbase ancestor in the output's spending chain.
+
+### Computation (store-at-write)
+
+- Coinbase outputs: `coinbase_root_height = block_height`
+- Spending tx outputs: `coinbase_root_height = min(coinbase_root_height
+  of all inputs)`
+
+Computed at write time in `add_sharechain_txs`. In-block spending
+chains (output created and spent within the same block) use a
+batch-local `HashMap` cache since uncommitted batch data is not
+readable from RocksDB.
+
+### Validation
+
+`validate_prevouts` computes `min_coinbase_root_height = tip_height -
+PPLNS_DEPTH` and passes it to `check_prevouts_and_find_coinbase`.
+Outputs with `coinbase_root_height < min_coinbase_root_height` are
+rejected in the same batch read that checks output existence -- no
+second pass needed.
+
+### Why store-at-write, not walk-at-validation
+
+A walk-at-validation approach was evaluated: walk the spending chain
+back to the coinbase during `validate_prevouts`. Rejected because an
+attacker can build spending chains up to ~12 million hops deep
+(120,960 blocks x 99 txs/block), creating a DoS of ~24 seconds per
+input validation. Store-at-write is O(1) at validation time and
+O(inputs) at write time, bounded by block size (~5000 inputs max).
+
+### Error handling
+
+- `min_coinbase_root_height_for_inputs` returns `StoreError` if any
+  input output is missing or undecodable (prevents persisting height 0
+  which would make outputs permanently unspendable).
+- `compute_block_height_from_parent` returns `StoreError` if parent
+  metadata is missing (genesis is special-cased to height 0).
+- `get_tip_height` errors in `validate_prevouts` are propagated (not
+  silently defaulted to 0, which would disable the spend rule).
+
+Relevant code:
+- `store/transaction_store.rs` (`StoredTxOut`,
+  `min_coinbase_root_height_for_inputs`,
+  `check_prevouts_and_find_coinbase`)
+- `store/share_store.rs` (`compute_block_height_from_parent`)
+- `shares/validation/mod.rs` (`validate_prevouts`)
+
+## Constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| PPLNS_DEPTH | 120,960 | 14 days at 10s/block |
+| PRUNE_DEPTH | 241,920 | 2 x PPLNS_DEPTH |
+| PRUNE_INTERVAL | 360 | 1 hour of blocks |
+| Block height | u32 | Overflows in ~1,361 years |
+
+Defined in `accounting/payout/sharechain_pplns/pplns_window.rs`.
+
+## Task 2: Actual Pruning (not yet implemented)
+
+After Task 1 (two-zone validation + output spendability):
+
+1. Pruning task: periodic every 360 blocks after is_current
+2. Atomic batch deletion of block body CFs (BlockTxids, TxidsBlocks,
+   BitcoinTxids, Inputs, Outputs, Tx, TemplateMerkleBranches,
+   SpendsIndex). Headers and BlockMetadata retained.
+3. Candidate chain pruning below prune boundary
+4. Startup pruning + compaction
+5. CLI manual prune command

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -111,13 +111,15 @@ impl ChainStoreHandle {
     }
 
     /// Batch-read all outpoints from the Outputs CF.
-    /// Returns an error if any is missing, otherwise returns coinbase outpoints.
+    /// Returns an error if any is missing or has coinbase_root_height
+    /// is below min_coinbase_root_height. Returns coinbase outpoints.
     pub fn check_prevouts_and_find_coinbase(
         &self,
         outpoints: &[bitcoin::OutPoint],
+        min_coinbase_root_height: u32,
     ) -> Result<Vec<bitcoin::OutPoint>, StoreError> {
         self.store_handle
-            .check_prevouts_and_find_coinbase(outpoints)
+            .check_prevouts_and_find_coinbase(outpoints, min_coinbase_root_height)
     }
 
     /// Return the first coinbase outpoint that is not yet mature, or None.
@@ -789,7 +791,7 @@ mockall::mock! {
         pub fn get_blockhashes_for_height(&self, height: u32) -> Vec<BlockHash>;
         pub fn network(&self) -> bitcoin::Network;
         pub fn get_all_prevouts(&self, transaction: &bitcoin::Transaction) -> Result<Vec<(usize, bitcoin::TxOut)>, StoreError>;
-        pub fn check_prevouts_and_find_coinbase(&self, outpoints: &[bitcoin::OutPoint]) -> Result<Vec<bitcoin::OutPoint>, StoreError>;
+        pub fn check_prevouts_and_find_coinbase(&self, outpoints: &[bitcoin::OutPoint], min_coinbase_root_height: u32) -> Result<Vec<bitcoin::OutPoint>, StoreError>;
         pub fn find_immature_coinbase_prevout(&self, coinbase_outpoints: &[bitcoin::OutPoint], min_depth: usize) -> Result<Option<bitcoin::OutPoint>, StoreError>;
         pub fn is_any_prevout_spent(&self, outpoints: &[bitcoin::OutPoint]) -> Result<bool, StoreError>;
         pub fn are_all_txids_confirmed(&self, txids: &[bitcoin::Txid]) -> Result<bool, StoreError>;

--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -1054,7 +1054,10 @@ mod tests {
             .work(1)
             .build();
 
-        chain_handle.add_share_block(share1.clone()).await.unwrap();
+        chain_handle
+            .add_share_block_and_organise_header(share1.clone())
+            .await
+            .unwrap();
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
@@ -1062,7 +1065,10 @@ mod tests {
             .work(1)
             .build();
 
-        chain_handle.add_share_block(share2).await.unwrap();
+        chain_handle
+            .add_share_block_and_organise_header(share2)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -1064,9 +1064,7 @@ impl DefaultShareValidator {
         }
         let tip_height = chain_store_handle
             .get_tip_height()
-            .map_err(|error| {
-                ValidationError::new(format!("Failed to get tip height: {error}"))
-            })?
+            .map_err(|error| ValidationError::new(format!("Failed to get tip height: {error}")))?
             .unwrap_or(0);
         let min_coinbase_root_height = tip_height.saturating_sub(MAX_PPLNS_WINDOW_SHARES as u32);
         let coinbase_outpoints = chain_store_handle

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -1064,8 +1064,9 @@ impl DefaultShareValidator {
         }
         let tip_height = chain_store_handle
             .get_tip_height()
-            .ok()
-            .flatten()
+            .map_err(|error| {
+                ValidationError::new(format!("Failed to get tip height: {error}"))
+            })?
             .unwrap_or(0);
         let min_coinbase_root_height = tip_height.saturating_sub(MAX_PPLNS_WINDOW_SHARES as u32);
         let coinbase_outpoints = chain_store_handle

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -1062,13 +1062,15 @@ impl DefaultShareValidator {
         {
             return Err(ValidationError::new("prevout not on confirmed chain"));
         }
+        let tip_height = chain_store_handle
+            .get_tip_height()
+            .ok()
+            .flatten()
+            .unwrap_or(0);
+        let min_coinbase_root_height = tip_height.saturating_sub(MAX_PPLNS_WINDOW_SHARES as u32);
         let coinbase_outpoints = chain_store_handle
-            .check_prevouts_and_find_coinbase(&all_outpoints)
-            .map_err(|error| {
-                ValidationError::new(format!(
-                    "One or more prevouts do not exist in the Outputs store: {error}"
-                ))
-            })?;
+            .check_prevouts_and_find_coinbase(&all_outpoints, min_coinbase_root_height)
+            .map_err(|error| ValidationError::new(format!("Prevout check failed: {error}")))?;
         if chain_store_handle
             .is_any_prevout_spent(&all_outpoints)
             .map_err(|error| {
@@ -2195,11 +2197,14 @@ mod tests {
     fn test_validate_prevouts_exist_succeeds_for_coinbase_only() {
         let mut chain_store_handle = ChainStoreHandle::default();
         chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(100)));
+        chain_store_handle
             .expect_are_all_txids_confirmed()
             .returning(|_txids| Ok(true));
         chain_store_handle
             .expect_check_prevouts_and_find_coinbase()
-            .returning(|_outpoints| Ok(Vec::new()));
+            .returning(|_outpoints, _min_coinbase_root_height| Ok(Vec::new()));
         chain_store_handle
             .expect_is_any_prevout_spent()
             .returning(|_outpoints| Ok(false));
@@ -2216,11 +2221,14 @@ mod tests {
         let (_spent_output, spending_tx) = build_p2sh_op_true_spent_output_and_spending_tx();
 
         chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(100)));
+        chain_store_handle
             .expect_are_all_txids_confirmed()
             .returning(|_txids| Ok(true));
         chain_store_handle
             .expect_check_prevouts_and_find_coinbase()
-            .returning(|_outpoints| Ok(Vec::new()));
+            .returning(|_outpoints, _min_coinbase_root_height| Ok(Vec::new()));
         chain_store_handle
             .expect_is_any_prevout_spent()
             .returning(|_outpoints| Ok(false));
@@ -2239,6 +2247,9 @@ mod tests {
         let mut chain_store_handle = ChainStoreHandle::default();
         let (_spent_output, spending_tx) = build_p2sh_op_true_spent_output_and_spending_tx();
 
+        chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(100)));
         chain_store_handle
             .expect_are_all_txids_confirmed()
             .returning(|_txids| Ok(false));
@@ -2263,11 +2274,16 @@ mod tests {
         let (_spent_output, spending_tx) = build_p2sh_op_true_spent_output_and_spending_tx();
 
         chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(100)));
+        chain_store_handle
             .expect_are_all_txids_confirmed()
             .returning(|_txids| Ok(true));
         chain_store_handle
             .expect_check_prevouts_and_find_coinbase()
-            .returning(|_outpoints| Err(StoreError::NotFound("Output not found".to_string())));
+            .returning(|_outpoints, _min_coinbase_root_height| {
+                Err(StoreError::NotFound("Output not found".to_string()))
+            });
 
         let share = TestShareBlockBuilder::new()
             .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
@@ -2277,7 +2293,10 @@ mod tests {
         let error = validator()
             .validate_prevouts(&share, &chain_store_handle)
             .unwrap_err();
-        assert!(error.to_string().contains("do not exist"), "got: {error}");
+        assert!(
+            error.to_string().contains("Prevout check failed"),
+            "got: {error}"
+        );
     }
 
     #[test]
@@ -2286,11 +2305,14 @@ mod tests {
         let (_spent_output, spending_tx) = build_p2sh_op_true_spent_output_and_spending_tx();
 
         chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(100)));
+        chain_store_handle
             .expect_are_all_txids_confirmed()
             .returning(|_txids| Ok(true));
         chain_store_handle
             .expect_check_prevouts_and_find_coinbase()
-            .returning(|_outpoints| Ok(Vec::new()));
+            .returning(|_outpoints, _min_coinbase_root_height| Ok(Vec::new()));
         chain_store_handle
             .expect_is_any_prevout_spent()
             .returning(|_outpoints| Ok(true));
@@ -2309,6 +2331,9 @@ mod tests {
     #[test]
     fn test_validate_prevouts_exist_skips_in_block_source_tx() {
         let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(100)));
 
         let producing_tx = bitcoin::Transaction {
             version: bitcoin::transaction::Version::ONE,
@@ -2359,7 +2384,7 @@ mod tests {
             .returning(|_txids| Ok(true));
         chain_store_handle
             .expect_check_prevouts_and_find_coinbase()
-            .withf(move |outpoints| {
+            .withf(move |outpoints, _min_coinbase_root_height| {
                 outpoints.len() == 2
                     && outpoints
                         .iter()
@@ -2368,7 +2393,7 @@ mod tests {
                         .iter()
                         .any(|outpoint| outpoint.txid == producing_txid_for_check)
             })
-            .returning(|_outpoints| Ok(Vec::new()));
+            .returning(|_outpoints, _min_coinbase_root_height| Ok(Vec::new()));
         chain_store_handle
             .expect_is_any_prevout_spent()
             .withf(move |outpoints| outpoints.len() == 2)
@@ -2387,6 +2412,9 @@ mod tests {
     #[test]
     fn test_validate_prevouts_fails_when_in_block_spend_references_missing_vout() {
         let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(100)));
 
         let producing_tx = bitcoin::Transaction {
             version: bitcoin::transaction::Version::ONE,
@@ -2435,7 +2463,9 @@ mod tests {
         // a non-existent vout.
         chain_store_handle
             .expect_check_prevouts_and_find_coinbase()
-            .returning(|_outpoints| Err(StoreError::NotFound("Output not found".to_string())));
+            .returning(|_outpoints, _min_coinbase_root_height| {
+                Err(StoreError::NotFound("Output not found".to_string()))
+            });
 
         let share = TestShareBlockBuilder::new()
             .miner_pubkey("020202020202020202020202020202020202020202020202020202020202020202")
@@ -2446,12 +2476,18 @@ mod tests {
         let error = validator()
             .validate_prevouts(&share, &chain_store_handle)
             .unwrap_err();
-        assert!(error.to_string().contains("do not exist"), "got: {error}");
+        assert!(
+            error.to_string().contains("Prevout check failed"),
+            "got: {error}"
+        );
     }
 
     #[test]
     fn test_validate_prevouts_fails_when_two_inputs_spend_same_prevout() {
-        let chain_store_handle = ChainStoreHandle::default();
+        let mut chain_store_handle = ChainStoreHandle::default();
+        chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(100)));
 
         let shared_prevout = bitcoin::OutPoint {
             txid: bitcoin::Txid::all_zeros(),
@@ -2508,13 +2544,16 @@ mod tests {
     fn test_validate_prevouts_rejects_immature_coinbase_spend() {
         let mut chain_store_handle = ChainStoreHandle::default();
         chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(100)));
+        chain_store_handle
             .expect_are_all_txids_confirmed()
             .returning(|_txids| Ok(true));
 
         let coinbase_outpoint = bitcoin::OutPoint::new(bitcoin::Txid::all_zeros(), 0);
         chain_store_handle
             .expect_check_prevouts_and_find_coinbase()
-            .returning(move |_outpoints| Ok(vec![coinbase_outpoint]));
+            .returning(move |_outpoints, _min_coinbase_root_height| Ok(vec![coinbase_outpoint]));
         chain_store_handle
             .expect_is_any_prevout_spent()
             .returning(|_outpoints| Ok(false));
@@ -2552,13 +2591,16 @@ mod tests {
     fn test_validate_prevouts_accepts_mature_coinbase_spend() {
         let mut chain_store_handle = ChainStoreHandle::default();
         chain_store_handle
+            .expect_get_tip_height()
+            .returning(|| Ok(Some(100)));
+        chain_store_handle
             .expect_are_all_txids_confirmed()
             .returning(|_txids| Ok(true));
 
         let coinbase_outpoint = bitcoin::OutPoint::new(bitcoin::Txid::all_zeros(), 0);
         chain_store_handle
             .expect_check_prevouts_and_find_coinbase()
-            .returning(move |_outpoints| Ok(vec![coinbase_outpoint]));
+            .returning(move |_outpoints, _min_coinbase_root_height| Ok(vec![coinbase_outpoint]));
         chain_store_handle
             .expect_is_any_prevout_spent()
             .returning(|_outpoints| Ok(false));

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -694,8 +694,11 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
 
-        // Create initial share
+        // Create initial share (genesis)
         let share1 = TestShareBlockBuilder::new().build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&share1, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
 
         // Create uncles for share2
         let uncle1_share2 = TestShareBlockBuilder::new()
@@ -719,24 +722,14 @@ mod tests {
             .prev_share_blockhash(share2.block_hash().to_string())
             .build();
 
-        let mut batch = rocksdb::WriteBatch::default();
-        // Add all shares to store
-        store.add_share_block(&share1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
-
-        let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&uncle1_share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
-
-        let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&uncle2_share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
-
-        let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&share2, &mut batch).unwrap();
+        // Add all shares to store with valid metadata
+        store.store_with_valid_metadata(&uncle1_share2);
+        store.store_with_valid_metadata(&uncle2_share2);
+        store.store_with_valid_metadata(&share2);
         // Uncle block index updates are handled by organise_header, not
-        // add_share_block. Manually register uncle->nephew entries here
+        // store_with_valid_metadata. Manually register uncle->nephew entries here
         // since this test exercises the block index directly.
+        let mut batch = Store::get_write_batch();
         for uncle_blockhash in &share2.header.uncles {
             store
                 .update_block_index(uncle_blockhash, &share2.block_hash(), &mut batch)
@@ -744,10 +737,7 @@ mod tests {
         }
         store.commit_batch(batch).unwrap();
 
-        let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&share3, &mut batch).unwrap();
-
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share3);
 
         // Verify children of share1
         let children_share1 = store
@@ -793,8 +783,11 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
 
-        // Create initial share
+        // Create initial share (genesis)
         let share1 = TestShareBlockBuilder::new().build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&share1, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
 
         // Create uncles for share2
         let uncle1_share2 = TestShareBlockBuilder::new()
@@ -818,24 +811,11 @@ mod tests {
             .prev_share_blockhash(share2.block_hash().to_string())
             .build();
 
-        let mut batch = rocksdb::WriteBatch::default();
-        // Add all shares to store
-        store.add_share_block(&share1, &mut batch).unwrap();
-        store.add_share_block(&uncle1_share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
-
-        let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&uncle2_share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
-
-        let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
-
-        let mut batch = rocksdb::WriteBatch::default();
-        store.add_share_block(&share3, &mut batch).unwrap();
-
-        store.commit_batch(batch).unwrap();
+        // Add all shares to store with valid metadata
+        store.store_with_valid_metadata(&uncle1_share2);
+        store.store_with_valid_metadata(&uncle2_share2);
+        store.store_with_valid_metadata(&share2);
+        store.store_with_valid_metadata(&share3);
 
         // Verify descendants of share1
         let descendants_share1 = store
@@ -1858,9 +1838,7 @@ mod tests {
                 .nonce(0xe9695791 + i)
                 .build();
 
-            let mut batch = Store::get_write_batch();
-            store.add_share_block(&share, &mut batch).unwrap();
-            store.commit_batch(batch).unwrap();
+            store.store_with_valid_metadata(&share);
 
             blocks.push(share.block_hash());
             prev_hash = share.block_hash();
@@ -1908,25 +1886,19 @@ mod tests {
             .prev_share_blockhash(genesis.block_hash().to_string())
             .nonce(0xe9695792)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share1);
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(0xe9695793)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share2);
 
         let share3 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .nonce(0xe9695794)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share3);
 
         // Test common ancestor of share3 and share2
         let ancestor = store
@@ -1973,25 +1945,19 @@ mod tests {
             .prev_share_blockhash(genesis.block_hash().to_string())
             .nonce(0xe9695792)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share1);
 
         let uncle1 = TestShareBlockBuilder::new()
             .prev_share_blockhash(genesis.block_hash().to_string())
             .nonce(0xe9695793)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle1);
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(0xe9695794)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share2);
 
         // Test common ancestor of share2 and uncle1 (should be genesis)
         let ancestor = store
@@ -2067,26 +2033,20 @@ mod tests {
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(100)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle1);
 
         // Create share2 - sibling of uncle1
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share2);
 
         // Create share3 with uncle1 as uncle (uncle1 is sibling of share3's parent)
         let share3 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .uncles(vec![uncle1.block_hash()])
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share3);
 
         // Get DAG from share3 with depth 10 (more than enough to include all blocks)
         let chain = store.get_dag_for_depth(&share3.block_hash(), 10).unwrap();
@@ -2134,32 +2094,24 @@ mod tests {
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(100)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle1);
 
         let uncle2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(200)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle2);
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share2);
 
         let share3 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .uncles(vec![uncle1.block_hash(), uncle2.block_hash()])
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share3);
 
         let chain = store.get_dag_for_depth(&share3.block_hash(), 10).unwrap();
 
@@ -2208,43 +2160,33 @@ mod tests {
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(100)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle1);
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share2);
 
         // uncle2 is sibling of share3
         let uncle2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .nonce(200)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle2);
 
         // share3 has uncle1 as uncle (sibling of its parent share2)
         let share3 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .uncles(vec![uncle1.block_hash()])
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share3);
 
         // share4 has uncle2 as uncle (sibling of its parent share3)
         let share4 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share3.block_hash().to_string())
             .uncles(vec![uncle2.block_hash()])
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share4, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share4);
 
         let chain = store.get_dag_for_depth(&share4.block_hash(), 10).unwrap();
 
@@ -2295,24 +2237,18 @@ mod tests {
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(100)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle1);
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share2);
 
         let share3 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .uncles(vec![uncle1.block_hash()])
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share3);
 
         // With depth=2, we should get exactly 2 main chain blocks + uncles
         let chain = store.get_dag_for_depth(&share3.block_hash(), 2).unwrap();
@@ -2375,39 +2311,29 @@ mod tests {
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(100)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle1);
 
         let uncle2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(200)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle2);
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share2);
 
         let share3 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .uncles(vec![uncle1.block_hash(), uncle2.block_hash()])
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share3);
 
         let share4 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share3.block_hash().to_string())
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share4, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share4);
 
         // With depth=2, we should get share4, share3 (main chain) + uncle1, uncle2
         let chain = store.get_dag_for_depth(&share4.block_hash(), 2).unwrap();
@@ -2460,40 +2386,30 @@ mod tests {
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(100)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle1);
 
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share2);
 
         let uncle2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .nonce(200)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle2);
 
         let share3 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .uncles(vec![uncle1.block_hash()])
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share3);
 
         let share4 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share3.block_hash().to_string())
             .uncles(vec![uncle2.block_hash()])
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share4, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share4);
 
         // With depth=3, we should get share4, share3, share2 (main chain) + uncle2, uncle1
         let chain = store.get_dag_for_depth(&share4.block_hash(), 3).unwrap();
@@ -2535,30 +2451,22 @@ mod tests {
         let share2 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share1.block_hash().to_string())
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share2);
 
         let share3 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share3);
 
         let share4 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share3.block_hash().to_string())
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share4, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share4);
 
         let share5 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share4.block_hash().to_string())
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share5, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share5);
 
         // With depth=3, should get exactly 3 main chain blocks
         let chain = store.get_dag_for_depth(&share5.block_hash(), 3).unwrap();

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -398,7 +398,9 @@ impl Store {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shares::share_block::ShareTransaction;
     use crate::test_utils::TestShareBlockBuilder;
+    use bitcoin::hashes::Hash;
     use tempfile::tempdir;
 
     // ── append_to_confirmed tests ─────────────────────────────────────────
@@ -1727,8 +1729,6 @@ mod tests {
     /// it out removes them, re-confirming a replacement re-adds them.
     #[test]
     fn test_spends_index_follows_confirmation_state() {
-        use bitcoin::hashes::Hash;
-
         let temp_dir = tempdir().unwrap();
         let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
 
@@ -1737,12 +1737,30 @@ mod tests {
         store.setup_genesis(&genesis, &mut batch).unwrap();
         store.commit_batch(batch).unwrap();
 
-        // Build a spending tx whose prevout points at a fabricated
-        // outpoint. SpendsIndex doesn't care whether the prevout
-        // actually exists as an output — it only records the spend.
-        let fabricated_prevout_txid: bitcoin::Txid =
-            bitcoin::hashes::sha256d::Hash::from_byte_array([0xaa; 32]).into();
-        let prevout = bitcoin::OutPoint::new(fabricated_prevout_txid, 0);
+        // Build a funding coinbase tx and store it so its output exists
+        // in the Outputs CF for coinbase_root_height computation.
+        let funding_tx = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::ONE,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(bitcoin::Txid::all_zeros(), u32::MAX),
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(1_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let funding_txid = funding_tx.compute_txid();
+        let mut batch = Store::get_write_batch();
+        store
+            .add_sharechain_txs(&[ShareTransaction(funding_tx)], 0, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let prevout = bitcoin::OutPoint::new(funding_txid, 0);
         let spending_tx = bitcoin::Transaction {
             version: bitcoin::transaction::Version::ONE,
             lock_time: bitcoin::absolute::LockTime::ZERO,

--- a/p2poolv2_lib/src/store/organise/mod.rs
+++ b/p2poolv2_lib/src/store/organise/mod.rs
@@ -182,18 +182,14 @@ mod tests {
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(0xe9695793)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share2);
 
         // share3 extends share2 and is NOT on candidate chain
         let share3 = TestShareBlockBuilder::new()
             .prev_share_blockhash(share2.block_hash().to_string())
             .nonce(0xe9695794)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share3, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share3);
 
         // Branch from share3 should be [share1, share2, share3]
         let branch = store
@@ -227,9 +223,7 @@ mod tests {
             .prev_share_blockhash(share1.block_hash().to_string())
             .nonce(0xe9695793)
             .build();
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share2);
 
         // Branch from share2 should be just [share1, share2]
         let branch = store

--- a/p2poolv2_lib/src/store/share_store.rs
+++ b/p2poolv2_lib/src/store/share_store.rs
@@ -22,6 +22,7 @@ use crate::shares::share_block::{
 use bitcoin::BlockHash;
 use bitcoin::TxMerkleNode;
 use bitcoin::consensus::{self, Encodable, encode};
+use bitcoin::hashes::Hash;
 use std::collections::{HashMap, HashSet};
 use tracing::debug;
 
@@ -53,13 +54,8 @@ impl Store {
             share.header.get_work()
         );
 
-        // Compute block height from parent metadata for coinbase_root_height
-        let block_height = self
-            .get_block_metadata(&share.header.prev_share_blockhash)
-            .ok()
-            .and_then(|metadata| metadata.expected_height)
-            .map(|parent_height| parent_height + 1)
-            .unwrap_or(0);
+        let block_height =
+            self.compute_block_height_from_parent(&share.header.prev_share_blockhash)?;
 
         // Store transactions and get their metadata
         let txs_metadata = self.add_sharechain_txs(&share.transactions, block_height, batch)?;
@@ -87,6 +83,34 @@ impl Store {
         self.add_share_header(&share.header, batch)?;
 
         Ok(())
+    }
+
+    /// Compute the block height from the parent's metadata.
+    ///
+    /// Genesis (parent all-zeros) has height 0. For all other blocks,
+    /// returns an error if parent metadata is missing to avoid
+    /// permanently persisting height 0 which would make outputs
+    /// unspendable once the chain tip advances.
+    fn compute_block_height_from_parent(
+        &self,
+        parent_blockhash: &BlockHash,
+    ) -> Result<u32, StoreError> {
+        if *parent_blockhash == BlockHash::all_zeros() {
+            return Ok(0);
+        }
+        let parent_metadata = self.get_block_metadata(parent_blockhash).map_err(|error| {
+            StoreError::NotFound(format!(
+                "Parent {parent_blockhash} metadata not found for coinbase_root_height: {error}",
+            ))
+        })?;
+        parent_metadata
+            .expected_height
+            .map(|height| height + 1)
+            .ok_or_else(|| {
+                StoreError::NotFound(format!(
+                    "Parent {parent_blockhash} has no expected_height for coinbase_root_height",
+                ))
+            })
     }
 
     /// Store a share header in the dedicated Header column family.
@@ -615,20 +639,14 @@ mod tests {
             .prev_share_blockhash(genesis_block.block_hash().to_string())
             .nonce(0xe9695792)
             .build();
-
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&share1);
 
         // Create uncle (also child of genesis)
         let uncle1 = TestShareBlockBuilder::new()
             .prev_share_blockhash(genesis_block.block_hash().to_string())
             .nonce(0xe9695793) // Different nonce to get different hash
             .build();
-
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&uncle1, &mut batch).unwrap();
-        store.commit_batch(batch).unwrap();
+        store.store_with_valid_metadata(&uncle1);
 
         // Create share2 referencing uncle1
         let share2 = TestShareBlockBuilder::new()
@@ -636,11 +654,10 @@ mod tests {
             .uncles(vec![uncle1.block_hash()])
             .nonce(0xe9695794)
             .build();
-
-        let mut batch = Store::get_write_batch();
-        store.add_share_block(&share2, &mut batch).unwrap();
+        store.store_with_valid_metadata(&share2);
         // Uncle block index updates are handled by organise_header, not
-        // add_share_block. Manually register uncle->nephew entries here.
+        // store_with_valid_metadata. Manually register uncle->nephew entries here.
+        let mut batch = Store::get_write_batch();
         for uncle_blockhash in &share2.header.uncles {
             store
                 .update_block_index(uncle_blockhash, &share2.block_hash(), &mut batch)

--- a/p2poolv2_lib/src/store/share_store.rs
+++ b/p2poolv2_lib/src/store/share_store.rs
@@ -53,8 +53,16 @@ impl Store {
             share.header.get_work()
         );
 
+        // Compute block height from parent metadata for coinbase_root_height
+        let block_height = self
+            .get_block_metadata(&share.header.prev_share_blockhash)
+            .ok()
+            .and_then(|metadata| metadata.expected_height)
+            .map(|parent_height| parent_height + 1)
+            .unwrap_or(0);
+
         // Store transactions and get their metadata
-        let txs_metadata = self.add_sharechain_txs(&share.transactions, batch)?;
+        let txs_metadata = self.add_sharechain_txs(&share.transactions, block_height, batch)?;
 
         let txids = Txids(txs_metadata.iter().map(|t| t.txid).collect());
         // Store block -> txids index

--- a/p2poolv2_lib/src/store/transaction_store.rs
+++ b/p2poolv2_lib/src/store/transaction_store.rs
@@ -27,11 +27,19 @@ use tracing::debug;
 const OUTPOINT_SIZE: usize = 36;
 
 /// A TxOut stored in the Outputs CF together with a flag indicating
-/// whether it belongs to a coinbase transaction.
+/// whether it belongs to a coinbase transaction and the height of the
+/// oldest coinbase ancestor in the output's spending chain.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct StoredTxOut {
     pub tx_out: bitcoin::TxOut,
     pub is_coinbase: bool,
+    /// Height of the oldest coinbase in this output's ancestry chain.
+    /// For coinbase outputs, this is the block height where the coinbase
+    /// was mined. For spending tx outputs, this is the minimum
+    /// coinbase_root_height across all inputs. Used to enforce the rule
+    /// that outputs whose coinbase root is deeper than PPLNS_DEPTH from
+    /// tip cannot be spent.
+    pub coinbase_root_height: u32,
 }
 
 impl Encodable for StoredTxOut {
@@ -41,6 +49,7 @@ impl Encodable for StoredTxOut {
     ) -> Result<usize, bitcoin::io::Error> {
         let mut length = self.tx_out.consensus_encode(writer)?;
         length += self.is_coinbase.consensus_encode(writer)?;
+        length += self.coinbase_root_height.consensus_encode(writer)?;
         Ok(length)
     }
 }
@@ -51,9 +60,11 @@ impl Decodable for StoredTxOut {
     ) -> Result<Self, bitcoin::consensus::encode::Error> {
         let tx_out = bitcoin::TxOut::consensus_decode(reader)?;
         let is_coinbase = bool::consensus_decode(reader)?;
+        let coinbase_root_height = u32::consensus_decode(reader)?;
         Ok(StoredTxOut {
             tx_out,
             is_coinbase,
+            coinbase_root_height,
         })
     }
 }
@@ -318,16 +329,21 @@ impl Store {
     ///
     /// Writes transaction metadata, each input, and each output into
     /// their respective column families. This function is pure tx
-    /// storage and does not touch the `SpendsIndex` — chain-state
+    /// storage and does not touch the `SpendsIndex` -- chain-state
     /// bookkeeping of spends is the responsibility of the confirmation
     /// path (`put_confirmed_entry` / `remove_spends_for_block`).
     ///
     /// The block -> txids association is stored separately via
     /// `add_txids_to_blocks_index`, allowing this function to persist
     /// transactions outside of a block context.
+    ///
+    /// `block_height` is used to set `coinbase_root_height` on outputs:
+    /// coinbase outputs get the block height directly, spending tx
+    /// outputs get the minimum coinbase_root_height across their inputs.
     pub(crate) fn add_sharechain_txs(
         &self,
         transactions: &[ShareTransaction],
+        block_height: u32,
         batch: &mut rocksdb::WriteBatch,
     ) -> Result<Vec<TxMetadata>, StoreError> {
         let inputs_cf = self.db.cf_handle(&ColumnFamily::Inputs).unwrap();
@@ -348,17 +364,51 @@ impl Store {
             }
 
             let is_coinbase = tx.0.is_coinbase();
+            let coinbase_root_height = if is_coinbase {
+                block_height
+            } else {
+                self.min_coinbase_root_height_for_inputs(tx, &outputs_cf)
+            };
+
             for (i, output) in tx.output.iter().enumerate() {
                 let output_key = format!("{txid}:{i}");
                 let stored = StoredTxOut {
                     tx_out: output.clone(),
                     is_coinbase,
+                    coinbase_root_height,
                 };
                 let serialized = consensus::serialize(&stored);
                 batch.put_cf::<&[u8], Vec<u8>>(&outputs_cf, output_key.as_ref(), serialized);
             }
         }
         Ok(txs_metadata)
+    }
+
+    /// Compute the minimum coinbase_root_height across all inputs of a
+    /// non-coinbase transaction by reading each input's output from the
+    /// Outputs CF.
+    fn min_coinbase_root_height_for_inputs(
+        &self,
+        tx: &ShareTransaction,
+        outputs_cf: &impl rocksdb::AsColumnFamilyRef,
+    ) -> u32 {
+        let mut min_height = u32::MAX;
+        for input in &tx.0.input {
+            let outpoint_key = format!(
+                "{}:{}",
+                input.previous_output.txid, input.previous_output.vout
+            );
+            if let Ok(Some(bytes)) = self.db.get_cf(outputs_cf, outpoint_key.as_bytes()) {
+                if let Ok(stored_out) = consensus::deserialize::<StoredTxOut>(&bytes) {
+                    min_height = std::cmp::min(min_height, stored_out.coinbase_root_height);
+                }
+            }
+        }
+        if min_height == u32::MAX {
+            0
+        } else {
+            min_height
+        }
     }
 
     /// Marks the transaction as successfully validated, this prevents us validating it again.
@@ -910,7 +960,7 @@ mod tests {
         let mut batch = Store::get_write_batch();
 
         let metadata = store
-            .add_sharechain_txs(&block.transactions, &mut batch)
+            .add_sharechain_txs(&block.transactions, 1, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -988,6 +1038,7 @@ mod tests {
                     ShareTransaction(tx_a.clone()),
                     ShareTransaction(tx_b.clone()),
                 ],
+                1,
                 &mut batch,
             )
             .unwrap();
@@ -1040,7 +1091,7 @@ mod tests {
 
         let mut batch = Store::get_write_batch();
         store
-            .add_sharechain_txs(&[ShareTransaction(funding_tx)], &mut batch)
+            .add_sharechain_txs(&[ShareTransaction(funding_tx)], 1, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -1123,7 +1174,7 @@ mod tests {
 
         let mut batch = Store::get_write_batch();
         store
-            .add_sharechain_txs(&[ShareTransaction(funding_tx)], &mut batch)
+            .add_sharechain_txs(&[ShareTransaction(funding_tx)], 1, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -1153,7 +1204,7 @@ mod tests {
 
         let mut batch = Store::get_write_batch();
         store
-            .add_sharechain_txs(&[ShareTransaction(funding_tx)], &mut batch)
+            .add_sharechain_txs(&[ShareTransaction(funding_tx)], 1, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -1203,6 +1254,7 @@ mod tests {
         store
             .add_sharechain_txs(
                 &[ShareTransaction(coinbase_tx), ShareTransaction(regular_tx)],
+                1,
                 &mut batch,
             )
             .unwrap();
@@ -1403,7 +1455,7 @@ mod tests {
         let txid = tx.compute_txid();
         let mut batch = Store::get_write_batch();
         store
-            .add_sharechain_txs(&[ShareTransaction(tx)], &mut batch)
+            .add_sharechain_txs(&[ShareTransaction(tx)], 1, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -1673,7 +1725,9 @@ mod tests {
 
         // Add transactions to store
         let mut batch = rocksdb::WriteBatch::default();
-        store.add_sharechain_txs(&transactions, &mut batch).unwrap();
+        store
+            .add_sharechain_txs(&transactions, 1, &mut batch)
+            .unwrap();
         store.db.write(batch).unwrap();
 
         // Verify transactions were stored correctly by retrieving them by txid
@@ -1715,7 +1769,7 @@ mod tests {
         let txid = tx.compute_txid();
         let mut batch = rocksdb::WriteBatch::default();
         let res = store
-            .add_sharechain_txs(&[ShareTransaction(tx.clone())], &mut batch)
+            .add_sharechain_txs(&[ShareTransaction(tx.clone())], 1, &mut batch)
             .unwrap();
         store.db.write(batch).unwrap();
 
@@ -2169,5 +2223,169 @@ mod tests {
             .find_immature_coinbase_prevout(&outpoints, 6048, 10000)
             .unwrap();
         assert_eq!(result, Some(bitcoin::OutPoint::new(immature_txid, 0)));
+    }
+
+    #[test]
+    fn test_min_coinbase_root_height_returns_min_across_inputs() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        // Store two funding coinbase txs at different heights
+        let funding_tx_a = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::null(),
+                ..Default::default()
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(1_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let txid_a = funding_tx_a.compute_txid();
+
+        let funding_tx_b = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::null(),
+                script_sig: bitcoin::ScriptBuf::from_bytes(vec![0x01]),
+                ..Default::default()
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(2_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let txid_b = funding_tx_b.compute_txid();
+
+        // Store at heights 100 and 500
+        let mut batch = Store::get_write_batch();
+        store
+            .add_sharechain_txs(&[ShareTransaction(funding_tx_a)], 100, &mut batch)
+            .unwrap();
+        store
+            .add_sharechain_txs(&[ShareTransaction(funding_tx_b)], 500, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Spending tx consumes one output from each funding tx
+        let spending_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![
+                bitcoin::TxIn {
+                    previous_output: bitcoin::OutPoint::new(txid_a, 0),
+                    ..Default::default()
+                },
+                bitcoin::TxIn {
+                    previous_output: bitcoin::OutPoint::new(txid_b, 0),
+                    ..Default::default()
+                },
+            ],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(2_900_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+
+        let outputs_cf = store.db.cf_handle(&ColumnFamily::Outputs).unwrap();
+        let result =
+            store.min_coinbase_root_height_for_inputs(&ShareTransaction(spending_tx), &outputs_cf);
+
+        assert_eq!(
+            result, 100,
+            "Should return the minimum height across inputs"
+        );
+    }
+
+    #[test]
+    fn test_min_coinbase_root_height_returns_zero_when_no_inputs_found() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        // Spending tx references outputs not in the store
+        let spending_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(Txid::all_zeros(), 0),
+                ..Default::default()
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(1_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+
+        let outputs_cf = store.db.cf_handle(&ColumnFamily::Outputs).unwrap();
+        let result =
+            store.min_coinbase_root_height_for_inputs(&ShareTransaction(spending_tx), &outputs_cf);
+
+        assert_eq!(result, 0, "Should return 0 when no inputs found in store");
+    }
+
+    #[test]
+    fn test_coinbase_root_height_propagates_through_spending_chain() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        // Store a coinbase tx at height 200
+        let coinbase_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::null(),
+                ..Default::default()
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(5_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let coinbase_txid = coinbase_tx.compute_txid();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .add_sharechain_txs(&[ShareTransaction(coinbase_tx)], 200, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Store a spending tx at height 300 that spends the coinbase
+        let spending_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(coinbase_txid, 0),
+                ..Default::default()
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(4_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let spending_txid = spending_tx.compute_txid();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .add_sharechain_txs(&[ShareTransaction(spending_tx)], 300, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Verify the spending tx's output inherited coinbase_root_height = 200
+        let output_key = format!("{spending_txid}:0");
+        let outputs_cf = store.db.cf_handle(&ColumnFamily::Outputs).unwrap();
+        let bytes = store
+            .db
+            .get_cf(&outputs_cf, output_key.as_bytes())
+            .unwrap()
+            .unwrap();
+        let stored_out = consensus::deserialize::<StoredTxOut>(&bytes).unwrap();
+
+        assert_eq!(
+            stored_out.coinbase_root_height, 200,
+            "Spending tx output should inherit coinbase_root_height from input"
+        );
     }
 }

--- a/p2poolv2_lib/src/store/transaction_store.rs
+++ b/p2poolv2_lib/src/store/transaction_store.rs
@@ -2591,7 +2591,7 @@ mod tests {
     }
 
     #[test]
-    fn test_min_coinbase_root_height_returns_zero_when_no_inputs_found() {
+    fn test_min_coinbase_root_height_errors_when_input_outputs_missing() {
         let temp_dir = tempdir().unwrap();
         let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
 

--- a/p2poolv2_lib/src/store/transaction_store.rs
+++ b/p2poolv2_lib/src/store/transaction_store.rs
@@ -379,7 +379,7 @@ impl Store {
             let coinbase_root_height = if is_coinbase {
                 block_height
             } else {
-                self.min_coinbase_root_height_for_inputs(tx, &outputs_cf)
+                self.min_coinbase_root_height_for_inputs(tx, &outputs_cf)?
             };
 
             for (i, output) in tx.output.iter().enumerate() {
@@ -398,29 +398,38 @@ impl Store {
 
     /// Compute the minimum coinbase_root_height across all inputs of a
     /// non-coinbase transaction by reading each input's output from the
-    /// Outputs CF.
+    /// Outputs CF. Returns an error if any input's output is missing or
+    /// cannot be deserialized, to avoid permanently persisting height 0
+    /// which would make outputs unspendable.
     fn min_coinbase_root_height_for_inputs(
         &self,
         tx: &ShareTransaction,
         outputs_cf: &impl rocksdb::AsColumnFamilyRef,
-    ) -> u32 {
+    ) -> Result<u32, StoreError> {
         let mut min_height = u32::MAX;
         for input in &tx.0.input {
             let outpoint_key = format!(
                 "{}:{}",
                 input.previous_output.txid, input.previous_output.vout
             );
-            if let Ok(Some(bytes)) = self.db.get_cf(outputs_cf, outpoint_key.as_bytes()) {
-                if let Ok(stored_out) = consensus::deserialize::<StoredTxOut>(&bytes) {
-                    min_height = std::cmp::min(min_height, stored_out.coinbase_root_height);
-                }
-            }
+            let bytes = self
+                .db
+                .get_cf(outputs_cf, outpoint_key.as_bytes())?
+                .ok_or_else(|| {
+                    StoreError::NotFound(format!(
+                        "Input output not found for coinbase_root_height: {}",
+                        outpoint_key
+                    ))
+                })?;
+            let stored_out: StoredTxOut = consensus::deserialize(&bytes).map_err(|_| {
+                StoreError::Serialization(format!(
+                    "Failed to deserialize output for coinbase_root_height: {}",
+                    outpoint_key
+                ))
+            })?;
+            min_height = std::cmp::min(min_height, stored_out.coinbase_root_height);
         }
-        if min_height == u32::MAX {
-            0
-        } else {
-            min_height
-        }
+        Ok(min_height)
     }
 
     /// Marks the transaction as successfully validated, this prevents us validating it again.
@@ -995,14 +1004,83 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
 
+        // Store three funding coinbase transactions so that spending inputs
+        // can find their outputs in the Outputs CF.
+        let funding_coinbase_input = bitcoin::TxIn {
+            previous_output: bitcoin::OutPoint::new(bitcoin::Txid::all_zeros(), u32::MAX),
+            sequence: bitcoin::Sequence::default(),
+            witness: bitcoin::Witness::default(),
+            script_sig: bitcoin::ScriptBuf::new(),
+        };
+        let funding_tx_1 = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![funding_coinbase_input.clone()],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(1_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let funding_txid_1 = funding_tx_1.compute_txid();
+
+        // funding_tx_2 needs at least 6 outputs (index 5 is used by tx_b)
+        let funding_tx_2 = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(bitcoin::Txid::all_zeros(), u32::MAX),
+                sequence: bitcoin::Sequence(1),
+                witness: bitcoin::Witness::default(),
+                script_sig: bitcoin::ScriptBuf::new(),
+            }],
+            output: vec![
+                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
+                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
+                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
+                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
+                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
+                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
+            ],
+        };
+        let funding_txid_2 = funding_tx_2.compute_txid();
+
+        // funding_tx_3 needs at least 2 outputs (index 1 is used by tx_b)
+        let funding_tx_3 = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(bitcoin::Txid::all_zeros(), u32::MAX),
+                sequence: bitcoin::Sequence(2),
+                witness: bitcoin::Witness::default(),
+                script_sig: bitcoin::ScriptBuf::new(),
+            }],
+            output: vec![
+                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
+                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
+            ],
+        };
+        let funding_txid_3 = funding_tx_3.compute_txid();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .add_sharechain_txs(
+                &[
+                    ShareTransaction(funding_tx_1),
+                    ShareTransaction(funding_tx_2),
+                    ShareTransaction(funding_tx_3),
+                ],
+                1,
+                &mut batch,
+            )
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Now create spending transactions that reference the funding outputs.
         let tx_a = Transaction {
             version: bitcoin::transaction::Version(1),
             lock_time: bitcoin::absolute::LockTime::ZERO,
             input: vec![bitcoin::TxIn {
-                previous_output: bitcoin::OutPoint::new(
-                    bitcoin::hashes::sha256d::Hash::from_byte_array([0x01; 32]).into(),
-                    0,
-                ),
+                previous_output: bitcoin::OutPoint::new(funding_txid_1, 0),
                 ..Default::default()
             }],
             output: vec![
@@ -1021,17 +1099,11 @@ mod tests {
             lock_time: bitcoin::absolute::LockTime::ZERO,
             input: vec![
                 bitcoin::TxIn {
-                    previous_output: bitcoin::OutPoint::new(
-                        bitcoin::hashes::sha256d::Hash::from_byte_array([0x02; 32]).into(),
-                        5,
-                    ),
+                    previous_output: bitcoin::OutPoint::new(funding_txid_2, 5),
                     ..Default::default()
                 },
                 bitcoin::TxIn {
-                    previous_output: bitcoin::OutPoint::new(
-                        bitcoin::hashes::sha256d::Hash::from_byte_array([0x03; 32]).into(),
-                        1,
-                    ),
+                    previous_output: bitcoin::OutPoint::new(funding_txid_3, 1),
                     ..Default::default()
                 },
             ],
@@ -1050,7 +1122,7 @@ mod tests {
                     ShareTransaction(tx_a.clone()),
                     ShareTransaction(tx_b.clone()),
                 ],
-                1,
+                2,
                 &mut batch,
             )
             .unwrap();
@@ -1812,16 +1884,34 @@ mod tests {
         let script_true = bitcoin::Script::builder()
             .push_opcode(bitcoin::opcodes::all::OP_PUSHNUM_1)
             .into_script();
+
+        // Store a funding coinbase tx so the spending tx can find its input
+        let funding_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(bitcoin::Txid::all_zeros(), u32::MAX),
+                sequence: bitcoin::Sequence::default(),
+                witness: bitcoin::Witness::default(),
+                script_sig: script_true.clone(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(1000000),
+                script_pubkey: script_true.clone(),
+            }],
+        };
+        let funding_txid = funding_tx.compute_txid();
+        let mut batch = rocksdb::WriteBatch::default();
+        store
+            .add_sharechain_txs(&[ShareTransaction(funding_tx)], 1, &mut batch)
+            .unwrap();
+        store.db.write(batch).unwrap();
+
         let tx = Transaction {
             version: bitcoin::transaction::Version(1),
             lock_time: bitcoin::absolute::LockTime::ZERO,
             input: vec![bitcoin::TxIn {
-                previous_output: bitcoin::OutPoint::new(
-                    "0101010101010101010101010101010101010101010101010101010101010101"
-                        .parse()
-                        .unwrap(),
-                    0,
-                ),
+                previous_output: bitcoin::OutPoint::new(funding_txid, 0),
                 sequence: bitcoin::Sequence::default(),
                 witness: bitcoin::Witness::default(),
                 script_sig: script_true.clone(),
@@ -1835,7 +1925,7 @@ mod tests {
         let txid = tx.compute_txid();
         let mut batch = rocksdb::WriteBatch::default();
         let res = store
-            .add_sharechain_txs(&[ShareTransaction(tx.clone())], 1, &mut batch)
+            .add_sharechain_txs(&[ShareTransaction(tx.clone())], 2, &mut batch)
             .unwrap();
         store.db.write(batch).unwrap();
 
@@ -1847,12 +1937,7 @@ mod tests {
         assert_eq!(tx.input.len(), 1);
         assert_eq!(
             tx.input[0].previous_output,
-            bitcoin::OutPoint::new(
-                "0101010101010101010101010101010101010101010101010101010101010101"
-                    .parse()
-                    .unwrap(),
-                0,
-            )
+            bitcoin::OutPoint::new(funding_txid, 0)
         );
         assert_eq!(tx.input[0].script_sig, script_true);
         assert_eq!(tx.output.len(), 1);
@@ -2357,8 +2442,9 @@ mod tests {
         };
 
         let outputs_cf = store.db.cf_handle(&ColumnFamily::Outputs).unwrap();
-        let result =
-            store.min_coinbase_root_height_for_inputs(&ShareTransaction(spending_tx), &outputs_cf);
+        let result = store
+            .min_coinbase_root_height_for_inputs(&ShareTransaction(spending_tx), &outputs_cf)
+            .unwrap();
 
         assert_eq!(
             result, 100,
@@ -2389,7 +2475,10 @@ mod tests {
         let result =
             store.min_coinbase_root_height_for_inputs(&ShareTransaction(spending_tx), &outputs_cf);
 
-        assert_eq!(result, 0, "Should return 0 when no inputs found in store");
+        assert!(
+            result.is_err(),
+            "Should return error when input outputs not found in store"
+        );
     }
 
     #[test]

--- a/p2poolv2_lib/src/store/transaction_store.rs
+++ b/p2poolv2_lib/src/store/transaction_store.rs
@@ -149,11 +149,14 @@ impl Store {
 
     /// Batch-read all outpoints from the Outputs CF in a single multi_get.
     ///
-    /// Returns an error if any outpoint is missing. On success, returns
-    /// the subset of outpoints that belong to coinbase transactions.
+    /// Returns an error if any outpoint is missing or has a
+    /// coinbase_root_height below `min_coinbase_root_height`. On success,
+    /// returns the subset of outpoints that belong to coinbase
+    /// transactions.
     pub(crate) fn check_prevouts_and_find_coinbase(
         &self,
         outpoints: &[OutPoint],
+        min_coinbase_root_height: u32,
     ) -> Result<Vec<OutPoint>, StoreError> {
         if outpoints.is_empty() {
             return Ok(Vec::new());
@@ -178,6 +181,15 @@ impl Store {
             let stored: StoredTxOut = encode::deserialize(&data).map_err(|_| {
                 StoreError::Serialization("Failed to deserialize output".to_string())
             })?;
+            if stored.coinbase_root_height < min_coinbase_root_height {
+                return Err(StoreError::Database(format!(
+                    "Output {}:{} has coinbase_root_height {} below minimum {}",
+                    outpoints[index].txid,
+                    outpoints[index].vout,
+                    stored.coinbase_root_height,
+                    min_coinbase_root_height,
+                )));
+            }
             if stored.is_coinbase {
                 coinbase_outpoints.push(outpoints[index]);
             }
@@ -1146,7 +1158,7 @@ mod tests {
     fn test_check_prevouts_and_find_coinbase_returns_empty_for_empty_input() {
         let temp_dir = tempdir().unwrap();
         let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
-        let result = store.check_prevouts_and_find_coinbase(&[]).unwrap();
+        let result = store.check_prevouts_and_find_coinbase(&[], 0).unwrap();
         assert!(result.is_empty());
     }
 
@@ -1182,7 +1194,9 @@ mod tests {
             bitcoin::OutPoint::new(funding_txid, 0),
             bitcoin::OutPoint::new(funding_txid, 1),
         ];
-        let coinbase_outpoints = store.check_prevouts_and_find_coinbase(&outpoints).unwrap();
+        let coinbase_outpoints = store
+            .check_prevouts_and_find_coinbase(&outpoints, 0)
+            .unwrap();
         assert!(coinbase_outpoints.is_empty());
     }
 
@@ -1214,7 +1228,7 @@ mod tests {
             bitcoin::OutPoint::new(funding_txid, 0),
             bitcoin::OutPoint::new(unknown_txid, 0),
         ];
-        let result = store.check_prevouts_and_find_coinbase(&outpoints);
+        let result = store.check_prevouts_and_find_coinbase(&outpoints, 0);
         assert!(result.is_err());
     }
 
@@ -1264,9 +1278,61 @@ mod tests {
             bitcoin::OutPoint::new(coinbase_txid, 0),
             bitcoin::OutPoint::new(regular_txid, 0),
         ];
-        let coinbase_outpoints = store.check_prevouts_and_find_coinbase(&outpoints).unwrap();
+        let coinbase_outpoints = store
+            .check_prevouts_and_find_coinbase(&outpoints, 0)
+            .unwrap();
         assert_eq!(coinbase_outpoints.len(), 1);
         assert_eq!(coinbase_outpoints[0].txid, coinbase_txid);
+    }
+
+    #[test]
+    fn test_check_prevouts_rejects_expired_coinbase_root_height() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        // Store a coinbase tx at height 50
+        let coinbase_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(bitcoin::Txid::all_zeros(), u32::MAX),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+                script_sig: bitcoin::ScriptBuf::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(5_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let coinbase_txid = coinbase_tx.compute_txid();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .add_sharechain_txs(&[ShareTransaction(coinbase_tx)], 50, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let outpoints = vec![bitcoin::OutPoint::new(coinbase_txid, 0)];
+
+        // min_coinbase_root_height = 100: output at height 50 is expired
+        let result = store.check_prevouts_and_find_coinbase(&outpoints, 100);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("coinbase_root_height"),
+            "Expected coinbase_root_height error"
+        );
+
+        // min_coinbase_root_height = 50: output at height 50 is exactly at boundary
+        let result = store.check_prevouts_and_find_coinbase(&outpoints, 50);
+        assert!(result.is_ok());
+
+        // min_coinbase_root_height = 0: no filtering
+        let result = store.check_prevouts_and_find_coinbase(&outpoints, 0);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/p2poolv2_lib/src/store/transaction_store.rs
+++ b/p2poolv2_lib/src/store/transaction_store.rs
@@ -361,6 +361,11 @@ impl Store {
         let inputs_cf = self.db.cf_handle(&ColumnFamily::Inputs).unwrap();
         let outputs_cf = self.db.cf_handle(&ColumnFamily::Outputs).unwrap();
         let mut txs_metadata = Vec::new();
+        // Track coinbase_root_height for outputs written in this batch
+        // so in-block spending chains can look up earlier outputs.
+        let mut batch_heights: HashMap<String, u32> =
+            HashMap::with_capacity(transactions.len() * 2);
+
         for tx in transactions {
             let txid = tx.compute_txid();
             let metadata = self.add_tx_metadata(txid, tx, false, batch)?;
@@ -379,11 +384,12 @@ impl Store {
             let coinbase_root_height = if is_coinbase {
                 block_height
             } else {
-                self.min_coinbase_root_height_for_inputs(tx, &outputs_cf)?
+                self.min_coinbase_root_height_for_inputs(tx, &outputs_cf, &batch_heights)?
             };
 
             for (i, output) in tx.output.iter().enumerate() {
                 let output_key = format!("{txid}:{i}");
+                batch_heights.insert(output_key.clone(), coinbase_root_height);
                 let stored = StoredTxOut {
                     tx_out: output.clone(),
                     is_coinbase,
@@ -397,14 +403,15 @@ impl Store {
     }
 
     /// Compute the minimum coinbase_root_height across all inputs of a
-    /// non-coinbase transaction by reading each input's output from the
-    /// Outputs CF. Returns an error if any input's output is missing or
-    /// cannot be deserialized, to avoid permanently persisting height 0
-    /// which would make outputs unspendable.
+    /// non-coinbase transaction. Checks the in-batch cache first (for
+    /// in-block spending chains), then falls back to the Outputs CF.
+    /// Returns an error if any input's output is missing or cannot be
+    /// deserialized.
     fn min_coinbase_root_height_for_inputs(
         &self,
         tx: &ShareTransaction,
         outputs_cf: &impl rocksdb::AsColumnFamilyRef,
+        batch_heights: &HashMap<String, u32>,
     ) -> Result<u32, StoreError> {
         let mut min_height = u32::MAX;
         for input in &tx.0.input {
@@ -412,22 +419,28 @@ impl Store {
                 "{}:{}",
                 input.previous_output.txid, input.previous_output.vout
             );
-            let bytes = self
-                .db
-                .get_cf(outputs_cf, outpoint_key.as_bytes())?
-                .ok_or_else(|| {
-                    StoreError::NotFound(format!(
-                        "Input output not found for coinbase_root_height: {}",
+
+            let height = if let Some(cached_height) = batch_heights.get(&outpoint_key) {
+                *cached_height
+            } else {
+                let bytes = self
+                    .db
+                    .get_cf(outputs_cf, outpoint_key.as_bytes())?
+                    .ok_or_else(|| {
+                        StoreError::NotFound(format!(
+                            "Input output not found for coinbase_root_height: {}",
+                            outpoint_key
+                        ))
+                    })?;
+                let stored_out: StoredTxOut = consensus::deserialize(&bytes).map_err(|_| {
+                    StoreError::Serialization(format!(
+                        "Failed to deserialize output for coinbase_root_height: {}",
                         outpoint_key
                     ))
                 })?;
-            let stored_out: StoredTxOut = consensus::deserialize(&bytes).map_err(|_| {
-                StoreError::Serialization(format!(
-                    "Failed to deserialize output for coinbase_root_height: {}",
-                    outpoint_key
-                ))
-            })?;
-            min_height = std::cmp::min(min_height, stored_out.coinbase_root_height);
+                stored_out.coinbase_root_height
+            };
+            min_height = std::cmp::min(min_height, height);
         }
         Ok(min_height)
     }
@@ -1428,6 +1441,102 @@ mod tests {
 
         // min_coinbase_root_height = 0: no filtering
         let result = store.check_prevouts_and_find_coinbase(&outpoints, 0);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_check_prevouts_rejects_expired_root_through_in_block_spend_chain() {
+        // A coinbase at height 50 is spent by spend1 and spend2 within
+        // the same block at height 60. The chain is:
+        //   coinbase(h:50) -> spend1(h:60) -> spend2(h:60)
+        // Both spend1 and spend2 inherit coinbase_root_height = 50.
+        // Checking spend2's output with min = 100 should reject it.
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        // Coinbase at height 50 (stored in a previous block)
+        let coinbase_tx = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(bitcoin::Txid::all_zeros(), u32::MAX),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+                script_sig: bitcoin::ScriptBuf::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(5_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let coinbase_txid = coinbase_tx.compute_txid();
+
+        let mut batch = Store::get_write_batch();
+        store
+            .add_sharechain_txs(&[ShareTransaction(coinbase_tx)], 50, &mut batch)
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // spend1 and spend2 in the same block at height 60
+        let spend1 = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(coinbase_txid, 0),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+                script_sig: bitcoin::ScriptBuf::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(4_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let spend1_txid = spend1.compute_txid();
+
+        let spend2 = Transaction {
+            version: bitcoin::transaction::Version(1),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint::new(spend1_txid, 0),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+                script_sig: bitcoin::ScriptBuf::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(3_000_000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        };
+        let spend2_txid = spend2.compute_txid();
+
+        // Store both in the same block at height 60
+        let mut batch = Store::get_write_batch();
+        store
+            .add_sharechain_txs(
+                &[ShareTransaction(spend1), ShareTransaction(spend2)],
+                60,
+                &mut batch,
+            )
+            .unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // spend2's output inherits coinbase_root_height = 50 from the
+        // chain: coinbase(50) -> spend1(inherits 50) -> spend2(inherits 50)
+        let outpoints = vec![bitcoin::OutPoint::new(spend2_txid, 0)];
+
+        // min = 100: root height 50 is expired
+        let result = store.check_prevouts_and_find_coinbase(&outpoints, 100);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("coinbase_root_height"),
+        );
+
+        // min = 50: root height 50 is at boundary, passes
+        let result = store.check_prevouts_and_find_coinbase(&outpoints, 50);
         assert!(result.is_ok());
     }
 
@@ -2466,8 +2575,13 @@ mod tests {
         };
 
         let outputs_cf = store.db.cf_handle(&ColumnFamily::Outputs).unwrap();
+        let empty_cache: HashMap<String, u32> = HashMap::new();
         let result = store
-            .min_coinbase_root_height_for_inputs(&ShareTransaction(spending_tx), &outputs_cf)
+            .min_coinbase_root_height_for_inputs(
+                &ShareTransaction(spending_tx),
+                &outputs_cf,
+                &empty_cache,
+            )
             .unwrap();
 
         assert_eq!(
@@ -2496,8 +2610,12 @@ mod tests {
         };
 
         let outputs_cf = store.db.cf_handle(&ColumnFamily::Outputs).unwrap();
-        let result =
-            store.min_coinbase_root_height_for_inputs(&ShareTransaction(spending_tx), &outputs_cf);
+        let empty_cache: HashMap<String, u32> = HashMap::new();
+        let result = store.min_coinbase_root_height_for_inputs(
+            &ShareTransaction(spending_tx),
+            &outputs_cf,
+            &empty_cache,
+        );
 
         assert!(
             result.is_err(),

--- a/p2poolv2_lib/src/store/transaction_store.rs
+++ b/p2poolv2_lib/src/store/transaction_store.rs
@@ -1034,12 +1034,30 @@ mod tests {
                 script_sig: bitcoin::ScriptBuf::new(),
             }],
             output: vec![
-                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
-                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
-                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
-                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
-                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
-                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(100_000),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(100_000),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(100_000),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(100_000),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(100_000),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(100_000),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
             ],
         };
         let funding_txid_2 = funding_tx_2.compute_txid();
@@ -1055,8 +1073,14 @@ mod tests {
                 script_sig: bitcoin::ScriptBuf::new(),
             }],
             output: vec![
-                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
-                bitcoin::TxOut { value: bitcoin::Amount::from_sat(100_000), script_pubkey: bitcoin::ScriptBuf::new() },
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(100_000),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
+                bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(100_000),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
             ],
         };
         let funding_txid_3 = funding_tx_3.compute_txid();

--- a/p2poolv2_lib/src/store/writer/handle.rs
+++ b/p2poolv2_lib/src/store/writer/handle.rs
@@ -64,12 +64,15 @@ impl StoreHandle {
     }
 
     /// Batch-read all outpoints from the Outputs CF.
-    /// Returns an error if any is missing, otherwise returns coinbase outpoints.
+    /// Returns an error if any is missing or has coinbase_root_height
+    /// below min_coinbase_root_height. Returns coinbase outpoints.
     pub fn check_prevouts_and_find_coinbase(
         &self,
         outpoints: &[bitcoin::OutPoint],
+        min_coinbase_root_height: u32,
     ) -> Result<Vec<bitcoin::OutPoint>, StoreError> {
-        self.store.check_prevouts_and_find_coinbase(outpoints)
+        self.store
+            .check_prevouts_and_find_coinbase(outpoints, min_coinbase_root_height)
     }
 
     /// Return the first coinbase outpoint that is not yet mature, or None.


### PR DESCRIPTION
Each output tracks the lowest height of all the coinbases in the
ouputs tree. If any of the coinbases is below PPLNS window, the
transaction becomes unspendable.

This creates a burden on the wallets to inform the user the time left
on the spendability of any utxos they are about to create by spending
an utxo.