### PR TITLE
Ignore bodies below prune depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Pruning support: Add two-zone block body validation, PPLNS zone and
+  Prune Zone. Full block bodies are required for PPLNS zone at sync
+  time. We fetch and retain only headers in the prune zone. All blocks
+  below the prune zone will be deleted in a future PR. See wiki page
+  on Pruning and/or the LLM architecture docs in docs/architecture for
+  more details.
+  - Block bodies are only fetched within PRUNE_DEPTH of the candidate
+    tip. Blocks below this are validated header-only with PoW at sync
+    time.
+  - `validate_below_pplns_depth`: lightweight validation for
+    prune-zone blocks, including PoW, uncles check, block size, tx
+    count.
+  - `coinbase_root_height` stored in StoredTxOut: tracks oldest
+    coinbase ancestor. Outputs deeper than PPLNS_DEPTH from tip are
+    unspendable.
+  - Confirmation pipeline promotes prune-zone blocks without body
+    data.  SpendsIndex skipped for these blocks as outputs are
+    unspendable anyway.
+  - `verify_chain` tool respects prune boundary. There are no body
+    checks below it.
+  - Constants: `PPLNS_DEPTH=120960`, `PRUNE_DEPTH=241920`,
+    `PRUNE_INTERVAL=360`.
+
 - ShareBlock relay: blocks are now pushed directly as full ShareBlocks
   instead of the Inv-then-fetch protocol, reducing propagation latency.
   Blocks are relayed on validation and broadcast only when the chain is

--- a/docs/architecture/pruning.md
+++ b/docs/architecture/pruning.md
@@ -146,6 +146,49 @@ Relevant code:
 - `store/share_store.rs` (`compute_block_height_from_parent`)
 - `shares/validation/mod.rs` (`validate_prevouts`)
 
+## Confirmation Pipeline (prune-zone promotion)
+
+The confirmation pipeline (`organise_block`) promotes candidate blocks
+to confirmed status. Blocks below the prune boundary are promoted
+without requiring block body data.
+
+### Flow
+
+`organise_block` computes `prune_height = candidate_tip - PRUNE_DEPTH`
+once from a single candidate tip snapshot, then passes it to all
+downstream functions to avoid inconsistency from concurrent updates.
+
+### Gates modified for pruning
+
+1. **`contiguous_candidates_with_block_data`**: blocks with
+   `height < prune_height` pass without `share_block_exists` check.
+   Blocks at or above require full body data.
+
+2. **`all_block_and_uncle_data_available`**: blocks below prune_height
+   skip body and uncle body checks. Returns `Result<bool>` to
+   propagate metadata errors (expected_height must always exist for
+   candidates).
+
+3. **`put_confirmed_entry`**: only calls `add_spends_for_block` when
+   `share_block_exists` returns true. Prune-zone blocks without body
+   data get the confirmed height index entry but no SpendsIndex
+   population.
+
+### Safety
+
+Prune-zone blocks without SpendsIndex entries cannot cause
+double-spend acceptance:
+- Their outputs have `coinbase_root_height` below `tip - PPLNS_DEPTH`
+- `check_prevouts_and_find_coinbase` rejects spending those outputs
+- SpendsIndex is only needed for outputs that CAN be spent
+
+Relevant code:
+- `store/organise/organise_block.rs` (`organise_block`,
+  `find_promotable_candidates`, `contiguous_candidates_with_block_data`)
+- `store/organise/confirmed.rs` (`put_confirmed_entry`,
+  `all_block_and_uncle_data_available`, `should_extend_confirmed`,
+  `reorg_confirmed`)
+
 ## Constants
 
 | Constant | Value | Meaning |

--- a/docs/architecture/pruning.md
+++ b/docs/architecture/pruning.md
@@ -164,15 +164,27 @@ downstream functions to avoid inconsistency from concurrent updates.
    `height < prune_height` pass without `share_block_exists` check.
    Blocks at or above require full body data.
 
-2. **`all_block_and_uncle_data_available`**: blocks below prune_height
-   skip body and uncle body checks. Returns `Result<bool>` to
-   propagate metadata errors (expected_height must always exist for
-   candidates).
+2. **`all_block_and_uncle_data_available`**: both blocks and their
+   uncles are checked against prune_height using
+   `get_block_height_from_metadata`. Blocks or uncles below
+   prune_height skip the body check. Returns `Result<bool, StoreError>`
+   -- propagates errors when metadata or expected_height is missing
+   (these indicate store corruption for candidates that went through
+   organise_header). Missing headers also error rather than silently
+   assuming no uncles.
 
 3. **`put_confirmed_entry`**: only calls `add_spends_for_block` when
    `share_block_exists` returns true. Prune-zone blocks without body
    data get the confirmed height index entry but no SpendsIndex
    population.
+
+### Consistency
+
+`organise_block` reads candidate_tip_height once and derives
+prune_height from it. This single snapshot is passed to
+`find_promotable_candidates`, `should_extend_confirmed`,
+`reorg_confirmed`, and `try_fallback_confirmation` to avoid divergence
+from concurrent header arrivals advancing the candidate tip.
 
 ### Safety
 

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -60,12 +60,15 @@ impl Store {
                 debug!("Block {blockhash} missing block data");
                 return Ok(false);
             }
-            if let Ok(Some(header)) = self.get_share_header(blockhash) {
-                for uncle in &header.uncles {
-                    if !self.share_block_exists(uncle) {
-                        debug!("Uncle {uncle} of block {blockhash} missing block data");
-                        return Ok(false);
-                    }
+            let header = self.get_share_header(blockhash)?.ok_or_else(|| {
+                StoreError::NotFound(format!(
+                    "Header missing for candidate {blockhash} in uncle data check"
+                ))
+            })?;
+            for uncle in &header.uncles {
+                if !self.share_block_exists(uncle) {
+                    debug!("Uncle {uncle} of block {blockhash} missing block data");
+                    return Ok(false);
                 }
             }
         }

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -220,9 +220,8 @@ impl Store {
         let serialized = consensus::serialize(blockhash);
         batch.put_cf(&block_height_cf, key, serialized);
 
-        // If a block body exists, it means the block is in PPLNS zone
-        // and we need to add transactions to store and update spends
-        // index.
+        // If block body data exists, we can fetch transactions and update the spends index.
+        // (Blocks promoted header-only in the prune zone will not have body data.)
         if self.share_block_exists(blockhash) {
             let txs = self.get_txs_by_blockhash_index(blockhash)?;
             self.add_spends_for_block(&txs, batch)?;
@@ -1963,5 +1962,120 @@ mod tests {
             store.get_confirmed_at_height(1).unwrap(),
             share1.block_hash()
         );
+    }
+
+    // -- all_block_and_uncle_data_available prune_height tests --
+
+    #[test]
+    fn test_block_below_prune_height_passes_without_body() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Header-only block at height 1 (no body)
+        let share = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695792)
+            .build();
+        store.push_to_candidate_chain(&share).unwrap();
+        assert!(!store.share_block_exists(&share.block_hash()));
+
+        // prune_height = 2: block at height 1 is below, body not required
+        let result = store
+            .all_block_and_uncle_data_available(&[share.block_hash()], 2)
+            .unwrap();
+        assert!(result, "Block below prune_height should pass without body");
+    }
+
+    #[test]
+    fn test_block_at_prune_height_fails_without_body() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Header-only block at height 1 (no body)
+        let share = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695792)
+            .build();
+        store.push_to_candidate_chain(&share).unwrap();
+
+        // prune_height = 1: block at height 1 is at boundary, body required
+        let result = store
+            .all_block_and_uncle_data_available(&[share.block_hash()], 1)
+            .unwrap();
+        assert!(!result, "Block at prune_height should fail without body");
+    }
+
+    #[test]
+    fn test_uncle_below_prune_height_passes_without_body() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Uncle at height 1 (header-only, no body)
+        let uncle = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695793)
+            .build();
+        store.push_to_candidate_chain(&uncle).unwrap();
+
+        // Main block at height 1 referencing the uncle, with full body
+        let main_block = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .uncles(vec![uncle.block_hash()])
+            .nonce(0xe9695792)
+            .build();
+        store.store_with_valid_metadata(&main_block);
+
+        // prune_height = 2: both blocks at height 1 are below boundary
+        let result = store
+            .all_block_and_uncle_data_available(&[main_block.block_hash()], 2)
+            .unwrap();
+        assert!(result, "Uncle below prune_height should pass without body");
+    }
+
+    #[test]
+    fn test_uncle_at_prune_height_fails_without_body() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Uncle at height 1 (header-only, no body)
+        let uncle = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695793)
+            .build();
+        store.push_to_candidate_chain(&uncle).unwrap();
+
+        // Main block at height 1 referencing the uncle, with full body
+        let main_block = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .uncles(vec![uncle.block_hash()])
+            .nonce(0xe9695792)
+            .build();
+        store.store_with_valid_metadata(&main_block);
+
+        // prune_height = 1: uncle at height 1 is at boundary, body required
+        let result = store
+            .all_block_and_uncle_data_available(&[main_block.block_hash()], 1)
+            .unwrap();
+        assert!(!result, "Uncle at prune_height should fail without body");
     }
 }

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -36,8 +36,9 @@ impl Store {
     /// bodies stored. Skip blocks below `prune_height` in the check
     /// as they are organised by header only.
     ///
-    /// Returns false (with a debug log) on the first missing block body
-    /// or uncle body. Used by both `should_extend_confirmed` and
+    /// Returns `Ok(false)` (with a debug log) on the first missing block
+    /// body or uncle body. Returns `Err` if block metadata is missing or
+    /// has no expected_height. Used by both `should_extend_confirmed` and
     /// `reorg_confirmed` to ensure PPLNS can resolve all uncle data
     /// before a block is promoted.
     pub(super) fn all_block_and_uncle_data_available(
@@ -217,7 +218,7 @@ impl Store {
         let serialized = consensus::serialize(blockhash);
         batch.put_cf(&block_height_cf, key, serialized);
 
-        // a check for existing share block captures check for blocks in pplns zone
+        // If a block body exists, it means the block is in PPLNS zone
         if self.share_block_exists(blockhash) {
             let txs = self.get_txs_by_blockhash_index(blockhash)?;
             self.add_spends_for_block(&txs, batch)?;
@@ -359,10 +360,11 @@ impl Store {
     /// Check if the confirmed chain can be extended by the local candidate chain.
     ///
     /// Returns true when the first candidate is a child of the top
-    /// confirmed AND all candidates (plus their uncles) have block
-    /// body data available in the store. The uncle check ensures the
-    /// PPLNS window can resolve all uncle entries when computing
-    /// payout distributions.
+    /// confirmed AND all candidates at or above `prune_height` (plus
+    /// their uncles) have block body data available in the store.
+    /// Candidates below `prune_height` are promoted header-only since
+    /// their PoW was validated at header sync time and their outputs
+    /// are unspendable.
     pub(super) fn should_extend_confirmed(
         &self,
         candidates: &Chain,

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -61,6 +61,10 @@ impl Store {
                 ))
             })?;
             for uncle in &header.uncles {
+                let uncle_height = self.get_block_height_from_metadata(uncle)?;
+                if uncle_height < prune_height {
+                    continue;
+                }
                 if !self.share_block_exists(uncle) {
                     debug!("Uncle {uncle} of block {blockhash} missing block data");
                     return Ok(false);

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -47,12 +47,7 @@ impl Store {
         prune_height: u32,
     ) -> Result<bool, StoreError> {
         for blockhash in blockhashes {
-            let metadata = self.get_block_metadata(blockhash)?;
-            let block_height = metadata.expected_height.ok_or_else(|| {
-                StoreError::NotFound(format!(
-                    "Block {blockhash} has no expected_height in all_block_and_uncle_data_available"
-                ))
-            })?;
+            let block_height = self.get_block_height_from_metadata(blockhash)?;
             if block_height < prune_height {
                 continue;
             }
@@ -222,6 +217,8 @@ impl Store {
         batch.put_cf(&block_height_cf, key, serialized);
 
         // If a block body exists, it means the block is in PPLNS zone
+        // and we need to add transactions to store and update spends
+        // index.
         if self.share_block_exists(blockhash) {
             let txs = self.get_txs_by_blockhash_index(blockhash)?;
             self.add_spends_for_block(&txs, batch)?;

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -57,7 +57,7 @@ impl Store {
             }
             let header = self.get_share_header(blockhash)?.ok_or_else(|| {
                 StoreError::NotFound(format!(
-                    "Header missing for candidate {blockhash} in uncle data check"
+                    "Header missing for {blockhash} in uncle data check"
                 ))
             })?;
             for uncle in &header.uncles {

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -31,29 +31,44 @@ const CONFIRMED_SUFFIX: &str = ":f";
 const TOP_CONFIRMED_KEY: &str = "meta:top_confirmed_height";
 
 impl Store {
-    /// Check that every block in the list has its body stored and that
-    /// all uncles referenced by each block also have their bodies stored.
+    /// Check that every block in the list has its body stored and
+    /// that all uncles referenced by each block also have their
+    /// bodies stored. Skip blocks below `prune_height` in the check
+    /// as they are organised by header only.
     ///
     /// Returns false (with a debug log) on the first missing block body
     /// or uncle body. Used by both `should_extend_confirmed` and
     /// `reorg_confirmed` to ensure PPLNS can resolve all uncle data
     /// before a block is promoted.
-    pub(super) fn all_block_and_uncle_data_available(&self, blockhashes: &[BlockHash]) -> bool {
+    pub(super) fn all_block_and_uncle_data_available(
+        &self,
+        blockhashes: &[BlockHash],
+        prune_height: u32,
+    ) -> Result<bool, StoreError> {
         for blockhash in blockhashes {
+            let metadata = self.get_block_metadata(blockhash)?;
+            let block_height = metadata.expected_height.ok_or_else(|| {
+                StoreError::NotFound(format!(
+                    "Block {blockhash} has no expected_height in all_block_and_uncle_data_available"
+                ))
+            })?;
+            if block_height < prune_height {
+                continue;
+            }
             if !self.share_block_exists(blockhash) {
                 debug!("Block {blockhash} missing block data");
-                return false;
+                return Ok(false);
             }
             if let Ok(Some(header)) = self.get_share_header(blockhash) {
                 for uncle in &header.uncles {
                     if !self.share_block_exists(uncle) {
                         debug!("Uncle {uncle} of block {blockhash} missing block data");
-                        return false;
+                        return Ok(false);
                     }
                 }
             }
         }
-        true
+        Ok(true)
     }
     /// Check if the candidate chain should reorg the confirmed chain.
     ///
@@ -111,6 +126,7 @@ impl Store {
         &self,
         top_confirmed: &TopResult,
         candidates: &Chain,
+        prune_height: u32,
         batch: &mut rocksdb::WriteBatch,
     ) -> Result<Option<Height>, StoreError> {
         let (_, tip_hash) = candidates
@@ -129,9 +145,9 @@ impl Store {
             StoreError::NotFound("Empty branch returned from get_branch_to_chain.".into())
         })?;
 
-        // Do not reorg if any block or its uncles lack block data
+        // Do not reorg if any block above the prune boundary lacks body data.
         let fork_hashes: Vec<BlockHash> = fork_branch.iter().copied().collect();
-        if !self.all_block_and_uncle_data_available(&fork_hashes) {
+        if !self.all_block_and_uncle_data_available(&fork_hashes, prune_height)? {
             debug!("Reorg skipped: block or uncle missing block data");
             return Ok(None);
         }
@@ -185,6 +201,11 @@ impl Store {
     /// `get_txs_by_blockhash_index`. Callers must ensure the
     /// block's tx data has already been committed in a prior batch - the
     /// read against a pending `WriteBatch` will not see its contents.
+    ///
+    /// For blocks with body data, fetches transactions and records
+    /// spends. For prune-zone blocks without body data, only writes the
+    /// confirmed height index (SpendsIndex not needed because their
+    /// outputs are unspendable via coinbase_root_height check).
     pub(super) fn put_confirmed_entry(
         &self,
         height: Height,
@@ -196,8 +217,11 @@ impl Store {
         let serialized = consensus::serialize(blockhash);
         batch.put_cf(&block_height_cf, key, serialized);
 
-        let txs = self.get_txs_by_blockhash_index(blockhash)?;
-        self.add_spends_for_block(&txs, batch)?;
+        // a check for existing share block captures check for blocks in pplns zone
+        if self.share_block_exists(blockhash) {
+            let txs = self.get_txs_by_blockhash_index(blockhash)?;
+            self.add_spends_for_block(&txs, batch)?;
+        }
         Ok(())
     }
 
@@ -344,6 +368,7 @@ impl Store {
         candidates: &Chain,
         top_confirmed_height: Height,
         top_confirmed_hash: BlockHash,
+        prune_height: u32,
     ) -> Result<bool, StoreError> {
         debug!(
             "top confirmed height {}, top confirmed hash {}",
@@ -370,7 +395,7 @@ impl Store {
         }
 
         let candidate_hashes: Vec<BlockHash> = candidates.iter().map(|(_, hash)| *hash).collect();
-        Ok(self.all_block_and_uncle_data_available(&candidate_hashes))
+        self.all_block_and_uncle_data_available(&candidate_hashes, prune_height)
     }
 
     /// Promote candidates to confirmed.
@@ -1278,7 +1303,7 @@ mod tests {
         let candidates = vec![(1, fork_share.block_hash())];
         let mut batch = Store::get_write_batch();
         let result = store
-            .reorg_confirmed(&top_confirmed, &candidates, &mut batch)
+            .reorg_confirmed(&top_confirmed, &candidates, 0, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -1412,7 +1437,7 @@ mod tests {
         let candidates = vec![(1, fork_1.block_hash()), (2, fork_2.block_hash())];
         let mut batch = Store::get_write_batch();
         let result = store
-            .reorg_confirmed(&top_confirmed, &candidates, &mut batch)
+            .reorg_confirmed(&top_confirmed, &candidates, 0, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -1555,7 +1580,7 @@ mod tests {
         let candidates = vec![(1, fork_share.block_hash())];
         let mut batch = Store::get_write_batch();
         let result = store
-            .reorg_confirmed(&top_confirmed, &candidates, &mut batch)
+            .reorg_confirmed(&top_confirmed, &candidates, 0, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -1670,7 +1695,7 @@ mod tests {
         let candidates = vec![(2, fork_share.block_hash())];
         let mut batch = Store::get_write_batch();
         let result = store
-            .reorg_confirmed(&top_confirmed, &candidates, &mut batch)
+            .reorg_confirmed(&top_confirmed, &candidates, 0, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -1718,7 +1743,7 @@ mod tests {
         let candidates: Chain = Vec::new();
 
         let mut batch = Store::get_write_batch();
-        let result = store.reorg_confirmed(&top_confirmed, &candidates, &mut batch);
+        let result = store.reorg_confirmed(&top_confirmed, &candidates, 0, &mut batch);
         assert!(result.is_err());
     }
 
@@ -1832,7 +1857,7 @@ mod tests {
         let candidates = vec![(1, fork_1.block_hash())];
         let mut batch = Store::get_write_batch();
         store
-            .reorg_confirmed(&top_confirmed, &candidates, &mut batch)
+            .reorg_confirmed(&top_confirmed, &candidates, 0, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 
@@ -1921,7 +1946,7 @@ mod tests {
 
         let mut batch = Store::get_write_batch();
         let result = store
-            .reorg_confirmed(&top_confirmed, &candidates, &mut batch)
+            .reorg_confirmed(&top_confirmed, &candidates, 0, &mut batch)
             .unwrap();
         store.commit_batch(batch).unwrap();
 

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -52,7 +52,8 @@ impl Store {
         };
         let prune_height = candidate_tip_height.saturating_sub(PRUNE_DEPTH as u32);
 
-        let candidates = self.find_promotable_candidates(&top_confirmed, prune_height)?;
+        let candidates =
+            self.find_promotable_candidates(&top_confirmed, candidate_tip_height, prune_height)?;
 
         if !candidates.is_empty() {
             let promotable_height = candidates.last().unwrap().0;
@@ -121,19 +122,16 @@ impl Store {
     fn find_promotable_candidates(
         &self,
         top_confirmed: &TopResult,
+        candidate_tip_height: u32,
         prune_height: u32,
     ) -> Result<Chain, StoreError> {
-        let Ok(top_candidate) = self.get_top_candidate() else {
-            return Ok(Vec::new());
-        };
-
         debug!(
-            "Finding promotable candidates: top_confirmed {:?}, top_candidate {:?}",
-            top_confirmed, top_candidate
+            "Finding promotable candidates: top_confirmed {:?}, candidate_tip_height {}",
+            top_confirmed, candidate_tip_height
         );
 
         let scan_limit = top_confirmed.height + 1 + FETCH_BATCH_SIZE as u32;
-        let scan_end = std::cmp::min(scan_limit, top_candidate.height);
+        let scan_end = std::cmp::min(scan_limit, candidate_tip_height);
         let all_candidates = self.get_candidates(top_confirmed.height + 1, scan_end)?;
         Ok(self.contiguous_candidates_with_block_data(&all_candidates, prune_height))
     }

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -15,6 +15,7 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use super::{Chain, Height, Store, TopResult};
+use crate::accounting::payout::sharechain_pplns::pplns_window::PRUNE_DEPTH;
 use crate::node::request_response_handler::block_fetcher::FETCH_BATCH_SIZE;
 use crate::store::writer::StoreError;
 use tracing::debug;
@@ -44,6 +45,13 @@ impl Store {
             StoreError::Database("organise_block called without a genesis block".into())
         })?;
 
+        let candidate_tip_height = match self.get_top_candidate_height() {
+            Ok(height) => height,
+            Err(StoreError::NotFound(_)) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let prune_height = candidate_tip_height.saturating_sub(PRUNE_DEPTH as u32);
+
         let candidates = self.find_promotable_candidates(&top_confirmed)?;
 
         if !candidates.is_empty() {
@@ -53,16 +61,17 @@ impl Store {
                 &candidates,
                 top_confirmed.height,
                 top_confirmed.hash,
+                prune_height,
             )? {
                 return self.extend_confirmed(promotable_height, &candidates, batch);
             }
 
             if self.should_reorg_confirmed(&top_confirmed, &candidates) {
-                return self.reorg_confirmed(&top_confirmed, &candidates, batch);
+                return self.reorg_confirmed(&top_confirmed, &candidates, prune_height, batch);
             }
         }
 
-        self.try_fallback_confirmation(&top_confirmed, batch)
+        self.try_fallback_confirmation(&top_confirmed, prune_height, batch)
     }
 
     /// Fallback: when no candidate chain blocks can be promoted, look
@@ -71,6 +80,7 @@ impl Store {
     fn try_fallback_confirmation(
         &self,
         top_confirmed: &TopResult,
+        prune_height: u32,
         batch: &mut rocksdb::WriteBatch,
     ) -> Result<Option<Height>, StoreError> {
         let next_height = top_confirmed.height + 1;
@@ -84,7 +94,7 @@ impl Store {
                 if header.prev_share_blockhash != top_confirmed.hash {
                     continue;
                 }
-                if !self.all_block_and_uncle_data_available(&[*blockhash]) {
+                if !self.all_block_and_uncle_data_available(&[*blockhash], prune_height)? {
                     continue;
                 }
                 debug!(
@@ -99,11 +109,15 @@ impl Store {
         Ok(None)
     }
 
-    /// Find the contiguous prefix of candidates with block data that
-    /// are eligible for promotion to confirmed.
+    /// Find the contiguous prefix of candidates that are eligible for
+    /// promotion to confirmed.
+    ///
+    /// Blocks below the prune boundary (candidate_tip - PRUNE_DEPTH) do
+    /// not require block body data -- they are promoted header-only.
+    /// Blocks at or above the boundary require full block data.
     ///
     /// Returns an empty vec when no candidate chain exists or when the
-    /// first candidate lacks block data.
+    /// first block above the prune boundary lacks block data.
     fn find_promotable_candidates(&self, top_confirmed: &TopResult) -> Result<Chain, StoreError> {
         let Ok(top_candidate) = self.get_top_candidate() else {
             return Ok(Vec::new());
@@ -114,19 +128,27 @@ impl Store {
             top_confirmed, top_candidate
         );
 
+        let prune_height = top_candidate.height.saturating_sub(PRUNE_DEPTH as u32);
         let scan_limit = top_confirmed.height + 1 + FETCH_BATCH_SIZE as u32;
         let scan_end = std::cmp::min(scan_limit, top_candidate.height);
         let all_candidates = self.get_candidates(top_confirmed.height + 1, scan_end)?;
-        Ok(self.contiguous_candidates_with_block_data(&all_candidates))
+        Ok(self.contiguous_candidates_with_block_data(&all_candidates, prune_height))
     }
 
-    /// Return the contiguous prefix of candidates that have full block
-    /// data stored. Stops at the first candidate where
-    /// `share_block_exists` returns false.
-    fn contiguous_candidates_with_block_data(&self, candidates: &Chain) -> Chain {
+    /// Return the contiguous prefix of candidates eligible for promotion.
+    ///
+    /// Blocks below `prune_height` are allowed without body data (their
+    /// PoW was validated at header time). Blocks at or above the boundary
+    /// must have full block data stored. Stops at the first block above
+    /// the boundary that lacks data.
+    fn contiguous_candidates_with_block_data(
+        &self,
+        candidates: &Chain,
+        prune_height: u32,
+    ) -> Chain {
         let mut result = Vec::with_capacity(candidates.len());
         for (height, blockhash) in candidates {
-            if !self.share_block_exists(blockhash) {
+            if *height >= prune_height && !self.share_block_exists(blockhash) {
                 debug!(
                     "Candidate at height {} ({}) missing block data, stopping promotion",
                     height, blockhash
@@ -1205,6 +1227,115 @@ mod tests {
         assert_eq!(
             store.get_confirmed_at_height(2).unwrap(),
             local_block.block_hash()
+        );
+    }
+
+    /// contiguous_candidates_with_block_data allows blocks below
+    /// prune_height without body data. Test by calling it directly with
+    /// an artificial prune_height.
+    #[test]
+    fn test_contiguous_candidates_allows_prune_zone_blocks_without_body() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // Build 3 candidates: header-only (no body)
+        let share1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695792)
+            .build();
+        store.push_to_candidate_chain(&share1).unwrap();
+
+        let share2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share1.block_hash().to_string())
+            .nonce(0xe9695793)
+            .build();
+        store.push_to_candidate_chain(&share2).unwrap();
+
+        let share3 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share2.block_hash().to_string())
+            .nonce(0xe9695794)
+            .build();
+        store.push_to_candidate_chain(&share3).unwrap();
+
+        let candidates: Chain = vec![
+            (1, share1.block_hash()),
+            (2, share2.block_hash()),
+            (3, share3.block_hash()),
+        ];
+
+        // prune_height = 4: all blocks (1,2,3) below boundary, no body needed
+        let result = store.contiguous_candidates_with_block_data(&candidates, 4);
+        assert_eq!(result.len(), 3, "All 3 should pass when below prune_height");
+
+        // prune_height = 2: block at height 1 is below (OK), height 2 needs body
+        let result = store.contiguous_candidates_with_block_data(&candidates, 2);
+        assert_eq!(
+            result.len(),
+            1,
+            "Only block at height 1 should pass (below 2), height 2 needs body"
+        );
+
+        // prune_height = 0: all blocks need body, none have it
+        let result = store.contiguous_candidates_with_block_data(&candidates, 0);
+        assert_eq!(
+            result.len(),
+            0,
+            "No blocks should pass when all need body data"
+        );
+    }
+
+    /// contiguous_candidates_with_block_data stops at the first block
+    /// above prune_height that lacks body, even if later blocks have it.
+    #[test]
+    fn test_contiguous_candidates_stops_at_first_gap_above_prune_height() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        let genesis = TestShareBlockBuilder::new().nonce(0xe9695791).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&genesis, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        // share1: header only (no body)
+        let share1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(genesis.block_hash().to_string())
+            .nonce(0xe9695792)
+            .build();
+        store.push_to_candidate_chain(&share1).unwrap();
+
+        // share2: header only (no body)
+        let share2 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share1.block_hash().to_string())
+            .nonce(0xe9695793)
+            .build();
+        store.push_to_candidate_chain(&share2).unwrap();
+
+        // share3: has full body
+        let share3 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share2.block_hash().to_string())
+            .nonce(0xe9695794)
+            .build();
+        store.store_with_valid_metadata(&share3);
+
+        let candidates: Chain = vec![
+            (1, share1.block_hash()),
+            (2, share2.block_hash()),
+            (3, share3.block_hash()),
+        ];
+
+        // prune_height = 2: height 1 is below (OK without body),
+        // height 2 is at boundary (needs body, missing) -> stops
+        // share3 at height 3 has body but is never reached
+        let result = store.contiguous_candidates_with_block_data(&candidates, 2);
+        assert_eq!(
+            result.len(),
+            1,
+            "Should stop at height 2 (missing body at boundary)"
         );
     }
 }

--- a/p2poolv2_lib/src/store/organise/organise_block.rs
+++ b/p2poolv2_lib/src/store/organise/organise_block.rs
@@ -52,7 +52,7 @@ impl Store {
         };
         let prune_height = candidate_tip_height.saturating_sub(PRUNE_DEPTH as u32);
 
-        let candidates = self.find_promotable_candidates(&top_confirmed)?;
+        let candidates = self.find_promotable_candidates(&top_confirmed, prune_height)?;
 
         if !candidates.is_empty() {
             let promotable_height = candidates.last().unwrap().0;
@@ -118,7 +118,11 @@ impl Store {
     ///
     /// Returns an empty vec when no candidate chain exists or when the
     /// first block above the prune boundary lacks block data.
-    fn find_promotable_candidates(&self, top_confirmed: &TopResult) -> Result<Chain, StoreError> {
+    fn find_promotable_candidates(
+        &self,
+        top_confirmed: &TopResult,
+        prune_height: u32,
+    ) -> Result<Chain, StoreError> {
         let Ok(top_candidate) = self.get_top_candidate() else {
             return Ok(Vec::new());
         };
@@ -128,7 +132,6 @@ impl Store {
             top_confirmed, top_candidate
         );
 
-        let prune_height = top_candidate.height.saturating_sub(PRUNE_DEPTH as u32);
         let scan_limit = top_confirmed.height + 1 + FETCH_BATCH_SIZE as u32;
         let scan_end = std::cmp::min(scan_limit, top_candidate.height);
         let all_candidates = self.get_candidates(top_confirmed.height + 1, scan_end)?;

--- a/p2poolv2_lib/src/store/share_store.rs
+++ b/p2poolv2_lib/src/store/share_store.rs
@@ -432,9 +432,7 @@ impl Store {
     pub fn get_block_height_from_metadata(&self, blockhash: &BlockHash) -> Result<u32, StoreError> {
         let metadata = self.get_block_metadata(blockhash)?;
         metadata.expected_height.ok_or_else(|| {
-            StoreError::NotFound(format!(
-                "Block {blockhash} has no expected_height"
-            ))
+            StoreError::NotFound(format!("Block {blockhash} has no expected_height"))
         })
     }
 

--- a/p2poolv2_lib/src/store/share_store.rs
+++ b/p2poolv2_lib/src/store/share_store.rs
@@ -426,6 +426,18 @@ impl Store {
         self.get_shares(&blockhashes)
     }
 
+    /// Get the expected height for a block from its metadata.
+    ///
+    /// Returns an error if metadata is missing or has no expected_height.
+    pub fn get_block_height_from_metadata(&self, blockhash: &BlockHash) -> Result<u32, StoreError> {
+        let metadata = self.get_block_metadata(blockhash)?;
+        metadata.expected_height.ok_or_else(|| {
+            StoreError::NotFound(format!(
+                "Block {blockhash} has no expected_height"
+            ))
+        })
+    }
+
     /// Get the block metadata for a blockhash
     pub fn get_block_metadata(&self, blockhash: &BlockHash) -> Result<BlockMetadata, StoreError> {
         let block_metadata_cf = self.db.cf_handle(&ColumnFamily::BlockMetadata).unwrap();

--- a/p2poolv2_node/src/verify_chain.rs
+++ b/p2poolv2_node/src/verify_chain.rs
@@ -158,7 +158,7 @@ fn main() {
             }
         };
 
-        // 3. Verify full block data for blocks above prune boundary.
+        // 3. Verify full block data for blocks at or above prune boundary.
         // Blocks below the boundary may or may not have data (pruning
         // not yet implemented), so no check is performed for those.
         if height >= prune_boundary {

--- a/p2poolv2_node/src/verify_chain.rs
+++ b/p2poolv2_node/src/verify_chain.rs
@@ -104,7 +104,7 @@ fn main() {
     println!("Top confirmed height: {top_height}");
 
     let prune_boundary = top_height.saturating_sub(PRUNE_DEPTH as u32);
-    println!("Prune boundary: {prune_boundary} (blocks above this must have full data)");
+    println!("Prune boundary: {prune_boundary} (blocks at or above this must have full data)");
 
     let mut summary = VerificationSummary::new();
 

--- a/p2poolv2_node/src/verify_chain.rs
+++ b/p2poolv2_node/src/verify_chain.rs
@@ -21,6 +21,7 @@
 
 use bitcoin::BlockHash;
 use bitcoin::hashes::Hash;
+use p2poolv2_lib::accounting::payout::sharechain_pplns::pplns_window::PRUNE_DEPTH;
 use p2poolv2_lib::shares::validation::MAX_UNCLES;
 use p2poolv2_lib::store::Store;
 use p2poolv2_lib::store::block_tx_metadata::Status;
@@ -102,6 +103,9 @@ fn main() {
 
     println!("Top confirmed height: {top_height}");
 
+    let prune_boundary = top_height.saturating_sub(PRUNE_DEPTH as u32);
+    println!("Prune boundary: {prune_boundary} (blocks above this must have full data)");
+
     let mut summary = VerificationSummary::new();
 
     // Track confirmed hashes by height for parent linkage checks
@@ -154,28 +158,32 @@ fn main() {
             }
         };
 
-        // 3. Verify full block data exists
-        if !store.share_block_exists(&blockhash) {
-            summary.error(format!(
-                "h:{height} {blockhash} - block data missing (no txids in BlockTxids CF)"
-            ));
-        }
+        // 3. Verify full block data for blocks above prune boundary.
+        // Blocks below the boundary may or may not have data (pruning
+        // not yet implemented), so no check is performed for those.
+        if height >= prune_boundary {
+            if !store.share_block_exists(&blockhash) {
+                summary.error(format!(
+                    "h:{height} {blockhash} - block data missing (no txids in BlockTxids CF)"
+                ));
+            }
 
-        // 4. Verify share can be fully reconstructed
-        let share = store.get_share(&blockhash);
-        match &share {
-            Some(share_block) => {
-                // 5. Verify transactions non-empty (at least coinbase)
-                if share_block.transactions.is_empty() {
+            // 4. Verify share can be fully reconstructed
+            let share = store.get_share(&blockhash);
+            match &share {
+                Some(share_block) => {
+                    // 5. Verify transactions non-empty (at least coinbase)
+                    if share_block.transactions.is_empty() {
+                        summary.error(format!(
+                            "h:{height} {blockhash} - share has zero transactions (expected at least coinbase)"
+                        ));
+                    }
+                }
+                None => {
                     summary.error(format!(
-                        "h:{height} {blockhash} - share has zero transactions (expected at least coinbase)"
+                        "h:{height} {blockhash} - failed to reconstruct ShareBlock from store"
                     ));
                 }
-            }
-            None => {
-                summary.error(format!(
-                    "h:{height} {blockhash} - failed to reconstruct ShareBlock from store"
-                ));
             }
         }
 

--- a/p2poolv2_node/src/verify_chain.rs
+++ b/p2poolv2_node/src/verify_chain.rs
@@ -280,7 +280,7 @@ fn main() {
                 }
             };
 
-            if !store.share_block_exists(uncle_hash) {
+            if height >= prune_boundary && !store.share_block_exists(uncle_hash) {
                 summary.warn(format!(
                     "h:{height} {blockhash} - uncle {uncle_hash} block data missing (header-only)"
                 ));

--- a/p2poolv2_node/src/verify_chain.rs
+++ b/p2poolv2_node/src/verify_chain.rs
@@ -280,10 +280,19 @@ fn main() {
                 }
             };
 
-            if height >= prune_boundary && !store.share_block_exists(uncle_hash) {
-                summary.warn(format!(
-                    "h:{height} {blockhash} - uncle {uncle_hash} block data missing (header-only)"
-                ));
+            match store.get_block_height_from_metadata(uncle_hash) {
+                Ok(uncle_height) => {
+                    if uncle_height >= prune_boundary && !store.share_block_exists(uncle_hash) {
+                        summary.warn(format!(
+                            "h:{height} {blockhash} - uncle {uncle_hash} (uncle h:{uncle_height}) block data missing (header-only)"
+                        ));
+                    }
+                }
+                Err(error) => {
+                    summary.error(format!(
+                        "h:{height} {blockhash} - uncle {uncle_hash} metadata error: {error}"
+                    ));
+                }
             }
 
             // 10b. Uncle not referenced by another confirmed nephew


### PR DESCRIPTION
When syncing, uncles and main chain block bodies are not required. In
the checks for these bodies, skip the check for blocks below prune
depth from the currrent candidate tip.