### PR TITLE
Use protocol string instead of magic numbers

### DIFF
--- a/p2poolv2_lib/src/node/behaviour/mod.rs
+++ b/p2poolv2_lib/src/node/behaviour/mod.rs
@@ -25,7 +25,9 @@ use libp2p::{
     kad::{self, store::MemoryStore},
     swarm::NetworkBehaviour,
 };
-use request_response::{ConsensusCodec, P2PoolRequestResponseProtocol, protocol_string};
+use request_response::{
+    ConsensusCodec, P2PoolRequestResponseProtocol, kad_protocol_string, protocol_string,
+};
 use request_response::{RequestResponseBehaviour, RequestResponseEvent};
 use std::error::Error;
 use std::time::Duration;
@@ -63,11 +65,8 @@ impl P2PoolBehaviour {
         let mut kad_config = kad::Config::default();
         kad_config.set_query_timeout(tokio::time::Duration::from_secs(60));
         kad_config.set_protocol_names(vec![
-            libp2p::StreamProtocol::try_from_owned(format!(
-                "/p2pool/{}/kad/1.0.0",
-                config.stratum.network.to_core_arg()
-            ))
-            .expect("valid protocol"),
+            libp2p::StreamProtocol::try_from_owned(kad_protocol_string(config.stratum.network))
+                .expect("valid protocol"),
         ]);
 
         let mut kademlia_behaviour =

--- a/p2poolv2_lib/src/node/behaviour/mod.rs
+++ b/p2poolv2_lib/src/node/behaviour/mod.rs
@@ -26,7 +26,7 @@ use libp2p::{
     kad::{self, store::MemoryStore},
     swarm::NetworkBehaviour,
 };
-use request_response::{ConsensusCodec, P2PoolRequestResponseProtocol};
+use request_response::{ConsensusCodec, P2PoolRequestResponseProtocol, protocol_string};
 use request_response::{RequestResponseBehaviour, RequestResponseEvent};
 use std::error::Error;
 use std::time::Duration;
@@ -63,14 +63,20 @@ impl P2PoolBehaviour {
         let store = MemoryStore::new(local_key.public().to_peer_id());
         let mut kad_config = kad::Config::default();
         kad_config.set_query_timeout(tokio::time::Duration::from_secs(60));
-        kad_config.set_protocol_names(vec![libp2p::StreamProtocol::new("/p2pool/kad/1.0.0")]);
+        kad_config.set_protocol_names(vec![
+            libp2p::StreamProtocol::try_from_owned(format!(
+                "/p2pool/{}/kad/1.0.0",
+                config.stratum.network.to_core_arg()
+            ))
+            .expect("valid protocol"),
+        ]);
 
         let mut kademlia_behaviour =
             kad::Behaviour::with_config(local_key.public().to_peer_id(), store, kad_config);
         kademlia_behaviour.set_mode(Some(kad::Mode::Server));
 
         let identify_config =
-            identify::Config::new("/p2pool/1.0.0".to_string(), local_key.public())
+            identify::Config::new(protocol_string(config.stratum.network), local_key.public())
                 .with_agent_version(format!("p2poolv2/{}", env!("CARGO_PKG_VERSION")))
                 .with_push_listen_addr_updates(true);
         let identify_behaviour = identify::Behaviour::new(identify_config);
@@ -104,7 +110,10 @@ impl P2PoolBehaviour {
             ping: ping_behaviour,
             request_response: RequestResponseBehaviour::with_codec(
                 codec,
-                std::iter::once((P2PoolRequestResponseProtocol::new(), ProtocolSupport::Full)),
+                std::iter::once((
+                    P2PoolRequestResponseProtocol::new(config.stratum.network),
+                    ProtocolSupport::Full,
+                )),
                 libp2p::request_response::Config::default(),
             ),
             limits,

--- a/p2poolv2_lib/src/node/behaviour/mod.rs
+++ b/p2poolv2_lib/src/node/behaviour/mod.rs
@@ -64,10 +64,9 @@ impl P2PoolBehaviour {
         let store = MemoryStore::new(local_key.public().to_peer_id());
         let mut kad_config = kad::Config::default();
         kad_config.set_query_timeout(tokio::time::Duration::from_secs(60));
-        kad_config.set_protocol_names(vec![
-            libp2p::StreamProtocol::try_from_owned(kad_protocol_string(config.stratum.network))
-                .expect("valid protocol"),
-        ]);
+        kad_config.set_protocol_names(vec![libp2p::StreamProtocol::try_from_owned(
+            kad_protocol_string(config.stratum.network),
+        )?]);
 
         let mut kademlia_behaviour =
             kad::Behaviour::with_config(local_key.public().to_peer_id(), store, kad_config);

--- a/p2poolv2_lib/src/node/behaviour/mod.rs
+++ b/p2poolv2_lib/src/node/behaviour/mod.rs
@@ -16,7 +16,6 @@
 
 pub mod request_response;
 use crate::config::Config;
-use crate::node::messages::network_magic;
 use libp2p::connection_limits;
 use libp2p::ping;
 use libp2p::request_response::ProtocolSupport;
@@ -89,17 +88,6 @@ impl P2PoolBehaviour {
             .with_max_established_per_peer(Some(config.network.max_established_per_peer));
         let limits = connection_limits::Behaviour::new(limits_config);
 
-        // Select the appropriate network magic based on the bitcoin network
-        let magic = match config.stratum.network {
-            bitcoin::Network::Bitcoin => network_magic::MAINNET,
-            bitcoin::Network::Testnet => network_magic::TESTNET,
-            bitcoin::Network::Signet => network_magic::SIGNET,
-            bitcoin::Network::Regtest => network_magic::REGTEST,
-            _ => network_magic::REGTEST, // Default to regtest for unknown networks
-        };
-
-        let codec = ConsensusCodec::new(magic);
-
         let ping_config =
             ping::Config::new().with_interval(Duration::from_secs(PING_INTERVAL_SECS));
         let ping_behaviour = ping::Behaviour::new(ping_config);
@@ -109,7 +97,7 @@ impl P2PoolBehaviour {
             identify: identify_behaviour,
             ping: ping_behaviour,
             request_response: RequestResponseBehaviour::with_codec(
-                codec,
+                ConsensusCodec,
                 std::iter::once((
                     P2PoolRequestResponseProtocol::new(config.stratum.network),
                     ProtocolSupport::Full,

--- a/p2poolv2_lib/src/node/behaviour/request_response.rs
+++ b/p2poolv2_lib/src/node/behaviour/request_response.rs
@@ -22,19 +22,24 @@ use std::io;
 
 use crate::node::messages::{Message, RawMessage, network_magic};
 
+/// Build the network-aware libp2p protocol string for a given bitcoin network.
+///
+/// Network isolation is enforced through protocol negotiation: nodes on
+/// different networks derive different protocol strings and therefore fail to
+/// negotiate a shared protocol. Centralizing construction here keeps the string
+/// consistent across the request-response protocol, Kademlia, Identify, and the
+/// Noise prologue, and gives a single place to extend for a future network_id.
+pub fn protocol_string(network: bitcoin::Network) -> String {
+    format!("/p2pool/{}/1.0.0", network.to_core_arg())
+}
+
 // Protocol name for our request-response protocol
 #[derive(Debug, Clone)]
 pub struct P2PoolRequestResponseProtocol(String);
 
 impl P2PoolRequestResponseProtocol {
-    pub fn new() -> Self {
-        Self("/p2pool/1.0.0".to_string())
-    }
-}
-
-impl Default for P2PoolRequestResponseProtocol {
-    fn default() -> Self {
-        Self::new()
+    pub fn new(network: bitcoin::Network) -> Self {
+        Self(protocol_string(network))
     }
 }
 

--- a/p2poolv2_lib/src/node/behaviour/request_response.rs
+++ b/p2poolv2_lib/src/node/behaviour/request_response.rs
@@ -16,11 +16,12 @@
 
 use async_trait::async_trait;
 use bitcoin::consensus::{Decodable, Encodable};
+use bitcoin::hashes::{Hash, sha256d};
 use libp2p::futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::request_response::{Codec, OutboundFailure};
 use std::io;
 
-use crate::node::messages::{Message, RawMessage, network_magic};
+use crate::node::messages::{Message, RawMessage};
 
 /// Build the network-aware libp2p protocol string for a given bitcoin network.
 ///
@@ -51,44 +52,44 @@ impl AsRef<str> for P2PoolRequestResponseProtocol {
 
 // Consensus codec implementation using RawMessage for request-response protocols
 #[derive(Clone)]
-pub struct ConsensusCodec {
-    magic: [u8; 4],
-}
-
-impl ConsensusCodec {
-    pub fn new(magic: [u8; 4]) -> Self {
-        Self { magic }
-    }
-}
-
-impl Default for ConsensusCodec {
-    fn default() -> Self {
-        Self {
-            magic: network_magic::REGTEST,
-        }
-    }
-}
+pub struct ConsensusCodec;
 
 impl ConsensusCodec {
     async fn read_message<T>(&self, io: &mut T) -> io::Result<Message>
     where
         T: AsyncRead + Unpin + Send,
     {
-        // Read header: magic (4) + payload_len (4) + checksum (4) = 12 bytes
-        let mut header_bytes = [0u8; 12];
+        // Read header: payload_len (4) + checksum (4) = 8 bytes
+        let mut header_bytes = [0u8; 8];
         io.read_exact(&mut header_bytes).await?;
 
-        // Parse payload length from header
+        // Parse payload length and checksum from header
         let payload_len = u32::from_le_bytes([
+            header_bytes[0],
+            header_bytes[1],
+            header_bytes[2],
+            header_bytes[3],
+        ]);
+        let expected_checksum = [
             header_bytes[4],
             header_bytes[5],
             header_bytes[6],
             header_bytes[7],
-        ]);
+        ];
 
         // Read exactly payload_len bytes
         let mut payload_bytes = vec![0u8; payload_len as usize];
         io.read_exact(&mut payload_bytes).await?;
+
+        // Verify the payload checksum before decoding
+        let hash = sha256d::Hash::hash(&payload_bytes);
+        let actual_checksum = [hash[0], hash[1], hash[2], hash[3]];
+        if actual_checksum != expected_checksum {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Checksum mismatch",
+            ));
+        }
 
         let message = Message::consensus_decode(&mut &payload_bytes[..])
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
@@ -100,7 +101,7 @@ impl ConsensusCodec {
     where
         T: AsyncWrite + Unpin + Send,
     {
-        let raw_msg = RawMessage::new(self.magic, msg);
+        let raw_msg = RawMessage::new(msg);
         let mut bytes = Vec::new();
         raw_msg
             .consensus_encode(&mut bytes)

--- a/p2poolv2_lib/src/node/behaviour/request_response.rs
+++ b/p2poolv2_lib/src/node/behaviour/request_response.rs
@@ -28,10 +28,19 @@ use crate::node::messages::{Message, RawMessage};
 /// Network isolation is enforced through protocol negotiation: nodes on
 /// different networks derive different protocol strings and therefore fail to
 /// negotiate a shared protocol. Centralizing construction here keeps the string
-/// consistent across the request-response protocol, Kademlia, Identify, and the
-/// Noise prologue, and gives a single place to extend for a future network_id.
+/// consistent across the request-response protocol, Identify, and the Noise
+/// prologue, and gives a single place to extend for a future network_id.
 pub fn protocol_string(network: bitcoin::Network) -> String {
     format!("/p2pool/{}/1.0.0", network.to_core_arg())
+}
+
+/// Build the network-aware Kademlia protocol string for a given bitcoin network.
+///
+/// Kademlia uses a distinct protocol name from [`protocol_string`] but shares
+/// the same per-network segment, so it is derived here to keep both in step for
+/// a future network_id.
+pub fn kad_protocol_string(network: bitcoin::Network) -> String {
+    format!("/p2pool/{}/kad/1.0.0", network.to_core_arg())
 }
 
 // Protocol name for our request-response protocol

--- a/p2poolv2_lib/src/node/behaviour/request_response.rs
+++ b/p2poolv2_lib/src/node/behaviour/request_response.rs
@@ -17,6 +17,7 @@
 use async_trait::async_trait;
 use bitcoin::consensus::{Decodable, Encodable};
 use bitcoin::hashes::{Hash, sha256d};
+use bitcoin::p2p::message::MAX_MSG_SIZE;
 use libp2p::futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::request_response::{Codec, OutboundFailure};
 use std::io;
@@ -86,8 +87,18 @@ impl ConsensusCodec {
             header_bytes[7],
         ];
 
+        // Reject an oversized advertised length before allocating, so a
+        // malicious peer cannot trigger a multi-gigabyte allocation / OOM.
+        let payload_len = payload_len as usize;
+        if payload_len > MAX_MSG_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Payload length exceeds maximum message size",
+            ));
+        }
+
         // Read exactly payload_len bytes
-        let mut payload_bytes = vec![0u8; payload_len as usize];
+        let mut payload_bytes = vec![0u8; payload_len];
         io.read_exact(&mut payload_bytes).await?;
 
         // Verify the payload checksum before decoding

--- a/p2poolv2_lib/src/node/messages.rs
+++ b/p2poolv2_lib/src/node/messages.rs
@@ -49,19 +49,6 @@ mod getdata_discriminants {
     pub const TXID: u8 = 1;
 }
 
-/// Network magic bytes for different P2Poolv2 networks
-/// Chosen at random.
-pub mod network_magic {
-    /// Mainnet P2Poolv2
-    pub const MAINNET: [u8; 4] = [0x5a, 0xf0, 0x19, 0x13];
-    /// Testnet P2Poolv2
-    pub const TESTNET: [u8; 4] = [0xbc, 0xc7, 0x13, 0xc6];
-    /// Signet P2Poolv2
-    pub const SIGNET: [u8; 4] = [0x44, 0xe0, 0x9a, 0x44];
-    /// Regtest P2Poolv2
-    pub const REGTEST: [u8; 4] = [0x3f, 0x8e, 0xa2, 0xd8];
-}
-
 /// P2P network messages, encoded using bitcoin consensus_encode
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Message {
@@ -92,11 +79,13 @@ pub struct HandshakeData {
     pub tip_hash: BlockHash,
 }
 
-/// A complete P2P network message with protocol framing
+/// A complete P2P network message with protocol framing.
+///
+/// Network isolation is enforced at the libp2p protocol negotiation and Noise
+/// prologue layers (see `behaviour::request_response::protocol_string`), so the
+/// wire framing carries no network magic bytes.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RawMessage {
-    /// Network magic bytes (4 bytes identifier)
-    pub magic: [u8; 4],
     /// The actual message payload
     pub payload: Message,
     /// Length of the payload in bytes
@@ -106,9 +95,9 @@ pub struct RawMessage {
 }
 
 impl RawMessage {
-    /// Create a new RawMessage from magic bytes and a Message
+    /// Create a new RawMessage from a Message
     /// Automatically computes payload_len and checksum
-    pub fn new(magic: [u8; 4], payload: Message) -> Self {
+    pub fn new(payload: Message) -> Self {
         // Encode payload to calculate length and checksum
         let mut engine = sha256d::Hash::engine();
         let payload_len = payload
@@ -121,7 +110,6 @@ impl RawMessage {
         let checksum = [hash[0], hash[1], hash[2], hash[3]];
 
         Self {
-            magic,
             payload,
             payload_len,
             checksum,
@@ -137,16 +125,11 @@ impl RawMessage {
     pub fn payload(&self) -> &Message {
         &self.payload
     }
-
-    /// Get the magic bytes
-    pub fn magic(&self) -> &[u8; 4] {
-        &self.magic
-    }
 }
 
 impl Display for RawMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "RawMessage(magic: {:?}, {})", self.magic, self.payload)
+        write!(f, "RawMessage({})", self.payload)
     }
 }
 
@@ -318,7 +301,6 @@ impl Decodable for Message {
 impl Encodable for RawMessage {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, bitcoin::io::Error> {
         let mut len = 0;
-        len += self.magic.consensus_encode(w)?;
         len += self.payload_len.consensus_encode(w)?;
         len += self.checksum.consensus_encode(w)?;
         len += self.payload.consensus_encode(w)?;
@@ -329,7 +311,6 @@ impl Encodable for RawMessage {
 impl Decodable for RawMessage {
     fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         // Read header
-        let magic: [u8; 4] = Decodable::consensus_decode(r)?;
         let payload_len: u32 = Decodable::consensus_decode(r)?;
         let expected_checksum: [u8; 4] = Decodable::consensus_decode(r)?;
 
@@ -347,7 +328,6 @@ impl Decodable for RawMessage {
         let payload = Message::consensus_decode(&mut &payload_bytes[..])?;
 
         Ok(RawMessage {
-            magic,
             payload_len,
             checksum: expected_checksum,
             payload,
@@ -449,7 +429,7 @@ mod tests {
                 .unwrap(),
         ];
         let msg = Message::Inventory(InventoryMessage::BlockHashes(block_hashes.clone()));
-        let raw = RawMessage::new(network_magic::REGTEST, msg.clone());
+        let raw = RawMessage::new(msg.clone());
 
         // Test encoding
         let mut encoded = Vec::new();
@@ -458,7 +438,6 @@ mod tests {
         // Test decoding
         let decoded = RawMessage::consensus_decode(&mut &encoded[..]).unwrap();
 
-        assert_eq!(decoded.magic, network_magic::REGTEST);
         assert_eq!(decoded.payload, msg);
         assert_eq!(decoded.payload_len, raw.payload_len);
         assert_eq!(decoded.checksum, raw.checksum);
@@ -467,32 +446,18 @@ mod tests {
     #[test]
     fn test_raw_message_checksum_verification() {
         let msg = Message::NotFound(GetData::Block(BlockHash::all_zeros()));
-        let raw = RawMessage::new(network_magic::MAINNET, msg);
+        let raw = RawMessage::new(msg);
 
         let mut encoded = Vec::new();
         raw.consensus_encode(&mut encoded).unwrap();
 
-        // Corrupt the checksum
-        encoded[8] ^= 0xFF;
+        // Corrupt the checksum. The header is now payload_len (4 bytes) followed
+        // by the checksum (4 bytes), so the checksum starts at byte 4.
+        encoded[4] ^= 0xFF;
 
         // Decoding should fail
         let result = RawMessage::consensus_decode(&mut &encoded[..]);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_raw_message_different_networks() {
-        let msg = Message::NotFound(GetData::Block(BlockHash::all_zeros()));
-
-        let raw_mainnet = RawMessage::new(network_magic::MAINNET, msg.clone());
-        let raw_testnet = RawMessage::new(network_magic::TESTNET, msg.clone());
-        let raw_signet = RawMessage::new(network_magic::SIGNET, msg.clone());
-        let raw_regtest = RawMessage::new(network_magic::REGTEST, msg);
-
-        assert_eq!(raw_mainnet.magic, network_magic::MAINNET);
-        assert_eq!(raw_testnet.magic, network_magic::TESTNET);
-        assert_eq!(raw_signet.magic, network_magic::SIGNET);
-        assert_eq!(raw_regtest.magic, network_magic::REGTEST);
     }
 
     #[test]

--- a/p2poolv2_lib/src/node/messages.rs
+++ b/p2poolv2_lib/src/node/messages.rs
@@ -18,6 +18,7 @@ use crate::shares::share_block::{ShareBlock, ShareHeader, Txids};
 use bitcoin::consensus::{Decodable, Encodable, encode};
 use bitcoin::hashes::{Hash, sha256d};
 use bitcoin::io::{Read, Write};
+use bitcoin::p2p::message::MAX_MSG_SIZE;
 use bitcoin::{BlockHash, Txid, VarInt};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -199,9 +200,7 @@ impl Decodable for ShareHeaderDeserializationWrapper {
 
     #[inline]
     fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        Self::consensus_decode_from_finite_reader(
-            &mut r.take(bitcoin::p2p::message::MAX_MSG_SIZE as u64),
-        )
+        Self::consensus_decode_from_finite_reader(&mut r.take(MAX_MSG_SIZE as u64))
     }
 }
 
@@ -313,6 +312,14 @@ impl Decodable for RawMessage {
         // Read header
         let payload_len: u32 = Decodable::consensus_decode(r)?;
         let expected_checksum: [u8; 4] = Decodable::consensus_decode(r)?;
+
+        // Reject an oversized advertised length before allocating, so a
+        // malicious peer cannot trigger a multi-gigabyte allocation / OOM.
+        if payload_len as usize > MAX_MSG_SIZE {
+            return Err(encode::Error::ParseFailed(
+                "Payload length exceeds maximum message size",
+            ));
+        }
 
         // Read payload into buffer
         let mut payload_bytes = vec![0u8; payload_len as usize];
@@ -456,6 +463,19 @@ mod tests {
         encoded[4] ^= 0xFF;
 
         // Decoding should fail
+        let result = RawMessage::consensus_decode(&mut &encoded[..]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_message_rejects_oversized_payload_len() {
+        // A malicious peer advertises a payload length larger than the maximum
+        // message size. Decoding must reject it without allocating the buffer.
+        let payload_len = (MAX_MSG_SIZE as u32) + 1;
+        let mut encoded = Vec::new();
+        encoded.extend_from_slice(&payload_len.to_le_bytes());
+        encoded.extend_from_slice(&[0u8; 4]); // checksum placeholder
+
         let result = RawMessage::consensus_decode(&mut &encoded[..]);
         assert!(result.is_err());
     }

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -43,6 +43,7 @@ use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::chain::chain_store_handle::ChainStoreHandle;
 use crate::shares::share_block::ShareBlock;
 use crate::shares::validation::ShareValidator;
+use behaviour::request_response::protocol_string;
 use behaviour::{P2PoolBehaviour, P2PoolBehaviourEvent};
 use bitcoin::BlockHash;
 use libp2p::PeerId;
@@ -145,7 +146,8 @@ impl Node {
 
         let tcp_config = TcpConfig::default().nodelay(true);
         let noise_config = match libp2p::noise::Config::new(&id_keys) {
-            Ok(cfg) => cfg,
+            //* Bind the handshake to this network via a prologue
+            Ok(cfg) => cfg.with_prologue(protocol_string(config.stratum.network).into_bytes()),
             Err(err) => {
                 error!("Failed to create Noise config: {}", err);
                 return Err(Box::new(err));


### PR DESCRIPTION
We are going to depend on libp2p network string and magic numbers are
checked much later than libp2p checks the network string.

When we later implement QUIC, we will need to validate the string in a
higher layer, but for TCP/Noise this is the right thing to do.

Earlier all network, main, regtest, signet were using the same
protocol string.

Closes #572 
