### PR TITLE
Organise header when storing locally mined block

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Run tests
         run: cargo nextest run --workspace
 
+      - name: Run sim-feature tests
+        run: "cargo nextest run -p p2poolv2_lib --features sim sim::"
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
         run: cargo nextest run --workspace
 
       - name: Run sim-feature tests
-        run: "cargo nextest run -p p2poolv2_lib --features sim sim::"
+        run: cargo nextest run -p p2poolv2_lib --features sim
 
   coverage:
     name: Code Coverage

--- a/justfile
+++ b/justfile
@@ -25,13 +25,14 @@ _default:
     echo 'You can easily run a local cluster with `just compose`'
 
 # Run tests for entire workspace or a specific package.
-# The full-workspace run (no package arg) adds a second pass that runs only
-# the `sim`-feature-gated tests (compiled with --features sim), so the default
-# pass above is not re-run. CI's --all-features coverage job runs the whole
-# suite in sim mode; this just catches sim-gated test breakage locally.
+# The full-workspace run (no package arg) adds a second pass that runs the
+# whole p2poolv2_lib suite with the `sim` feature enabled. p2poolv2_lib is the
+# only crate with sim-conditional code, so this covers every sim-gated test
+# without a fragile name filter. The lib already recompiles under `--features
+# sim` regardless, so the extra cost is only re-executing the unit tests.
 test package="":
     cargo nextest run {{ if package == "" { "" } else { "-p " + package } }}
-    {{ if package == "" { "cargo nextest run -p p2poolv2_lib --features sim sim::" } else { "true" } }}
+    {{ if package == "" { "cargo nextest run -p p2poolv2_lib --features sim" } else { "true" } }}
 
 # Run a specific test in a package with debug logging and no output capture
 debug-test package="p2poolv2_tests" testname="":

--- a/justfile
+++ b/justfile
@@ -24,9 +24,14 @@ _default:
     echo 'Edit the ./config-dev.toml file for your specific needs'
     echo 'You can easily run a local cluster with `just compose`'
 
-# Run tests for entire workspace or a specific package
+# Run tests for entire workspace or a specific package.
+# The full-workspace run (no package arg) adds a second pass that runs only
+# the `sim`-feature-gated tests (compiled with --features sim), so the default
+# pass above is not re-run. CI's --all-features coverage job runs the whole
+# suite in sim mode; this just catches sim-gated test breakage locally.
 test package="":
     cargo nextest run {{ if package == "" { "" } else { "-p " + package } }}
+    {{ if package == "" { "cargo nextest run -p p2poolv2_lib --features sim sim::" } else { "true" } }}
 
 # Run a specific test in a package with debug logging and no output capture
 debug-test package="p2poolv2_tests" testname="":

--- a/p2poolv2_lib/src/node/emission_worker.rs
+++ b/p2poolv2_lib/src/node/emission_worker.rs
@@ -205,8 +205,8 @@ mod tests {
 
         let mut mock_chain_store = ChainStoreHandle::default();
         mock_chain_store
-            .expect_add_share_block()
-            .returning(|_| Ok(()));
+            .expect_add_share_block_and_organise_header()
+            .returning(|_| Ok(None));
 
         let worker = EmissionWorker::new(emissions_rx, mock_chain_store, validation_tx);
         let worker_handle = tokio::spawn(worker.run());
@@ -269,9 +269,9 @@ mod tests {
             .times(1)
             .returning(|_| Err(StoreError::ChannelClosed));
         mock_chain_store
-            .expect_add_share_block()
+            .expect_add_share_block_and_organise_header()
             .times(1)
-            .returning(|_| Ok(()));
+            .returning(|_| Ok(None));
 
         let worker = EmissionWorker::new(emissions_rx, mock_chain_store, validation_tx);
         let worker_handle = tokio::spawn(worker.run());

--- a/p2poolv2_lib/src/shares/handle_stratum_share.rs
+++ b/p2poolv2_lib/src/shares/handle_stratum_share.rs
@@ -99,10 +99,11 @@ pub async fn handle_stratum_share(
             share_block.transactions.len()
         );
 
-        // Store share block via ChainStoreHandle. This is later
-        // organised in emission worker once this function returns.
+        // Persist the share block and organise its header onto the
+        // candidate chain in a single atomic write, matching the block
+        // receiver path.
         chain_store_handle
-            .add_share_block(share_block.clone())
+            .add_share_block_and_organise_header(share_block.clone())
             .await
             .map_err(|e| format!("Failed to add share to chain: {e}"))?;
 
@@ -251,8 +252,8 @@ mod tests {
 
         // Mock add_share to succeed
         mock_chain_store
-            .expect_add_share_block()
-            .returning(|_| Ok(()));
+            .expect_add_share_block_and_organise_header()
+            .returning(|_| Ok(None));
 
         let emission = create_test_emission_with_commitment();
 
@@ -265,6 +266,35 @@ mod tests {
         let share_block = share_block.unwrap();
         // Verify the share block has the expected structure
         assert_eq!(share_block.transactions.len(), 1); // One share coinbase
+    }
+
+    /// Regression test: a locally mined share must be persisted and have
+    /// its header organised onto the candidate chain atomically, exactly
+    /// like the block receiver path.
+    ///
+    /// Organising the header writes the block metadata up front. If the
+    /// share were persisted without it (the body-only `add_share_block`
+    /// path), a chain-context validation rejection in the organise worker
+    /// would leave the share in the DAG with a parent->child edge but no
+    /// metadata. A later share building on it would drive the confirm walk
+    /// into `get_block_metadata` -> NotFound and wedge the confirmed chain
+    /// permanently. No expectation is set for the body-only path, so
+    /// reverting to it would panic this test.
+    #[tokio::test]
+    async fn test_handle_stratum_share_organises_header_atomically() {
+        let mut mock_chain_store = ChainStoreHandle::default();
+
+        mock_chain_store
+            .expect_add_share_block_and_organise_header()
+            .times(1)
+            .returning(|_| Ok(None));
+
+        let emission = create_test_emission_with_commitment();
+
+        let result = handle_stratum_share(emission, &mock_chain_store).await;
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_some());
     }
 
     #[tokio::test]
@@ -291,8 +321,8 @@ mod tests {
 
         // Mock add_share to succeed
         mock_chain_store
-            .expect_add_share_block()
-            .returning(|_| Ok(()));
+            .expect_add_share_block_and_organise_header()
+            .returning(|_| Ok(None));
 
         let emission = create_test_emission_with_commitment();
         let expected_commitment = emission.share_commitment.clone().unwrap();
@@ -329,8 +359,8 @@ mod tests {
 
         // Mock add_share to succeed
         mock_chain_store
-            .expect_add_share_block()
-            .returning(|_| Ok(()));
+            .expect_add_share_block_and_organise_header()
+            .returning(|_| Ok(None));
 
         // Create emission with some bitcoin transactions
         let pplns = SimplePplnsShare {

--- a/p2poolv2_lib/src/sim/share.rs
+++ b/p2poolv2_lib/src/sim/share.rs
@@ -232,7 +232,9 @@ mod tests {
 
         // Run through the real pipeline to produce the ShareBlock peers see.
         let mut store = ChainStoreHandle::default();
-        store.expect_add_share_block().returning(|_| Ok(()));
+        store
+            .expect_add_share_block_and_organise_header()
+            .returning(|_| Ok(None));
         let share_block = handle_stratum_share(emission, &store)
             .await
             .expect("handle ok")


### PR DESCRIPTION
We were not storing metadata for locally mined blocks until validated. This was different from the receieved shares where we store block and metadata atomically. The difference resulted in a sync failure under time sped up nightly simulation.