### PR TITLE
Close Stratum sockets before worker accounting

### DIFF
--- a/p2poolv2_lib/src/accounting/stats/metrics.rs
+++ b/p2poolv2_lib/src/accounting/stats/metrics.rs
@@ -382,6 +382,23 @@ pub struct MetricsHandle {
 }
 
 impl MetricsHandle {
+    #[cfg(test)]
+    pub(crate) fn delayed_for_test() -> (Self, oneshot::Receiver<()>, oneshot::Sender<()>) {
+        let (sender, mut receiver) = mpsc::channel(1);
+        let (received_tx, received_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            if let Some(message) = receiver.recv().await {
+                let _ = received_tx.send(());
+                let _ = release_rx.await;
+                drop(message);
+            }
+        });
+
+        (Self { sender }, received_rx, release_tx)
+    }
+
     /// Record an accepted share with the given difficulty
     pub async fn record_share_accepted(
         &self,

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -600,6 +600,11 @@ where
             }
         }
     }
+    // Close the TCP writer before awaiting accounting. If accounting is
+    // delayed, retaining the write half leaves the socket in CLOSE_WAIT.
+    let _ = writer.shutdown().await;
+    drop(writer);
+
     let _ = ctx
         .metrics
         .decrement_worker_count(
@@ -678,6 +683,7 @@ mod stratum_server_tests {
     use bitcoindrpc::test_utils::setup_mock_bitcoin_rpc;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::Arc;
+    use tokio::io::AsyncReadExt;
     use tokio::sync::mpsc;
 
     #[tokio::test]
@@ -753,6 +759,75 @@ mod stratum_server_tests {
 
         // Wait for the task to complete
         let _ = server_handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_handle_connection_closes_writer_before_accounting() {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+        let (_mock_rpc_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+        let (message_tx, message_rx) = mpsc::channel(1);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (notify_tx, _notify_rx) = mpsc::channel(1);
+        let (emissions_tx, _emissions_rx) = mpsc::channel(1);
+        let tracker_handle = start_tracker_actor();
+        let (chain_store_handle, _temp_dir) = setup_test_chain_store_handle(true).await;
+        let (metrics_handle, accounting_started_rx, release_accounting_tx) =
+            metrics::MetricsHandle::delayed_for_test();
+        let ctx = StratumContext {
+            notify_tx,
+            tracker_handle,
+            bitcoindrpc_client: BitcoindRpcClient::new(
+                &bitcoinrpc_config.url,
+                &bitcoinrpc_config.username,
+                &bitcoinrpc_config.password,
+            )
+            .unwrap(),
+            start_difficulty: 1,
+            minimum_difficulty: 1,
+            maximum_difficulty: Some(2),
+            ignore_difficulty: false,
+            validate_addresses: true,
+            emissions_tx,
+            network: bitcoin::Network::Regtest,
+            metrics: metrics_handle,
+            chain_store_handle,
+            mode: PoolMode::P2poolv2,
+        };
+        let (template_tx, template_rx) = watch::channel(None);
+        let (writer, mut peer) = tokio::io::duplex(64);
+
+        let handler = tokio::spawn(async move {
+            let _message_tx = message_tx;
+            let _shutdown_tx = shutdown_tx;
+            let _template_tx = template_tx;
+            handle_connection(
+                tokio::io::empty(),
+                writer,
+                addr,
+                message_rx,
+                shutdown_rx,
+                0x1fffe000,
+                ctx,
+                &SystemTimeProvider {},
+                template_rx,
+            )
+            .await
+        });
+
+        accounting_started_rx
+            .await
+            .expect("worker accounting should start");
+
+        let mut byte = [0u8; 1];
+        let bytes_read =
+            tokio::time::timeout(tokio::time::Duration::from_secs(1), peer.read(&mut byte))
+                .await
+                .expect("writer should close before accounting finishes")
+                .expect("peer read should succeed");
+        assert_eq!(bytes_read, 0, "peer should observe EOF");
+
+        let _ = release_accounting_tx.send(());
+        assert!(handler.await.unwrap().is_ok());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- shut down and drop each Stratum TCP writer before awaiting worker-accounting cleanup
- add a regression test that deliberately stalls metrics accounting and verifies that the client has already observed EOF

## Root cause

When a Stratum connection exits the normal receive loop, `handle_connection` currently awaits `decrement_worker_count(...)` before its owned writer is dropped. The metrics call sends to an actor and waits for its response. If that actor is delayed or backpressured, the task retains the TCP write half, leaving a client-closed connection in `CLOSE_WAIT` until accounting finishes.

Under sustained reconnect traffic this can accumulate sockets, tasks, file descriptors, and memory. The explicit `shutdown()` and `drop()` move transport cleanup ahead of non-critical accounting while preserving the existing best-effort metrics update.

## Field observation

This was found in a Hydrapool deployment using an older P2PoolV2-based fork, then confirmed to have the same cleanup ordering on current upstream `main`.

After roughly 11 days under frequently reconnecting Stratum clients, the affected process had:

- 19,881 sockets in `CLOSE_WAIT`
- approximately 58,916 open file descriptors
- approximately 13.1 GB RSS

After applying this teardown change and restarting under the same client traffic, it held at:

- 0 sockets in `CLOSE_WAIT`
- approximately 420 open file descriptors
- approximately 114-133 MB RSS using a release build

Hydrapool exposed the issue, but the affected implementation is the shared P2PoolV2 Stratum server and can affect either pool mode.

## Validation

The new test uses a deliberately delayed metrics actor. It waits until worker-accounting cleanup has started, then asserts that the remote side of a duplex stream already sees EOF. This directly enforces the required teardown ordering.

Commands run:

```text
cargo fmt --all -- --check
cargo test -p p2poolv2_lib test_handle_connection_closes_writer_before_accounting --lib
cargo test -p p2poolv2_lib stratum::server::stratum_server_tests --lib
```

All 14 Stratum server tests passed, including the new regression test.
