### PR TITLE
Log warning when sharechain fork is detected

### DIFF
--- a/p2poolv2_lib/src/store/organise/candidate.rs
+++ b/p2poolv2_lib/src/store/organise/candidate.rs
@@ -448,6 +448,8 @@ impl Store {
     /// candidate or confirmed chain. Delegates to
     /// `reorg_candidate_from_candidate` or
     /// `reorg_candidate_from_confirmed` depending on the branch point.
+    ///
+    /// On success, logs a reorg notice (info for shallow, warn for deep).
     pub(super) fn reorg_candidate(
         &self,
         blockhash: &BlockHash,
@@ -465,11 +467,38 @@ impl Store {
             StoreError::NotFound("Empty branch returned from get_branch_to_chain.".into())
         })?;
 
-        if self.is_confirmed(branch_point) {
-            self.reorg_candidate_from_confirmed(&branch, batch)
+        let fork_point_height = self
+            .get_block_metadata(branch_point)?
+            .expected_height
+            .ok_or_else(|| {
+                StoreError::NotFound(
+                    "Branch point metadata missing expected_height for candidate reorg".into(),
+                )
+            })?;
+
+        let (new_height, new_chain) = if self.is_confirmed(branch_point) {
+            self.reorg_candidate_from_confirmed(&branch, batch)?
         } else {
-            self.reorg_candidate_from_candidate(&branch, top_candidate, batch)
+            self.reorg_candidate_from_candidate(&branch, top_candidate, batch)?
+        };
+
+        if let Some(old_tip) = top_candidate {
+            let (new_tip_height, new_tip_hash) = new_chain.last().ok_or_else(|| {
+                StoreError::NotFound("Empty new candidate chain after reorg".into())
+            })?;
+            let depth = super::reorg_depth(old_tip.height, fork_point_height);
+            super::log_reorg(
+                "candidate",
+                depth,
+                fork_point_height,
+                &old_tip.hash,
+                old_tip.height,
+                new_tip_hash,
+                *new_tip_height,
+            );
         }
+
+        Ok((new_height, new_chain))
     }
 
     /// Reorg when the branch point is on the candidate chain.

--- a/p2poolv2_lib/src/store/organise/confirmed.rs
+++ b/p2poolv2_lib/src/store/organise/confirmed.rs
@@ -147,6 +147,14 @@ impl Store {
         let fork_point = fork_branch.front().ok_or_else(|| {
             StoreError::NotFound("Empty branch returned from get_branch_to_chain.".into())
         })?;
+        let fork_point_height = self
+            .get_block_metadata(fork_point)?
+            .expected_height
+            .ok_or_else(|| {
+                StoreError::NotFound(
+                    "Fork point metadata missing expected_height for confirmed reorg".into(),
+                )
+            })?;
 
         // Do not reorg if any block above the prune boundary lacks body data.
         let fork_hashes: Vec<BlockHash> = fork_branch.iter().copied().collect();
@@ -173,6 +181,7 @@ impl Store {
 
         // Write new fork entries and update their metadata status to Confirmed
         let mut new_top_height = 0u32;
+        let mut new_tip_hash = *fork_point;
         for to_confirm in &fork_branch {
             let mut metadata = self.get_block_metadata(to_confirm)?;
             let height = metadata.expected_height.ok_or_else(|| {
@@ -186,10 +195,22 @@ impl Store {
             self.update_block_metadata(to_confirm, &metadata, batch)?;
 
             new_top_height = height;
+            new_tip_hash = *to_confirm;
         }
 
         self.set_top_confirmed_height(new_top_height, batch);
-        tracing::info!("Chain reorg completed to height {new_top_height}");
+
+        let depth = super::reorg_depth(top_confirmed.height, fork_point_height);
+        super::log_reorg(
+            "confirmed",
+            depth,
+            fork_point_height,
+            &top_confirmed.hash,
+            top_confirmed.height,
+            &new_tip_hash,
+            new_top_height,
+        );
+
         Ok(Some(new_top_height))
     }
 

--- a/p2poolv2_lib/src/store/organise/mod.rs
+++ b/p2poolv2_lib/src/store/organise/mod.rs
@@ -17,6 +17,7 @@
 use super::{ColumnFamily, Store, writer::StoreError};
 use bitcoin::{BlockHash, Work, consensus::encode};
 use std::collections::VecDeque;
+use tracing::{info, warn};
 
 mod candidate;
 mod confirmed;
@@ -24,6 +25,10 @@ pub mod organise_block;
 pub mod organise_header;
 
 const BRANCH_INITIAL_CAPACITY: usize = 16;
+
+/// Reorgs at least this deep are logged at `warn!` (shallower at `info!`).
+/// Mirrors bitcoind's "more than 6 blocks" threshold for deep chain divergence.
+const DEEP_REORG_DEPTH: u32 = 6;
 
 /// Type to capture candidate and confirmed chains as vector of
 /// height, blockhash pairs
@@ -43,6 +48,36 @@ pub(crate) struct TopResult {
 /// Returns key for height with provided suffix
 pub(super) fn height_to_key_with_suffix(height: Height, suffix: &str) -> Vec<u8> {
     [&height.to_be_bytes(), suffix.as_bytes()].concat()
+}
+
+/// Number of blocks unwound from the old tip back to the fork point.
+fn reorg_depth(old_tip_height: Height, fork_point_height: Height) -> u32 {
+    old_tip_height.saturating_sub(fork_point_height)
+}
+
+/// Log a sharechain reorg. Shallow reorgs use `info!`; deep reorgs
+/// (depth >= [`DEEP_REORG_DEPTH`]) use `warn!` with a bitcoind-style hint.
+fn log_reorg(
+    kind: &str,
+    depth: u32,
+    fork_height: Height,
+    old_tip: &BlockHash,
+    old_tip_height: Height,
+    new_tip: &BlockHash,
+    new_tip_height: Height,
+) {
+    if depth >= DEEP_REORG_DEPTH {
+        warn!(
+            "Share chain reorg detected: kind={kind} depth={depth} fork_height={fork_height} \
+             old_tip={old_tip} (height {old_tip_height}) new_tip={new_tip} (height {new_tip_height}). \
+             Deep reorg may indicate database corruption or consensus incompatibility with peers."
+        );
+    } else {
+        info!(
+            "Share chain reorg detected: kind={kind} depth={depth} fork_height={fork_height} \
+             old_tip={old_tip} (height {old_tip_height}) new_tip={new_tip} (height {new_tip_height})"
+        );
+    }
 }
 
 impl Store {
@@ -131,6 +166,31 @@ mod tests {
     use super::*;
     use crate::test_utils::TestShareBlockBuilder;
     use tempfile::tempdir;
+
+    // ── reorg_depth tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_reorg_depth_zero_when_fork_at_tip() {
+        assert_eq!(reorg_depth(10, 10), 0);
+    }
+
+    #[test]
+    fn test_reorg_depth_shallow() {
+        assert_eq!(reorg_depth(13, 12), 1);
+        assert_eq!(reorg_depth(15, 10), 5);
+    }
+
+    #[test]
+    fn test_reorg_depth_at_and_above_deep_threshold() {
+        assert_eq!(reorg_depth(16, 10), DEEP_REORG_DEPTH);
+        assert_eq!(reorg_depth(20, 10), 10);
+        assert!(reorg_depth(20, 10) >= DEEP_REORG_DEPTH);
+    }
+
+    #[test]
+    fn test_reorg_depth_saturates_when_fork_above_tip() {
+        assert_eq!(reorg_depth(5, 10), 0);
+    }
 
     // ── get_branch_to_chain tests ─────────────────────────────────────────
 


### PR DESCRIPTION
Log candidate and confirmed reorgs with depth calculations. Reorgs reaching or exceeding 6 blocks (DEEP_REORG_DEPTH) log a warn! with a bitcoind-style hint, while shallower reorgs log at info! level.

Closes #529 