### PR TITLE
Add .cookie support for RPC authentication

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,8 +46,7 @@ docker compose up -d bitcoind
 
 The important details you want from your bitcoin.conf are:
 
-. rpcuser
-. rpcpassword
+. rpcuser and rpcpassword (or use `.cookie` file authentication via `cookie_file` in `config.toml`)
 
 Another important detail is to set your bitcoin config file to allow
 for 500 coinbase outputs. This is required before we ship our atomic

--- a/ansible/roles/p2poolv2/defaults/main.yml
+++ b/ansible/roles/p2poolv2/defaults/main.yml
@@ -69,6 +69,9 @@ p2poolv2_wait_for_chain_sync: true
 p2poolv2_bitcoin_rpc_url: "http://127.0.0.1:8332"
 p2poolv2_bitcoin_rpc_user: ""
 p2poolv2_bitcoin_rpc_pass: ""
+# Optional: path to a bitcoind .cookie file for RPC authentication.
+# When set, cookie_file is used only if username/password are not both specified.
+# p2poolv2_bitcoin_rpc_cookie_file: "/path/to/.cookie"
 
 # --- Logging config ---
 p2poolv2_log_file: "/var/log/p2poolv2/{{ p2poolv2_instance }}/p2poolv2.log"

--- a/ansible/roles/p2poolv2/templates/config.toml.j2
+++ b/ansible/roles/p2poolv2/templates/config.toml.j2
@@ -61,8 +61,12 @@ mode = "{{ p2poolv2_pool_mode }}"
 
 [bitcoinrpc]
 url = "{{ p2poolv2_bitcoin_rpc_url }}"
+{% if p2poolv2_bitcoin_rpc_cookie_file is defined and p2poolv2_bitcoin_rpc_cookie_file != "" %}
+cookie_file = "{{ p2poolv2_bitcoin_rpc_cookie_file }}"
+{% else %}
 username = "{{ p2poolv2_bitcoin_rpc_user }}"
 password = "{{ p2poolv2_bitcoin_rpc_pass }}"
+{% endif %}
 
 [logging]
 file = "{{ p2poolv2_log_file }}"

--- a/bitcoindrpc/Cargo.toml
+++ b/bitcoindrpc/Cargo.toml
@@ -33,6 +33,7 @@ test-log = { version = "0.2.17", features = ["trace"] }
 tokio = { version = "1.0", features = ["full", "test-util"] }
 mockall = "0.13.1"
 wiremock = "0.6.2"
+tempfile.workspace = true
 
 [features]
 test-utils = ["wiremock"]

--- a/bitcoindrpc/README.adoc
+++ b/bitcoindrpc/README.adoc
@@ -2,8 +2,14 @@
 
 This crate is used by p2poolv2 to make bitcoind API calls.
 
-We only support the endpoints that we need to call. As we need more,
-we will add more here.
+=== Authentication
+
+Supports two authentication modes via `BitcoinRpcConfig`:
+
+* Static credentials (`username` and `password`)
+* Cookie file authentication (`cookie_file` pointing to the bitcoind `.cookie` file)
+
+When using `.cookie` authentication, the client automatically re-reads the cookie file and retries requests if HTTP 401 Unauthorized status is received (e.g. after a bitcoind restart).
 
 List of supported calls:
 

--- a/bitcoindrpc/src/lib.rs
+++ b/bitcoindrpc/src/lib.rs
@@ -21,7 +21,7 @@ use std::error::Error;
 use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
@@ -54,8 +54,16 @@ struct JsonRpcError {
 #[allow(dead_code)]
 pub struct BitcoinRpcConfig {
     pub url: String,
-    pub username: String,
-    pub password: String,
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub password: Option<String>,
+    #[serde(default, alias = "cookiefile", alias = "cookie")]
+    pub cookie_file: Option<String>,
+    #[serde(default)]
+    pub datadir: Option<String>,
+    #[serde(default)]
+    pub network: Option<bitcoin::Network>,
 }
 
 /// Custom Debug to redact passwords
@@ -66,7 +74,80 @@ impl std::fmt::Debug for BitcoinRpcConfig {
             .field("url", &self.url)
             .field("username", &self.username)
             .field("password", &"[redacted]")
+            .field("cookie_file", &self.cookie_file)
+            .field("datadir", &self.datadir)
+            .field("network", &self.network)
             .finish()
+    }
+}
+
+impl BitcoinRpcConfig {
+    /// Returns authentication credentials. Static username and password
+    /// take precedence, followed by an explicit `cookie_file` path, followed
+    /// by an auto-detected `.cookie` from the datadir or `$HOME/.bitcoin`.
+    pub fn get_credentials(&self) -> Result<(String, String), BitcoindRpcError> {
+        // Static credentials take precedence over cookie_file
+        if let (Some(u), Some(p)) = (&self.username, &self.password) {
+            return Ok((u.clone(), p.clone()));
+        }
+
+        // Explicit cookie_file path
+        if let Some(ref cookie_path) = self.cookie_file {
+            return Self::read_cookie_file(cookie_path);
+        }
+
+        // Auto-detect .cookie from datadir or $HOME/.bitcoin
+        if let Some(auto_path) = self.default_cookie_path() {
+            if auto_path.exists() {
+                return Self::read_cookie_file(&auto_path);
+            }
+        }
+
+        Err(BitcoindRpcError::Other(
+            "RPC authentication error: no username/password or cookie_file specified, and default .cookie file not found".to_string(),
+        ))
+    }
+
+    /// Default .cookie path from datadir or `$HOME/.bitcoin` for the given network.
+    pub fn default_cookie_path(&self) -> Option<std::path::PathBuf> {
+        let base_dir = if let Some(ref d) = self.datadir {
+            std::path::PathBuf::from(d)
+        } else if let Ok(home) = std::env::var("HOME") {
+            std::path::PathBuf::from(home).join(".bitcoin")
+        } else {
+            return None;
+        };
+
+        let network = self.network.unwrap_or(bitcoin::Network::Bitcoin);
+        let path = match network {
+            bitcoin::Network::Bitcoin => base_dir.join(".cookie"),
+            bitcoin::Network::Testnet4 => base_dir.join("testnet4").join(".cookie"),
+            bitcoin::Network::Signet => base_dir.join("signet").join(".cookie"),
+            bitcoin::Network::Regtest => base_dir.join("regtest").join(".cookie"),
+            _ => base_dir.join(".cookie"),
+        };
+        Some(path)
+    }
+
+    /// Reads credentials from a .cookie file (format: `username:password`)
+    pub fn read_cookie_file<P: AsRef<std::path::Path>>(
+        path: P,
+    ) -> Result<(String, String), BitcoindRpcError> {
+        let content = std::fs::read_to_string(path.as_ref()).map_err(|e| {
+            BitcoindRpcError::Other(format!(
+                "Failed to read cookie file '{}': {e}",
+                path.as_ref().display()
+            ))
+        })?;
+        let trimmed = content.trim();
+        if let Some((user, pass)) = trimmed.split_once(':') {
+            Ok((user.to_string(), pass.to_string()))
+        } else {
+            Err(BitcoindRpcError::Other(format!(
+                "Invalid cookie file format in '{}': expected 'username:password'",
+                path.as_ref().display()
+            )))
+        }
     }
 }
 
@@ -120,30 +201,53 @@ pub struct GetBlockchainInfo {
 pub struct BitcoindRpcClient {
     client: reqwest::Client,
     url: String,
+    auth_header: Arc<std::sync::RwLock<String>>,
+    cookie_file: Option<std::path::PathBuf>,
     request_id: Arc<AtomicU64>,
 }
 
 impl BitcoindRpcClient {
     pub fn new(url: &str, username: &str, password: &str) -> Result<Self, BitcoindRpcError> {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(
-            reqwest::header::AUTHORIZATION,
-            format!(
-                "Basic {}",
-                STANDARD.encode(format!("{username}:{password}"))
-            )
-            .parse()
-            .map_err(|e| BitcoindRpcError::Other(format!("Invalid header: {e}")))?,
+        let auth_header = format!(
+            "Basic {}",
+            STANDARD.encode(format!("{username}:{password}"))
         );
-
         let client = reqwest::Client::builder()
-            .default_headers(headers)
             .build()
             .map_err(|e| BitcoindRpcError::Other(format!("Failed to create HTTP client: {e}")))?;
 
         Ok(Self {
             client,
             url: url.to_string(),
+            auth_header: Arc::new(std::sync::RwLock::new(auth_header)),
+            cookie_file: None,
+            request_id: Arc::new(AtomicU64::new(0)),
+        })
+    }
+
+    pub fn from_config(config: &BitcoinRpcConfig) -> Result<Self, BitcoindRpcError> {
+        let (username, password) = config.get_credentials()?;
+        let auth_header = format!(
+            "Basic {}",
+            STANDARD.encode(format!("{username}:{password}"))
+        );
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|e| BitcoindRpcError::Other(format!("Failed to create HTTP client: {e}")))?;
+
+        let cookie_file = if let (Some(_), Some(_)) = (&config.username, &config.password) {
+            None
+        } else if let Some(ref path) = config.cookie_file {
+            Some(std::path::PathBuf::from(path))
+        } else {
+            config.default_cookie_path()
+        };
+
+        Ok(Self {
+            client,
+            url: config.url.clone(),
+            auth_header: Arc::new(std::sync::RwLock::new(auth_header)),
+            cookie_file,
             request_id: Arc::new(AtomicU64::new(0)),
         })
     }
@@ -161,7 +265,20 @@ impl BitcoindRpcClient {
             id,
         };
 
-        let response = match self.client.post(&self.url).json(&request).send().await {
+        let mut current_auth = self
+            .auth_header
+            .read()
+            .map_err(|e| BitcoindRpcError::Other(format!("Lock error: {e}")))?
+            .clone();
+
+        let mut response = match self
+            .client
+            .post(&self.url)
+            .header(reqwest::header::AUTHORIZATION, &current_auth)
+            .json(&request)
+            .send()
+            .await
+        {
             Ok(resp) => resp,
             Err(e) => {
                 let status_code = e.status().map(|s| s.as_u16());
@@ -172,6 +289,42 @@ impl BitcoindRpcClient {
                 return Err(BitcoindRpcError::Other(format!("HTTP request failed: {e}")));
             }
         };
+
+        // On 401 Unauthorized, re-read the cookie file and retry the request once
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            if let Some(ref cookie_path) = self.cookie_file {
+                match BitcoinRpcConfig::read_cookie_file(cookie_path) {
+                    Ok((new_user, new_pass)) => {
+                        let new_auth = format!(
+                            "Basic {}",
+                            STANDARD.encode(format!("{new_user}:{new_pass}"))
+                        );
+                        if let Ok(mut lock) = self.auth_header.write() {
+                            *lock = new_auth.clone();
+                        }
+                        current_auth = new_auth;
+
+                        // Retry request once with new credentials
+                        if let Ok(retry_resp) = self
+                            .client
+                            .post(&self.url)
+                            .header(reqwest::header::AUTHORIZATION, &current_auth)
+                            .json(&request)
+                            .send()
+                            .await
+                        {
+                            response = retry_resp;
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Received 401 Unauthorized, but failed to re-read cookie file '{}': {e}",
+                            cookie_path.display()
+                        );
+                    }
+                }
+            }
+        }
 
         let status = response.status();
 
@@ -748,5 +901,193 @@ mod tests {
         } else {
             panic!("Expected BitcoindRpcError::HttpError, got {result:?}");
         }
+    }
+
+    #[tokio::test]
+    async fn test_cookie_file_auth() {
+        let mock_server = MockServer::start().await;
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cookie_path = temp_dir.path().join(".cookie");
+        std::fs::write(&cookie_path, "__cookie__:secret123\n").unwrap();
+
+        let auth_header = format!("Basic {}", STANDARD.encode("__cookie__:secret123"));
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", auth_header))
+            .and(body_json(serde_json::json!({
+                "method": "getdifficulty",
+                "params": [],
+                "id": 0
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": 500.0,
+                "error": null,
+                "id": 0
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let config = BitcoinRpcConfig {
+            url: mock_server.uri(),
+            username: None,
+            password: None,
+            cookie_file: Some(cookie_path.to_str().unwrap().to_string()),
+            datadir: None,
+            network: None,
+        };
+
+        let client = BitcoindRpcClient::from_config(&config).unwrap();
+        let diff = client.get_difficulty().await.unwrap();
+        assert_eq!(diff, 500.0);
+    }
+
+    #[tokio::test]
+    async fn test_cookie_file_auto_reload_on_401() {
+        let mock_server = MockServer::start().await;
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cookie_path = temp_dir.path().join(".cookie");
+        std::fs::write(&cookie_path, "__cookie__:old_secret\n").unwrap();
+
+        let old_auth = format!("Basic {}", STANDARD.encode("__cookie__:old_secret"));
+        let new_auth = format!("Basic {}", STANDARD.encode("__cookie__:new_secret"));
+
+        // First call with old auth gets 401
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", old_auth))
+            .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        // Second call with new auth gets 200
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", new_auth))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": 1000.0,
+                "error": null,
+                "id": 0
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = BitcoinRpcConfig {
+            url: mock_server.uri(),
+            username: None,
+            password: None,
+            cookie_file: Some(cookie_path.to_str().unwrap().to_string()),
+            datadir: None,
+            network: None,
+        };
+
+        let client = BitcoindRpcClient::from_config(&config).unwrap();
+
+        // Update cookie file before making request (simulating bitcoind restart)
+        std::fs::write(&cookie_path, "__cookie__:new_secret\n").unwrap();
+
+        let diff = client.get_difficulty().await.unwrap();
+        assert_eq!(diff, 1000.0);
+    }
+
+    #[test]
+    fn test_cookie_file_parsing_errors() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        // Missing file
+        let missing_path = temp_dir.path().join("nonexistent.cookie");
+        assert!(BitcoinRpcConfig::read_cookie_file(&missing_path).is_err());
+
+        // Invalid format (no colon)
+        let invalid_path = temp_dir.path().join("invalid.cookie");
+        std::fs::write(&invalid_path, "invalid_content_without_colon\n").unwrap();
+        assert!(BitcoinRpcConfig::read_cookie_file(&invalid_path).is_err());
+
+        // Valid format
+        let valid_path = temp_dir.path().join("valid.cookie");
+        std::fs::write(&valid_path, "user:pass\n").unwrap();
+        let (u, p) = BitcoinRpcConfig::read_cookie_file(&valid_path).unwrap();
+        assert_eq!(u, "user");
+        assert_eq!(p, "pass");
+    }
+
+    #[test]
+    fn test_from_config_missing_cookie_file_errors() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_path = temp_dir.path().join("missing.cookie");
+
+        let config = BitcoinRpcConfig {
+            url: "http://localhost:8332".to_string(),
+            username: None,
+            password: None,
+            cookie_file: Some(missing_path.to_str().unwrap().to_string()),
+            datadir: None,
+            network: None,
+        };
+
+        assert!(BitcoindRpcClient::from_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_get_credentials_static_credentials_win_over_cookie() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cookie_path = temp_dir.path().join(".cookie");
+        std::fs::write(&cookie_path, "cookie_user:cookie_pass\n").unwrap();
+
+        let config = BitcoinRpcConfig {
+            url: "http://localhost:8332".to_string(),
+            username: Some("static_user".to_string()),
+            password: Some("static_pass".to_string()),
+            cookie_file: Some(cookie_path.to_str().unwrap().to_string()),
+            datadir: None,
+            network: None,
+        };
+
+        // Static credentials take precedence over cookie_file
+        let (user, pass) = config.get_credentials().unwrap();
+        assert_eq!(user, "static_user");
+        assert_eq!(pass, "static_pass");
+    }
+
+    #[test]
+    fn test_get_credentials_auto_discovery() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let signet_dir = temp_dir.path().join("signet");
+        std::fs::create_dir_all(&signet_dir).unwrap();
+        let cookie_path = signet_dir.join(".cookie");
+        std::fs::write(&cookie_path, "__cookie__:auto_secret123\n").unwrap();
+
+        let config = BitcoinRpcConfig {
+            url: "http://localhost:8332".to_string(),
+            username: None,
+            password: None,
+            cookie_file: None,
+            datadir: Some(temp_dir.path().to_str().unwrap().to_string()),
+            network: Some(bitcoin::Network::Signet),
+        };
+
+        let (user, pass) = config.get_credentials().unwrap();
+        assert_eq!(user, "__cookie__");
+        assert_eq!(pass, "auto_secret123");
+    }
+
+    #[test]
+    fn test_get_credentials_missing_auth_errors() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_datadir = temp_dir.path().join("nonexistent_datadir");
+
+        let config = BitcoinRpcConfig {
+            url: "http://localhost:8332".to_string(),
+            username: None,
+            password: None,
+            cookie_file: None,
+            datadir: Some(missing_datadir.to_str().unwrap().to_string()),
+            network: None,
+        };
+
+        let err = config.get_credentials().unwrap_err();
+        assert!(err.to_string().contains("default .cookie file not found"));
     }
 }

--- a/bitcoindrpc/src/test_utils.rs
+++ b/bitcoindrpc/src/test_utils.rs
@@ -32,8 +32,11 @@ pub async fn setup_mock_bitcoin_rpc() -> (MockServer, BitcoinRpcConfig) {
     // Create test config
     let config = BitcoinRpcConfig {
         url: mock_server.uri(),
-        username: "testuser".to_string(),
-        password: "testpass".to_string(),
+        username: Some("testuser".to_string()),
+        password: Some("testpass".to_string()),
+        cookie_file: None,
+        datadir: None,
+        network: None,
     };
 
     (mock_server, config)

--- a/config-docker.sample.toml
+++ b/config-docker.sample.toml
@@ -49,9 +49,11 @@ difficulty_multiplier = 1.0
 pool_signature = "P2Poolv2"
 
 [bitcoinrpc]
+# Specify either username/password OR cookie_file for RPC authentication
 url = "http://bitcoind:38332"
 username = "p2pool"
 password = "p2pool"
+# cookie_file = "/path/to/.cookie"
 
 [logging]
 file = "/p2poolv2/logs/p2pool.log"

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -54,10 +54,11 @@ pool_signature = "P2Poolv2"
 # max_connections = 1000
 
 [bitcoinrpc]
-# RPC credentials are loaded from env vars
+# Specify either username/password OR cookie_file for RPC authentication
 url = "http://127.0.0.1:38332"
 username = "p2pool"
 password = "p2pool"
+# cookie_file = "/path/to/.cookie"
 
 [logging]
 # Specify a file path for the log file, if no log file is specified, console logging will be used

--- a/docker/docker-compose.p2poolv2.yml
+++ b/docker/docker-compose.p2poolv2.yml
@@ -33,6 +33,8 @@ services:
     volumes:
       - p2poolv2_data:/p2poolv2
       - ../${P2POOL_CONFIG:-config.toml}:/etc/p2poolv2/config.toml:ro
+      # Optional: Mount bitcoind data directory for .cookie file RPC authentication
+      # - bitcoin_data:/data:ro
     restart: unless-stopped
     logging:
       driver: "json-file"

--- a/p2poolv2_config/src/lib.rs
+++ b/p2poolv2_config/src/lib.rs
@@ -482,11 +482,17 @@ pub struct Config {
 #[allow(dead_code)]
 impl Config {
     pub fn load(path: &str) -> Result<Self, config::ConfigError> {
-        config::Config::builder()
+        let mut cfg: Config = config::Config::builder()
             .add_source(config::File::with_name(path))
             .add_source(config::Environment::with_prefix("P2POOL").separator("_"))
             .build()?
-            .try_deserialize()
+            .try_deserialize()?;
+
+        if cfg.bitcoinrpc.network.is_none() {
+            cfg.bitcoinrpc.network = Some(cfg.stratum.network);
+        }
+
+        Ok(cfg)
     }
 
     pub fn with_listen_address(mut self, listen_address: String) -> Self {
@@ -600,12 +606,22 @@ impl Config {
     }
 
     pub fn with_bitcoinrpc_username(mut self, bitcoin_username: String) -> Self {
-        self.bitcoinrpc.username = bitcoin_username;
+        self.bitcoinrpc.username = Some(bitcoin_username);
         self
     }
 
     pub fn with_bitcoinrpc_password(mut self, bitcoin_password: String) -> Self {
-        self.bitcoinrpc.password = bitcoin_password;
+        self.bitcoinrpc.password = Some(bitcoin_password);
+        self
+    }
+
+    pub fn with_bitcoinrpc_cookie_file(mut self, cookie_file: String) -> Self {
+        self.bitcoinrpc.cookie_file = Some(cookie_file);
+        self
+    }
+
+    pub fn with_bitcoinrpc_datadir(mut self, datadir: String) -> Self {
+        self.bitcoinrpc.datadir = Some(datadir);
         self
     }
 
@@ -714,8 +730,8 @@ mod tests {
         );
 
         assert_eq!(config.bitcoinrpc.url, "http://localhost:8332");
-        assert_eq!(config.bitcoinrpc.username, "testuser");
-        assert_eq!(config.bitcoinrpc.password, "testpass");
+        assert_eq!(config.bitcoinrpc.username, Some("testuser".to_string()));
+        assert_eq!(config.bitcoinrpc.password, Some("testpass".to_string()));
 
         assert_eq!(config.network.max_pending_incoming, 10);
         assert_eq!(config.network.max_pending_outgoing, 10);
@@ -744,6 +760,18 @@ mod tests {
 
         assert_eq!(config.store.background_task_frequency_hours, 2);
         assert_eq!(config.store.pplns_ttl_days, 7);
+    }
+
+    #[test]
+    fn test_config_cookie_file_setting() {
+        let config = Config::load("../config.sample.toml")
+            .unwrap()
+            .with_bitcoinrpc_cookie_file("/path/to/.cookie".to_string());
+
+        assert_eq!(
+            config.bitcoinrpc.cookie_file,
+            Some("/path/to/.cookie".to_string())
+        );
     }
 
     #[test]

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -655,8 +655,11 @@ mod tests {
             network: network_config.clone(),
             bitcoinrpc: BitcoinRpcConfig {
                 url: "http://localhost:8332".to_string(),
-                username: "testuser".to_string(),
-                password: "testpass".to_string(),
+                username: Some("testuser".to_string()),
+                password: Some("testpass".to_string()),
+                cookie_file: None,
+                datadir: None,
+                network: None,
             },
             store: StoreConfig {
                 path: "test_chain.db".to_string(),
@@ -769,8 +772,11 @@ mod tests {
             },
             bitcoinrpc: BitcoinRpcConfig {
                 url: "http://localhost:8332".to_string(),
-                username: "testuser".to_string(),
-                password: "testpass".to_string(),
+                username: Some("testuser".to_string()),
+                password: Some("testpass".to_string()),
+                cookie_file: None,
+                datadir: None,
+                network: None,
             },
             store: StoreConfig {
                 path: "test_chain.db".to_string(),

--- a/p2poolv2_lib/src/shares/validation/bitcoin_block_validation.rs
+++ b/p2poolv2_lib/src/shares/validation/bitcoin_block_validation.rs
@@ -97,13 +97,15 @@ mod tests {
         // Create test config
         let config = BitcoinRpcConfig {
             url: mock_server.uri(),
-            username: "testuser".to_string(),
-            password: "testpass".to_string(),
+            username: Some("testuser".to_string()),
+            password: Some("testpass".to_string()),
+            cookie_file: None,
+            datadir: None,
+            network: None,
         };
 
         // Test validation
-        let client =
-            BitcoindRpcClient::new(&config.url, &config.username, &config.password).unwrap();
+        let client = BitcoindRpcClient::from_config(&config).unwrap();
         let result = validate_bitcoin_block(&block, &client).await;
         assert!(result.is_ok());
         assert!(result.unwrap());
@@ -148,13 +150,15 @@ mod tests {
         // Create test config
         let config = BitcoinRpcConfig {
             url: mock_server.uri(),
-            username: "testuser".to_string(),
-            password: "testpass".to_string(),
+            username: Some("testuser".to_string()),
+            password: Some("testpass".to_string()),
+            cookie_file: None,
+            datadir: None,
+            network: None,
         };
 
         // Test validation
-        let client =
-            BitcoindRpcClient::new(&config.url, &config.username, &config.password).unwrap();
+        let client = BitcoindRpcClient::from_config(&config).unwrap();
         let result = validate_bitcoin_block(&block, &client).await;
         assert!(result.is_ok());
         assert!(!result.unwrap());
@@ -195,13 +199,15 @@ mod tests {
         // Create test config
         let config = BitcoinRpcConfig {
             url: mock_server.uri(),
-            username: "testuser".to_string(),
-            password: "testpass".to_string(),
+            username: Some("testuser".to_string()),
+            password: Some("testpass".to_string()),
+            cookie_file: None,
+            datadir: None,
+            network: None,
         };
 
         // Test validation
-        let client =
-            BitcoindRpcClient::new(&config.url, &config.username, &config.password).unwrap();
+        let client = BitcoindRpcClient::from_config(&config).unwrap();
         let result = validate_bitcoin_block(&block, &client).await;
         assert!(result.is_err());
     }

--- a/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/authorize_response.rs
@@ -184,12 +184,7 @@ mod tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle,
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -283,12 +278,7 @@ mod tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle,
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -421,12 +411,7 @@ mod tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle,
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -518,12 +503,7 @@ mod tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle,
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1000,
             minimum_difficulty: 1,
             maximum_difficulty: None,
@@ -576,12 +556,7 @@ mod tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle,
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1000,
             minimum_difficulty: 100,
             maximum_difficulty: None,
@@ -636,12 +611,7 @@ mod tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle,
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -700,12 +670,7 @@ mod tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle,
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1000,
             minimum_difficulty: 1,
             maximum_difficulty: None,

--- a/p2poolv2_lib/src/stratum/message_handlers/submit.rs
+++ b/p2poolv2_lib/src/stratum/message_handlers/submit.rs
@@ -367,12 +367,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -462,12 +457,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -557,12 +547,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -650,12 +635,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -719,12 +699,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -796,12 +771,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -889,12 +859,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx: notify_tx.clone(),
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -926,12 +891,7 @@ mod handle_submit_tests {
         let ctx2 = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -1009,12 +969,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -1078,12 +1033,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1,
             minimum_difficulty: 1,
             maximum_difficulty: None,
@@ -1159,12 +1109,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1,
             minimum_difficulty: 1,
             maximum_difficulty: None,
@@ -1257,12 +1202,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1,
             minimum_difficulty: 1,
             maximum_difficulty: None,
@@ -1339,12 +1279,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1,
             minimum_difficulty: 1,
             maximum_difficulty: None,
@@ -1422,12 +1357,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1,
             minimum_difficulty: 1,
             maximum_difficulty: None,
@@ -1483,12 +1413,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1,
             minimum_difficulty: 1,
             maximum_difficulty: None,
@@ -1574,12 +1499,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1,
             minimum_difficulty: 1,
             maximum_difficulty: None,
@@ -1658,12 +1578,7 @@ mod handle_submit_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 1,
             minimum_difficulty: 1,
             maximum_difficulty: None,

--- a/p2poolv2_lib/src/stratum/server.rs
+++ b/p2poolv2_lib/src/stratum/server.rs
@@ -253,17 +253,14 @@ impl StratumServer {
     ) -> Result<(), Box<dyn std::error::Error + Send>> {
         info!("Starting Stratum server at {}:{}", self.hostname, self.port);
 
-        let bitcoindrpc_client = BitcoindRpcClient::new(
-            &bitcoinrpc_config.url,
-            &bitcoinrpc_config.username,
-            &bitcoinrpc_config.password,
-        )
-        .map_err(|e| -> Box<dyn std::error::Error + Send> {
-            Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Failed to create BitcoindRpcClient: {}", e),
-            ))
-        })?;
+        let bitcoindrpc_client = BitcoindRpcClient::from_config(&bitcoinrpc_config).map_err(
+            |e| -> Box<dyn std::error::Error + Send> {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to create BitcoindRpcClient: {}", e),
+                ))
+            },
+        )?;
 
         if !wait_for_chain_sync(
             &self.chain_store_handle,
@@ -782,12 +779,7 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             metrics: metrics_handle,
             start_difficulty: 10000,
             minimum_difficulty: 1,
@@ -905,12 +897,7 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             metrics: metrics_handle,
             start_difficulty: 10000,
             minimum_difficulty: 1,
@@ -989,12 +976,7 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -1071,12 +1053,7 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -1173,12 +1150,7 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -1294,12 +1266,7 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
@@ -1405,12 +1372,7 @@ mod stratum_server_tests {
             let ctx = StratumContext {
                 notify_tx,
                 tracker_handle: tracker_handle.clone(),
-                bitcoindrpc_client: BitcoindRpcClient::new(
-                    &bitcoinrpc_config.url,
-                    &bitcoinrpc_config.username,
-                    &bitcoinrpc_config.password,
-                )
-                .unwrap(),
+                bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
                 metrics: metrics_handle,
                 start_difficulty: 10000,
                 minimum_difficulty: 1,
@@ -1488,12 +1450,7 @@ mod stratum_server_tests {
             let ctx = StratumContext {
                 notify_tx,
                 tracker_handle: tracker_handle.clone(),
-                bitcoindrpc_client: BitcoindRpcClient::new(
-                    &bitcoinrpc_config.url,
-                    &bitcoinrpc_config.username,
-                    &bitcoinrpc_config.password,
-                )
-                .unwrap(),
+                bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
                 metrics: metrics_handle,
                 start_difficulty: 10000,
                 minimum_difficulty: 1,
@@ -1628,12 +1585,7 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             metrics: metrics_handle,
             start_difficulty: 10000,
             minimum_difficulty: 1,
@@ -1758,12 +1710,7 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             metrics: metrics_handle,
             start_difficulty: 10000,
             minimum_difficulty: 1,
@@ -1898,12 +1845,7 @@ mod stratum_server_tests {
         let ctx = StratumContext {
             notify_tx,
             tracker_handle: tracker_handle.clone(),
-            bitcoindrpc_client: BitcoindRpcClient::new(
-                &bitcoinrpc_config.url,
-                &bitcoinrpc_config.username,
-                &bitcoinrpc_config.password,
-            )
-            .unwrap(),
+            bitcoindrpc_client: BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap(),
             metrics: metrics_handle,
             start_difficulty: 10000,
             minimum_difficulty: 1,

--- a/p2poolv2_lib/src/stratum/work/gbt.rs
+++ b/p2poolv2_lib/src/stratum/work/gbt.rs
@@ -116,11 +116,7 @@ pub async fn start_gbt(
     mut zmq_trigger_rx: tokio::sync::mpsc::Receiver<()>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Create the RPC client once and reuse it for all requests
-    let bitcoind = match BitcoindRpcClient::new(
-        &bitcoin_config.url,
-        &bitcoin_config.username,
-        &bitcoin_config.password,
-    ) {
+    let bitcoind = match BitcoindRpcClient::from_config(&bitcoin_config) {
         Ok(client) => client,
         Err(e) => {
             error!("Failed to connect to bitcoind: {}", e);
@@ -221,12 +217,7 @@ mod gbt_load_tests {
         )
         .await;
 
-        let bitcoind = BitcoindRpcClient::new(
-            &bitcoinrpc_config.url,
-            &bitcoinrpc_config.username,
-            &bitcoinrpc_config.password,
-        )
-        .unwrap();
+        let bitcoind = BitcoindRpcClient::from_config(&bitcoinrpc_config).unwrap();
         let result = get_block_template(&bitcoind, bitcoin::Network::Signet).await;
 
         assert!(result.is_ok());

--- a/p2poolv2_node/src/preflight.rs
+++ b/p2poolv2_node/src/preflight.rs
@@ -19,11 +19,7 @@ use bitcoindrpc::{BitcoinRpcConfig, BitcoindRpcClient};
 pub async fn ensure_bitcoin_node_synced(
     bitcoinrpc_config: &BitcoinRpcConfig,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let bitcoind = BitcoindRpcClient::new(
-        &bitcoinrpc_config.url,
-        &bitcoinrpc_config.username,
-        &bitcoinrpc_config.password,
-    )?;
+    let bitcoind = BitcoindRpcClient::from_config(bitcoinrpc_config)?;
 
     let is_in_ibd = bitcoind.getblockchaininfo().await?.initial_block_download;
 
@@ -47,8 +43,11 @@ mod tests {
         let mock_server = MockServer::start().await;
         let config = BitcoinRpcConfig {
             url: mock_server.uri(),
-            username: "testuser".to_string(),
-            password: "testpass".to_string(),
+            username: Some("testuser".to_string()),
+            password: Some("testpass".to_string()),
+            cookie_file: None,
+            datadir: None,
+            network: None,
         };
         (mock_server, config)
     }

--- a/p2poolv2_sim/src/main.rs
+++ b/p2poolv2_sim/src/main.rs
@@ -103,11 +103,7 @@ async fn main() -> ExitCode {
             .and_then(|a| a.require_network(sim_network).map_err(|e| e.to_string()))
         {
             Ok(miner_address) => {
-                match bitcoindrpc::BitcoindRpcClient::new(
-                    &node_config.bitcoinrpc.url,
-                    &node_config.bitcoinrpc.username,
-                    &node_config.bitcoinrpc.password,
-                ) {
+                match bitcoindrpc::BitcoindRpcClient::from_config(&node_config.bitcoinrpc) {
                     Ok(sim_rpc) => {
                         let emitter = SimEmitter::new(
                             handles.emissions_tx.clone(),

--- a/p2poolv2_tests/src/common/mod.rs
+++ b/p2poolv2_tests/src/common/mod.rs
@@ -45,8 +45,11 @@ pub fn default_test_config() -> Config {
         },
         bitcoinrpc: BitcoinRpcConfig {
             url: "http://localhost:8332".to_string(),
-            username: "testuser".to_string(),
-            password: "testpass".to_string(),
+            username: Some("testuser".to_string()),
+            password: Some("testpass".to_string()),
+            cookie_file: None,
+            datadir: None,
+            network: None,
         },
         store: StoreConfig {
             path: "test_chain.db".to_string(),


### PR DESCRIPTION
Allow bitcoind RPC authentication via .cookie file in addition to static username and password.

  Closes #474
