### PR TITLE
Wait and retry on Bitcoin node IBD instead of failing fast

### DIFF
--- a/p2poolv2_node/src/lib.rs
+++ b/p2poolv2_node/src/lib.rs
@@ -199,11 +199,23 @@ pub async fn build_node(config: Config) -> Result<(NodeHandles, NodeRunner), Exi
     };
     info!("Latest tip {} at height {}", tip, height);
 
-    if let Err(error) =
-        preflight::wait_for_bitcoin_node_synced(&config.bitcoinrpc, Duration::from_secs(300)).await
+    if let Err(error) = preflight::wait_for_bitcoin_node_synced(
+        &config.bitcoinrpc,
+        Duration::from_secs(300),
+        exit_sender.subscribe(),
+    )
+    .await
     {
-        error!("Failed to verify Bitcoin node is ready: {error}");
-        return Err(ExitCode::FAILURE);
+        match error {
+            preflight::PreflightError::ShutdownRequested => {
+                info!("Shutdown requested while waiting for Bitcoin node to sync, exiting.");
+                return Err(ExitCode::SUCCESS);
+            }
+            _ => {
+                error!("Failed to verify Bitcoin node is ready: {error}");
+                return Err(ExitCode::FAILURE);
+            }
+        }
     }
 
     background_tasks::start_background_tasks(

--- a/p2poolv2_node/src/lib.rs
+++ b/p2poolv2_node/src/lib.rs
@@ -199,8 +199,10 @@ pub async fn build_node(config: Config) -> Result<(NodeHandles, NodeRunner), Exi
     };
     info!("Latest tip {} at height {}", tip, height);
 
-    if let Err(error) = preflight::ensure_bitcoin_node_synced(&config.bitcoinrpc).await {
-        error!("Bitcoin node still in IBD: {error}");
+    if let Err(error) =
+        preflight::wait_for_bitcoin_node_synced(&config.bitcoinrpc, Duration::from_secs(300)).await
+    {
+        error!("Failed to verify Bitcoin node is ready: {error}");
         return Err(ExitCode::FAILURE);
     }
 

--- a/p2poolv2_node/src/preflight.rs
+++ b/p2poolv2_node/src/preflight.rs
@@ -14,14 +14,17 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::signal::ShutdownReason;
 use bitcoindrpc::{BitcoinRpcConfig, BitcoindRpcClient};
 use std::time::Duration;
+use tokio::sync::watch;
 use tracing::warn;
 
 #[derive(Debug)]
 pub enum PreflightError {
     NotSynced,
     Rpc(Box<dyn std::error::Error + Send + Sync>),
+    ShutdownRequested,
 }
 
 impl std::fmt::Display for PreflightError {
@@ -29,11 +32,36 @@ impl std::fmt::Display for PreflightError {
         match self {
             PreflightError::NotSynced => write!(f, "Bitcoin node still in initial block download"),
             PreflightError::Rpc(e) => write!(f, "{e}"),
+            PreflightError::ShutdownRequested => write!(f, "shutdown requested while waiting for Bitcoin node to sync"),
         }
     }
 }
 
-impl std::error::Error for PreflightError {}
+impl std::error::Error for PreflightError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            PreflightError::Rpc(e) => Some(e.as_ref()),
+            PreflightError::NotSynced => None,
+            PreflightError::ShutdownRequested => None,
+        }
+    }
+}
+
+fn check_synced(bitcoind: &BitcoindRpcClient) -> impl std::future::Future<Output = Result<(), PreflightError>> + '_ {
+    async move {
+        let is_in_ibd = bitcoind
+            .getblockchaininfo()
+            .await
+            .map_err(|e| PreflightError::Rpc(e.into()))?
+            .initial_block_download;
+
+        if is_in_ibd {
+            return Err(PreflightError::NotSynced);
+        }
+
+        Ok(())
+    }
+}
 
 pub async fn ensure_bitcoin_node_synced(
     bitcoinrpc_config: &BitcoinRpcConfig,
@@ -45,35 +73,43 @@ pub async fn ensure_bitcoin_node_synced(
     )
     .map_err(|e| PreflightError::Rpc(e.into()))?;
 
-    let is_in_ibd = bitcoind
-        .getblockchaininfo()
-        .await
-        .map_err(|e| PreflightError::Rpc(e.into()))?
-        .initial_block_download;
-
-    if is_in_ibd {
-        return Err(PreflightError::NotSynced);
-    }
-
-    Ok(())
+    check_synced(&bitcoind).await
 }
 
 /// Waits for the Bitcoin node to finish initial block download, checking
 /// periodically and logging progress, instead of failing immediately.
-/// Any error other than "still syncing" is returned right away.
+///
+/// The RPC client is built once and reused across polls. Any error other
+/// than "still syncing" is returned right away. If a shutdown is signalled
+/// via `shutdown_rx` while waiting, this returns early with
+/// `PreflightError::ShutdownRequested` instead of sleeping out the full
+/// interval.
 pub async fn wait_for_bitcoin_node_synced(
     bitcoinrpc_config: &BitcoinRpcConfig,
     poll_interval: Duration,
+    mut shutdown_rx: watch::Receiver<ShutdownReason>,
 ) -> Result<(), PreflightError> {
+    let bitcoind = BitcoindRpcClient::new(
+        &bitcoinrpc_config.url,
+        &bitcoinrpc_config.username,
+        &bitcoinrpc_config.password,
+    )
+    .map_err(|e| PreflightError::Rpc(e.into()))?;
+
     loop {
-        match ensure_bitcoin_node_synced(bitcoinrpc_config).await {
+        match check_synced(&bitcoind).await {
             Ok(()) => return Ok(()),
             Err(PreflightError::NotSynced) => {
                 warn!(
                     "Bitcoin node still syncing, checking again in {}s...",
                     poll_interval.as_secs()
                 );
-                tokio::time::sleep(poll_interval).await;
+                tokio::select! {
+                    _ = tokio::time::sleep(poll_interval) => {},
+                    _ = shutdown_rx.changed() => {
+                        return Err(PreflightError::ShutdownRequested);
+                    }
+                }
             }
             Err(e) => return Err(e),
         }
@@ -206,8 +242,13 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let result =
-            wait_for_bitcoin_node_synced(&bitcoinrpc_config, Duration::from_millis(10)).await;
+        let (_shutdown_tx, shutdown_rx) = watch::channel(ShutdownReason::None);
+        let result = wait_for_bitcoin_node_synced(
+            &bitcoinrpc_config,
+            Duration::from_millis(10),
+            shutdown_rx,
+        )
+        .await;
         assert!(
             result.is_ok(),
             "wait_for_bitcoin_node_synced should eventually succeed once the node is synced"

--- a/p2poolv2_node/src/preflight.rs
+++ b/p2poolv2_node/src/preflight.rs
@@ -32,7 +32,10 @@ impl std::fmt::Display for PreflightError {
         match self {
             PreflightError::NotSynced => write!(f, "Bitcoin node still in initial block download"),
             PreflightError::Rpc(e) => write!(f, "{e}"),
-            PreflightError::ShutdownRequested => write!(f, "shutdown requested while waiting for Bitcoin node to sync"),
+            PreflightError::ShutdownRequested => write!(
+                f,
+                "shutdown requested while waiting for Bitcoin node to sync"
+            ),
         }
     }
 }
@@ -47,7 +50,9 @@ impl std::error::Error for PreflightError {
     }
 }
 
-fn check_synced(bitcoind: &BitcoindRpcClient) -> impl std::future::Future<Output = Result<(), PreflightError>> + '_ {
+fn check_synced(
+    bitcoind: &BitcoindRpcClient,
+) -> impl std::future::Future<Output = Result<(), PreflightError>> + '_ {
     async move {
         let is_in_ibd = bitcoind
             .getblockchaininfo()

--- a/p2poolv2_node/src/preflight.rs
+++ b/p2poolv2_node/src/preflight.rs
@@ -15,23 +15,69 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use bitcoindrpc::{BitcoinRpcConfig, BitcoindRpcClient};
+use std::time::Duration;
+use tracing::warn;
+
+#[derive(Debug)]
+pub enum PreflightError {
+    NotSynced,
+    Rpc(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl std::fmt::Display for PreflightError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PreflightError::NotSynced => write!(f, "Bitcoin node still in initial block download"),
+            PreflightError::Rpc(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for PreflightError {}
 
 pub async fn ensure_bitcoin_node_synced(
     bitcoinrpc_config: &BitcoinRpcConfig,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<(), PreflightError> {
     let bitcoind = BitcoindRpcClient::new(
         &bitcoinrpc_config.url,
         &bitcoinrpc_config.username,
         &bitcoinrpc_config.password,
-    )?;
+    )
+    .map_err(|e| PreflightError::Rpc(e.into()))?;
 
-    let is_in_ibd = bitcoind.getblockchaininfo().await?.initial_block_download;
+    let is_in_ibd = bitcoind
+        .getblockchaininfo()
+        .await
+        .map_err(|e| PreflightError::Rpc(e.into()))?
+        .initial_block_download;
 
     if is_in_ibd {
-        return Err("Bitcoin node still in initial block download".into());
+        return Err(PreflightError::NotSynced);
     }
 
     Ok(())
+}
+
+/// Waits for the Bitcoin node to finish initial block download, checking
+/// periodically and logging progress, instead of failing immediately.
+/// Any error other than "still syncing" is returned right away.
+pub async fn wait_for_bitcoin_node_synced(
+    bitcoinrpc_config: &BitcoinRpcConfig,
+    poll_interval: Duration,
+) -> Result<(), PreflightError> {
+    loop {
+        match ensure_bitcoin_node_synced(bitcoinrpc_config).await {
+            Ok(()) => return Ok(()),
+            Err(PreflightError::NotSynced) => {
+                warn!(
+                    "Bitcoin node still syncing, checking again in {}s...",
+                    poll_interval.as_secs()
+                );
+                tokio::time::sleep(poll_interval).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -114,6 +160,57 @@ mod tests {
         assert!(
             result.is_err(),
             "ensure_bitcoin_node_synced should return error when in IBD"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_bitcoin_node_synced_retries_until_synced() {
+        let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
+
+        // First two checks: still syncing
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", test_auth_header().as_str()))
+            .and(body_partial_json(serde_json::json!({
+                "method": "getblockchaininfo",
+                "params": [],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": {
+                    "initialblockdownload": true,
+                },
+                "error": null,
+                "id": 0
+            })))
+            .up_to_n_times(2)
+            .with_priority(1)
+            .mount(&mock_server)
+            .await;
+
+        // After that: synced
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", test_auth_header().as_str()))
+            .and(body_partial_json(serde_json::json!({
+                "method": "getblockchaininfo",
+                "params": [],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": {
+                    "initialblockdownload": false,
+                },
+                "error": null,
+                "id": 0
+            })))
+            .with_priority(2)
+            .mount(&mock_server)
+            .await;
+
+        let result =
+            wait_for_bitcoin_node_synced(&bitcoinrpc_config, Duration::from_millis(10)).await;
+        assert!(
+            result.is_ok(),
+            "wait_for_bitcoin_node_synced should eventually succeed once the node is synced"
         );
     }
 }

--- a/p2poolv2_node/src/preflight.rs
+++ b/p2poolv2_node/src/preflight.rs
@@ -63,19 +63,6 @@ fn check_synced(bitcoind: &BitcoindRpcClient) -> impl std::future::Future<Output
     }
 }
 
-pub async fn ensure_bitcoin_node_synced(
-    bitcoinrpc_config: &BitcoinRpcConfig,
-) -> Result<(), PreflightError> {
-    let bitcoind = BitcoindRpcClient::new(
-        &bitcoinrpc_config.url,
-        &bitcoinrpc_config.username,
-        &bitcoinrpc_config.password,
-    )
-    .map_err(|e| PreflightError::Rpc(e.into()))?;
-
-    check_synced(&bitcoind).await
-}
-
 /// Waits for the Bitcoin node to finish initial block download, checking
 /// periodically and logging progress, instead of failing immediately.
 ///
@@ -144,7 +131,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ensure_bitcoin_node_synced_returns_ok_when_not_in_ibd() {
+    async fn check_synced_returns_ok_when_not_in_ibd() {
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
 
         Mock::given(method("POST"))
@@ -164,15 +151,18 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let result = ensure_bitcoin_node_synced(&bitcoinrpc_config).await;
-        assert!(
-            result.is_ok(),
-            "ensure_bitcoin_node_synced returned an error"
-        );
+        let bitcoind = BitcoindRpcClient::new(
+            &bitcoinrpc_config.url,
+            &bitcoinrpc_config.username,
+            &bitcoinrpc_config.password,
+        )
+        .unwrap();
+        let result = check_synced(&bitcoind).await;
+        assert!(result.is_ok(), "check_synced returned an error");
     }
 
     #[tokio::test]
-    async fn ensure_bitcoin_node_synced_returns_err_when_in_ibd() {
+    async fn check_synced_returns_err_when_in_ibd() {
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
 
         Mock::given(method("POST"))
@@ -192,10 +182,16 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let result = ensure_bitcoin_node_synced(&bitcoinrpc_config).await;
+        let bitcoind = BitcoindRpcClient::new(
+            &bitcoinrpc_config.url,
+            &bitcoinrpc_config.username,
+            &bitcoinrpc_config.password,
+        )
+        .unwrap();
+        let result = check_synced(&bitcoind).await;
         assert!(
             result.is_err(),
-            "ensure_bitcoin_node_synced should return error when in IBD"
+            "check_synced should return error when in IBD"
         );
     }
 


### PR DESCRIPTION
Currently, if the Bitcoin node is still in initial block download when p2poolv2 starts, it logs an error and exits. Since Docker's restart policy then restarts the container, this results in a crash-loop that continues until the node finishes syncing — which can take hours, and looks alarming in the logs even though nothing is actually broken.

This PR changes that behavior:

- Split the preflight error into two cases: `NotSynced` (node is still syncing) and `Rpc` (a genuine connection/config problem), instead of one generic error string.
- Added `wait_for_bitcoin_node_synced`, which checks sync status, and if the node is still syncing, logs a warning and retries every 5 minutes instead of exiting. Any other error (bad credentials, connection failure, etc.) still fails immediately, same as before.
- Added a test (`wait_for_bitcoin_node_synced_retries_until_synced`) that mocks the node reporting "still syncing" twice before reporting "synced," confirming the retry loop actually works end to end.

Ran into this firsthand testing an Umbrel packaging setup — a fresh Bitcoin node install can take many hours to sync, and during that whole window the pool container was stuck crash-looping. This should make that a much quieter, more expected first-run experience.

Happy to adjust the retry interval or logging if there's a preferred approach.