### PR TITLE
Failure modes in nightly simulation

### DIFF
--- a/.github/workflows/sim-nightly.yml
+++ b/.github/workflows/sim-nightly.yml
@@ -5,23 +5,72 @@ on:
     - cron: '0 3 * * *'   # every day at 03:00 UTC
   workflow_dispatch:
     inputs:
+      scenario:
+        description: 'Failure scenario to run'
+        required: false
+        type: choice
+        default: every
+        options:
+          - every
+          - clean
+          - restart-fast
+          - restart-delayed
+          - partition
       node_count:
         description: 'Number of sim nodes'
         required: false
         default: '10'
       duration_seconds:
-        description: 'Swarm run duration in seconds'
+        description: 'Settle time after the scenario, in seconds'
         required: false
-        default: '300'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  sim:
-    name: Sim Swarm (10 nodes, 5 min)
+  # One swarm per failure scenario, so a failing run names the failure mode
+  # that caused it. The matrix is built here rather than inline because a
+  # manual dispatch can narrow it to a single scenario, and the matrix context
+  # is not available to a job-level `if`.
+  select-scenarios:
+    name: Select scenarios
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+    steps:
+      - name: Build scenario matrix
+        id: select
+        env:
+          SELECTED: ${{ github.event.inputs.scenario || 'every' }}
+        run: |
+          set -euo pipefail
+          # convergence_wait is the settle time AFTER the scenario heals;
+          # restart-delayed needs the longest timeout because its node stays
+          # down 330s to cross the 300s tip-age threshold.
+          all='[
+            {"scenario":"clean",           "convergence_wait":"300","timeout":25},
+            {"scenario":"restart-fast",    "convergence_wait":"180","timeout":25},
+            {"scenario":"restart-delayed", "convergence_wait":"180","timeout":40},
+            {"scenario":"partition",       "convergence_wait":"180","timeout":30}
+          ]'
+          if [ "$SELECTED" = "every" ]; then
+            matrix=$(echo "$all" | jq -c .)
+          else
+            matrix=$(echo "$all" | jq -c --arg s "$SELECTED" '[.[] | select(.scenario == $s)]')
+          fi
+          echo "Selected scenarios: $matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  sim:
+    name: Sim Swarm (${{ matrix.scenario }})
+    needs: select-scenarios
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false   # one failing scenario must not cancel the others
+      matrix:
+        include: ${{ fromJSON(needs.select-scenarios.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -44,10 +93,14 @@ jobs:
 
       - name: Run sim integration test
         env:
+          SCENARIO: ${{ matrix.scenario }}
           NODE_COUNT: ${{ github.event.inputs.node_count || '10' }}
-          CONVERGENCE_WAIT_SECONDS: ${{ github.event.inputs.duration_seconds || '300' }}
+          CONVERGENCE_WAIT_SECONDS: ${{ github.event.inputs.duration_seconds || matrix.convergence_wait }}
           IDEAL_BLOCK_TIME: '5'
           SHARES_PER_BLOCK: '1000'
+          # UNCLE_RATE_THRESHOLD stays at its 25% default. Killing nodes creates
+          # forks, so this is the knob to raise if a failure scenario turns out
+          # to be flaky -- raise it here rather than weakening the check itself.
         run: |
           set -o pipefail
           mkdir -p /tmp/p2pool-sim
@@ -57,6 +110,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: sim-logs
+          name: sim-logs-${{ matrix.scenario }}
           path: /tmp/p2pool-sim/
           retention-days: 7

--- a/.github/workflows/sim-nightly.yml
+++ b/.github/workflows/sim-nightly.yml
@@ -103,13 +103,17 @@ jobs:
           # to be flaky -- raise it here rather than weakening the check itself.
         run: |
           set -o pipefail
-          mkdir -p /tmp/p2pool-sim
-          ./load-tests/sim/nightly.sh 2>&1 | tee /tmp/p2pool-sim/nightly-output.log
+          # Keep this log OUTSIDE the run dir: run-swarm.sh starts by doing
+          # `rm -rf "$RUN_DIR"`, which unlinks the file tee is still writing to,
+          # so a log written there never reaches the artifact.
+          ./load-tests/sim/nightly.sh 2>&1 | tee /tmp/nightly-output.log
 
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: sim-logs-${{ matrix.scenario }}
-          path: /tmp/p2pool-sim/
+          path: |
+            /tmp/p2pool-sim/
+            /tmp/nightly-output.log
           retention-days: 7

--- a/docs/simulation/RUNBOOK.md
+++ b/docs/simulation/RUNBOOK.md
@@ -192,7 +192,7 @@ uncle rate ≈ latency/10s (e.g. 750 ms → ~7%), but a 45s read is only ~4 bloc
 too noisy to trust. For a real number in ~5 min add `IDEAL_BLOCK_TIME=1` (10× more
 blocks, latency auto-scales), e.g.
 `IDEAL_BLOCK_TIME=1 LATENCY_MS=1500 SHARES_PER_BLOCK=20 ./load-tests/sim/run-swarm.sh 20`
-→ ~12% (≈50 min-equivalent). Knob in §9.
+→ ~12% (≈50 min-equivalent). Knob in §10.
 
 Under the hood it greps the `sim-uncle:` log lines:
 
@@ -258,7 +258,84 @@ Stop everything:
 
 ---
 
-## 8. Where things live
+## 8. Test F — a node fails and catches up (Phase 4)
+
+Failures are injected into an already-running swarm by `failures.sh`, which
+`SIGKILL`s nodes, restarts them against the *same* config and store, and then
+polls each one's log until its confirmed tip reaches where the rest of the
+swarm has got to.
+
+Start a swarm and, in a second terminal, kill a node and watch it come back:
+
+```sh
+./load-tests/sim/run-swarm.sh 6
+FAILURE_WARMUP=20 FAILURE_FAST_DOWN=10 ./load-tests/sim/failures.sh restart-fast
+```
+
+Expect the target to report `alive NO` in `observe.sh` during the downtime,
+then `alive yes` with a climbing tip, and a summary ending:
+
+```
+node 3: rejoined=yes catchup_secs=5 gap_heights=14 target_height=32
+rejoined: 1/1
+unrecovered nodes: 0
+```
+
+The interesting one is the long downtime, which is the default:
+
+```sh
+./load-tests/sim/failures.sh restart-delayed     # 330s down
+```
+
+330s crosses the 300s `MAX_TIP_AGE_SECS` threshold, so the node rejoins *not*
+current. Inv gossip is deliberately ignored in that state, so the catch-up has
+to come from the header-sync path. In the restarted node's log, after the
+`=== failure injection: restarting node <i> ===` marker, expect a fresh
+`Local peer id:`, then the handshake driving a header sync rather than
+inv-driven block fetches:
+
+```
+Received Handshake from peer ...: peer_height=187, ..., local_height=30
+Local chain behind peer ... (30 < 187), sending getheaders
+Sending GetHeaders to peer ...: GetShareHeaders([...15-hash locator...], 0000...)
+Received 160 ShareHeaders
+```
+
+The `partition` scenario kills `DIAL_FANOUT` consecutive nodes at once, cutting
+the `dial_peers` chain. Whether that is a real partition is an open question at
+runtime — Kademlia dials peers that were never in `dial_peers` — so the summary
+counts outbound connections crossing the cut and reports what actually happened:
+
+```sh
+./load-tests/sim/failures.sh partition
+# cross-side links at +15s: lower_to_upper=0 upper_to_lower=0   <- a real partition
+```
+
+The whole thing runs end to end, with the usual pass/fail verdict, via:
+
+```sh
+./load-tests/sim/nightly.sh restart-delayed
+```
+
+**Gotchas specific to failure injection**
+
+1. **Node 0 is never a target.** `metrics.sh` derives the share rate and uncle
+   rate from `node-0.log` alone, so killing it corrupts the run's own metrics.
+2. **Restarts append to the node log** (`>>`, not `>`). Truncating would throw
+   away the promotion history every log-based metric is computed from.
+3. **A restarted node has a new PeerId.** The libp2p keypair is generated per
+   process start and never persisted, so a rejoin looks like a new node to its
+   peers. The Kademlia routing table is in-memory too, so it starts empty.
+4. **Mid-run tip readings come from logs or the API, never the store.** RocksDB
+   holds an exclusive lock while a node runs, which is why `nightly.sh` only
+   does its store-based convergence check after `stop-swarm.sh`.
+5. **`pids.txt` is positional** (line `i+1` is node `i`). `failures.sh` rewrites
+   the line on restart, which is what keeps `observe.sh` and the nightly's
+   alive check honest.
+
+---
+
+## 9. Where things live
 
 | Thing              | Path                                                      |
 |--------------------|-----------------------------------------------------------|
@@ -267,7 +344,8 @@ Stop everything:
 | Per-node config    | `/tmp/p2pool-sim/node-<i>.toml`                           |
 | Per-node log       | `/tmp/p2pool-sim/node-<i>.log`                            |
 | Per-node store     | `/tmp/p2pool-sim/store-<i>.db`                            |
-| PIDs               | `/tmp/p2pool-sim/pids.txt`                                |
+| PIDs               | `/tmp/p2pool-sim/pids.txt` (line `i+1` is node `i`)        |
+| Failure summary    | `/tmp/p2pool-sim/failure-results.txt`                     |
 | Node APIs          | `http://127.0.0.1:760<i>` (node i)                        |
 | regtest bitcoind   | datadir `/tmp/p2pool-regtest`, RPC `:19443`, ZMQ `:28332` |
 
@@ -290,7 +368,7 @@ curl -s :7600/chain_info | jq            # tip/candidate heights (prefer logs fo
 
 ---
 
-## 9. Env knobs for `run-swarm.sh`
+## 10. Env knobs for `run-swarm.sh`
 
 `run-swarm.sh [N]` (default N=20). Override with env vars:
 
@@ -309,7 +387,7 @@ curl -s :7600/chain_info | jq            # tip/candidate heights (prefer logs fo
 
 ---
 
-## 10. Gotchas
+## 11. Gotchas
 
 1. **Swarms must run release.** A debug build hits a `debug_assert_eq!` inside
    `libp2p-request-response` under connection churn and nodes abort (you'd see

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -119,6 +119,7 @@ load-tests/sim/metrics.sh          # authoritative LOG-based summary: convergenc
                                    # difficulty, emission∝hashrate, uncles, block-finds
 load-tests/sim/plot-metrics.sh     # PNG time-series (share rate, difficulty, uncle rate,
                                    # block-finds, hashrate bars) → RUN_DIR/metrics.png
+load-tests/sim/failures.sh S       # inject failure scenario S into the running swarm
 load-tests/sim/stop-swarm.sh       # stop all (incl. orphans matching this RUN_DIR)
 ```
 
@@ -134,4 +135,37 @@ more blocks/min for faster data, auto-scales `LATENCY_MS`), `DIST_SEED`, `DISTIN
 shows as `distinct tips: 1` (a snapshot may straddle the latest 1–2 heights while
 the frontier propagates). Run release; always `stop-swarm.sh` before relaunching
 (orphans hold ports — `run-swarm.sh` now also clears its RUN_DIR's leftovers).
+
+### Failure scenarios (Phase 4)
+
+`failures.sh` injects one named failure mode into a running swarm, kills nodes
+with `SIGKILL`, brings them back against the *same* config and store, and
+verifies each one rejoins and catches up to the rest of the swarm. `nightly.sh`
+takes the same scenario name (`nightly.sh restart-delayed`, or `SCENARIO=...`),
+and the nightly workflow runs it once per scenario so a failing night names the
+failure mode that caused it.
+
+| Scenario | What it exercises |
+|---|---|
+| `clean` | nothing; the baseline run |
+| `restart-fast` | a node fails and comes back immediately |
+| `restart-delayed` | a node fails and comes back after `FAILURE_SLOW_DOWN` (default 330s). That crosses the 300s `MAX_TIP_AGE_SECS` threshold, so the node rejoins *not* current: inv gossip is ignored and it must bulk-sync via `getheaders` and block fetch |
+| `partition` | `DIAL_FANOUT` consecutive nodes fail at once, cutting the dial chain, then all come back |
+| `all` | the three failure scenarios in sequence (local use) |
+
+Tunables: `FAILURE_SEED` (target selection; targets are printed so a failing
+run is reproducible), `FAILURE_WARMUP`, `FAILURE_FAST_DOWN`,
+`FAILURE_SLOW_DOWN`, `FAILURE_PARTITION_DOWN`, `FAILURE_CATCHUP_TIMEOUT`.
+
+Two things to know about `partition`. First, it is a *topology* cut: it removes
+the nodes that bridge the `dial_peers` chain, but Kademlia discovers and dials
+peers that were never in `dial_peers`, so the two sides may well stay connected.
+The summary records which happened, by counting outbound connections that cross
+the cut (`cross-side links at +15s: lower_to_upper=0 upper_to_lower=0` means it
+really was a partition). Second, a restarted node comes back with a **new
+PeerId** — the libp2p keypair is generated per process start, not persisted — so
+rejoining looks to its peers like a new node arriving.
+
+Node 0 is never a target: `metrics.sh` derives the share rate and uncle rate
+from `node-0.log` alone, so killing it would corrupt the run's own metrics.
 

--- a/load-tests/sim/failures.sh
+++ b/load-tests/sim/failures.sh
@@ -1,0 +1,453 @@
+#!/usr/bin/env bash
+#
+# Failure-mode injection for a running sim swarm.
+#
+# Runs ONE named scenario against a swarm already started by run-swarm.sh:
+# kills nodes with SIGKILL, brings them back, and verifies each one rejoins
+# and catches up to the rest of the swarm. Writes a plain-text summary to
+# stdout and to $RUN_DIR/failure-results.txt; nightly.sh greps that summary
+# for its verdict (same contract metrics.sh has with nightly.sh).
+#
+# Usage:
+#   load-tests/sim/failures.sh <scenario>
+#
+# Scenarios:
+#   clean             no-op (today's nightly behaviour)
+#   restart-fast      one node fails and comes back immediately
+#   restart-delayed   one node fails and comes back after a long delay, so we
+#                     validate it catches up; the default downtime crosses the
+#                     300s tip-age threshold, so the node rejoins "not current"
+#                     and must bulk-sync via getheaders rather than inv gossip
+#   partition         DIAL_FANOUT consecutive nodes fail at once, cutting the
+#                     dial chain, then all come back. Kademlia may keep the two
+#                     sides connected; the summary reports which happened
+#   all               the three above in sequence (local use, not CI)
+#
+# Env overrides:
+#   RUN_DIR                   swarm work dir                (default /tmp/p2pool-sim)
+#   BASE_P2P / BASE_API       first libp2p / API port       (default 7000 / 7600)
+#   PROFILE                   cargo profile: release|debug  (default release)
+#   SIM_BIN                   sim binary path               (default from PROFILE)
+#   DIAL_FANOUT               peers each node dials         (default 3)
+#   FAILURE_SEED              target selection seed         (default 42)
+#   FAILURE_WARMUP            settle before injecting (s)   (default 60)
+#   FAILURE_FAST_DOWN         restart-fast downtime (s)     (default 10)
+#   FAILURE_SLOW_DOWN         restart-delayed downtime (s)  (default 330)
+#   FAILURE_PARTITION_DOWN    partition downtime (s)        (default 90)
+#   FAILURE_CATCHUP_TIMEOUT   max wait for catch-up (s)     (default 240)
+#
+# Node 0 is never a target: metrics.sh derives the share rate and uncle rate
+# from node-0.log alone, so killing it would corrupt the run's own metrics.
+#
+# (no `set -e`: a node that fails to catch up must still reach the summary)
+set -uo pipefail
+
+show_help() {
+  cat <<'HELP'
+failures.sh -- inject one failure scenario into a running sim swarm
+
+Kills nodes with SIGKILL, brings them back, and verifies each one rejoins and
+catches up. Writes a summary to stdout and $RUN_DIR/failure-results.txt.
+
+Usage:
+  load-tests/sim/failures.sh <scenario>
+
+Scenarios:
+  clean             no-op (today's nightly behaviour)
+  restart-fast      one node fails and comes back immediately
+  restart-delayed   one node fails and comes back after a long delay, so we
+                    validate it catches up; the default downtime crosses the
+                    300s tip-age threshold, so the node rejoins "not current"
+                    and must bulk-sync via getheaders rather than inv gossip
+  partition         DIAL_FANOUT consecutive nodes fail at once, cutting the
+                    dial chain, then all come back. Kademlia may keep the two
+                    sides connected; the summary reports which happened
+  all               the three above in sequence (local use, not CI)
+
+Env vars:
+  RUN_DIR                   swarm work dir                (default /tmp/p2pool-sim)
+  BASE_P2P / BASE_API       first libp2p / API port       (default 7000 / 7600)
+  PROFILE                   cargo profile: release|debug  (default release)
+  SIM_BIN                   sim binary path               (default from PROFILE)
+  DIAL_FANOUT               peers each node dials         (default 3)
+  FAILURE_SEED              target selection seed         (default 42)
+  FAILURE_WARMUP            settle before injecting (s)   (default 60)
+  FAILURE_FAST_DOWN         restart-fast downtime (s)     (default 10)
+  FAILURE_SLOW_DOWN         restart-delayed downtime (s)  (default 330)
+  FAILURE_PARTITION_DOWN    partition downtime (s)        (default 90)
+  FAILURE_CATCHUP_TIMEOUT   max wait for catch-up (s)     (default 240)
+
+Node 0 is never a target: metrics.sh derives the share rate and uncle rate
+from node-0.log alone, so killing it would corrupt the run's own metrics.
+
+Examples:
+  load-tests/sim/failures.sh restart-fast
+  FAILURE_WARMUP=20 FAILURE_SLOW_DOWN=60 load-tests/sim/failures.sh restart-delayed
+
+Related scripts:
+  load-tests/sim/run-swarm.sh N    launch the swarm this operates on
+  load-tests/sim/observe.sh        live per-node view (tip, peers, alive)
+  load-tests/sim/nightly.sh        automated runner; calls this script
+HELP
+  exit 0
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  show_help
+fi
+
+SCENARIO="${1:-clean}"
+
+RUN_DIR="${RUN_DIR:-/tmp/p2pool-sim}"
+BASE_P2P="${BASE_P2P:-7000}"
+BASE_API="${BASE_API:-7600}"
+PROFILE="${PROFILE:-release}"
+DIAL_FANOUT="${DIAL_FANOUT:-3}"
+FAILURE_SEED="${FAILURE_SEED:-42}"
+FAILURE_WARMUP="${FAILURE_WARMUP:-60}"
+FAILURE_FAST_DOWN="${FAILURE_FAST_DOWN:-10}"
+FAILURE_SLOW_DOWN="${FAILURE_SLOW_DOWN:-330}"
+FAILURE_PARTITION_DOWN="${FAILURE_PARTITION_DOWN:-90}"
+FAILURE_CATCHUP_TIMEOUT="${FAILURE_CATCHUP_TIMEOUT:-240}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+if [ "$PROFILE" = "release" ]; then
+  BIN="${SIM_BIN:-$REPO_ROOT/target/release/p2poolv2_sim}"
+else
+  BIN="${SIM_BIN:-$REPO_ROOT/target/debug/p2poolv2_sim}"
+fi
+
+PIDS_FILE="$RUN_DIR/pids.txt"
+RESULTS_FILE="$RUN_DIR/failure-results.txt"
+
+# Summary state, printed by write_summary at the end.
+SUMMARY_LINES=()
+OBSERVATION_LINES=()
+TARGET_LIST=""
+REJOINED_OK=0
+REJOINED_TOTAL=0
+# Tip height of each node just before it was killed, indexed by node number.
+TIP_AT_KILL=()
+
+log_message() {
+  echo "[$(date +%H:%M:%S)] $*"
+}
+
+# ---------------------------------------------------------------------------
+# Node lifecycle
+# ---------------------------------------------------------------------------
+
+node_pid() {
+  sed -n "$(($1 + 1))p" "$PIDS_FILE" 2>/dev/null
+}
+
+# Rewrite line i+1 of pids.txt so nightly.sh's alive check and observe.sh keep
+# reading the current pid for this node.
+set_node_pid() {
+  local index="$1" pid="$2" tmp
+  tmp="$(mktemp "$RUN_DIR/pids.XXXXXX")"
+  awk -v line="$((index + 1))" -v pid="$pid" 'NR == line { print pid; next } { print }' \
+    "$PIDS_FILE" > "$tmp"
+  mv "$tmp" "$PIDS_FILE"
+}
+
+# SIGKILL a node and wait for the process to go away. The marker written into
+# the node log must not contain "error" or "panic": observe.sh greps for those.
+kill_node() {
+  local index="$1" pid attempt
+  pid="$(node_pid "$index")"
+  TIP_AT_KILL[index]="$(log_tip_height "$index")"
+
+  if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+    log_message "  node $index already down (no live pid)"
+    return 1
+  fi
+
+  echo "=== failure injection: SIGKILL node $index at $(date +%H:%M:%S), tip ${TIP_AT_KILL[index]} ===" \
+    >> "$RUN_DIR/node-$index.log"
+  kill -9 "$pid" 2>/dev/null
+
+  attempt=0
+  while [ "$attempt" -lt 10 ]; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      log_message "  killed node $index (pid $pid, tip ${TIP_AT_KILL[index]})"
+      return 0
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+  log_message "  node $index (pid $pid) did not exit after SIGKILL"
+  return 1
+}
+
+# Relaunch a node against its existing config and store. The log is APPENDED
+# to: truncating it would destroy the promotion history metrics.sh reads.
+start_node() {
+  local index="$1" pid
+  echo "=== failure injection: restarting node $index at $(date +%H:%M:%S) ===" \
+    >> "$RUN_DIR/node-$index.log"
+  "$BIN" --config "$RUN_DIR/node-$index.toml" >> "$RUN_DIR/node-$index.log" 2>&1 &
+  pid=$!
+  set_node_pid "$index" "$pid"
+  log_message "  restarted node $index (pid $pid)"
+}
+
+# ---------------------------------------------------------------------------
+# Observation (logs and API only: RocksDB is locked while a node runs, so the
+# store-based checks in nightly.sh cannot be used mid-run)
+# ---------------------------------------------------------------------------
+
+log_tip_height() {
+  local height
+  height="$(grep -oE "to confirmed height Some\([0-9]+\)" "$RUN_DIR/node-$1.log" 2>/dev/null \
+    | grep -oE "[0-9]+" | sort -n | tail -1)"
+  echo "${height:-0}"
+}
+
+swarm_max_tip() {
+  local index height max=0
+  for index in $(seq 0 $((NODE_TOTAL - 1))); do
+    height="$(log_tip_height "$index")"
+    if [ "$height" -gt "$max" ]; then max="$height"; fi
+  done
+  echo "$max"
+}
+
+# Poll a restarted node's log until its confirmed tip reaches target_height.
+# Sets CATCHUP_SECS. Returns non-zero on timeout or if the process died.
+wait_for_catchup() {
+  local index="$1" target="$2" timeout="$3" start now height pid
+  start="$(date +%s)"
+  CATCHUP_SECS=0
+  while true; do
+    now="$(date +%s)"
+    CATCHUP_SECS=$((now - start))
+    height="$(log_tip_height "$index")"
+    if [ "$height" -ge "$target" ]; then
+      return 0
+    fi
+    pid="$(node_pid "$index")"
+    if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+      log_message "  node $index died while catching up (tip $height, target $target)"
+      return 1
+    fi
+    if [ "$CATCHUP_SECS" -ge "$timeout" ]; then
+      log_message "  node $index did not reach height $target within ${timeout}s (tip $height)"
+      return 1
+    fi
+    sleep 5
+  done
+}
+
+# Listen ports of the peers a node has dialled OUT to. Inbound entries carry an
+# ephemeral send_back port, so only outbound links map back to a node index --
+# which is enough, because every link is outbound from one of its two ends.
+outbound_peer_ports() {
+  curl -s -m 2 "http://127.0.0.1:$((BASE_API + $1))/peers" 2>/dev/null \
+    | jq -r '.[] | select(.direction == "Outbound") | .address' 2>/dev/null \
+    | grep -oE "/tcp/[0-9]+" | cut -d/ -f3
+}
+
+# Count links from the nodes in $1 (space-separated) to the nodes in $2.
+count_links_between() {
+  local sources="$1" targets="$2" index port target_ports="" links=0
+  for index in $targets; do
+    target_ports="$target_ports $((BASE_P2P + index))"
+  done
+  for index in $sources; do
+    while read -r port; do
+      [ -z "$port" ] && continue
+      case " $target_ports " in
+        *" $port "*) links=$((links + 1)) ;;
+      esac
+    done < <(outbound_peer_ports "$index")
+  done
+  echo "$links"
+}
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+# Kill every node in the argument list, recording its pre-kill tip.
+kill_nodes() {
+  local index
+  for index in "$@"; do
+    kill_node "$index"
+  done
+}
+
+# Restart every node in the argument list and verify each one catches up to
+# where the surviving swarm has got to. Accumulates the summary rows.
+restart_and_verify() {
+  local index target gap rejoined
+  target="$(swarm_max_tip)"
+  log_message "Restarting node(s) '$*'; catch-up target is height $target"
+  for index in "$@"; do
+    start_node "$index"
+  done
+  for index in "$@"; do
+    gap=$((target - ${TIP_AT_KILL[index]:-0}))
+    if wait_for_catchup "$index" "$target" "$FAILURE_CATCHUP_TIMEOUT"; then
+      rejoined="yes"
+      REJOINED_OK=$((REJOINED_OK + 1))
+      log_message "  node $index caught up to height $target in ${CATCHUP_SECS}s (gap ${gap} heights)"
+    else
+      rejoined="no"
+    fi
+    REJOINED_TOTAL=$((REJOINED_TOTAL + 1))
+    SUMMARY_LINES+=("node $index: rejoined=$rejoined catchup_secs=$CATCHUP_SECS gap_heights=$gap target_height=$target")
+  done
+}
+
+scenario_restart_fast() {
+  log_message "--- restart-fast: node $TARGET_FAST down for ${FAILURE_FAST_DOWN}s ---"
+  TARGET_LIST="$TARGET_LIST $TARGET_FAST"
+  kill_nodes "$TARGET_FAST"
+  sleep "$FAILURE_FAST_DOWN"
+  restart_and_verify "$TARGET_FAST"
+}
+
+scenario_restart_delayed() {
+  log_message "--- restart-delayed: node $TARGET_SLOW down for ${FAILURE_SLOW_DOWN}s ---"
+  TARGET_LIST="$TARGET_LIST $TARGET_SLOW"
+  kill_nodes "$TARGET_SLOW"
+  sleep "$FAILURE_SLOW_DOWN"
+  restart_and_verify "$TARGET_SLOW"
+}
+
+# Kill the nodes that bridge the dial chain, so nodes below and above the cut
+# have no configured path to each other, then bring them back. Whether this is
+# a real partition depends on Kademlia, which discovers and dials peers that
+# were never in dial_peers; the observation lines record what actually happened.
+scenario_partition() {
+  local killed="" lower="" upper="" index links_down links_up elapsed sample
+  for index in $(seq "$PARTITION_START" $((PARTITION_START + PARTITION_WIDTH - 1))); do
+    killed="$killed $index"
+  done
+  for index in $(seq 0 $((PARTITION_START - 1))); do
+    lower="$lower $index"
+  done
+  for index in $(seq $((PARTITION_START + PARTITION_WIDTH)) $((NODE_TOTAL - 1))); do
+    upper="$upper $index"
+  done
+
+  log_message "--- partition: nodes$killed down for ${FAILURE_PARTITION_DOWN}s (lower side$lower, upper side$upper) ---"
+  TARGET_LIST="$TARGET_LIST$killed"
+  # shellcheck disable=SC2086
+  kill_nodes $killed
+
+  elapsed=0
+  for sample in 15 45; do
+    if [ "$sample" -le "$FAILURE_PARTITION_DOWN" ]; then
+      sleep $((sample - elapsed))
+      elapsed="$sample"
+      links_down="$(count_links_between "$lower" "$upper")"
+      links_up="$(count_links_between "$upper" "$lower")"
+      OBSERVATION_LINES+=("cross-side links at +${sample}s: lower_to_upper=$links_down upper_to_lower=$links_up")
+      log_message "  cross-side links at +${sample}s: lower->upper=$links_down upper->lower=$links_up"
+    fi
+  done
+  if [ "$FAILURE_PARTITION_DOWN" -gt "$elapsed" ]; then
+    sleep $((FAILURE_PARTITION_DOWN - elapsed))
+  fi
+
+  # shellcheck disable=SC2086
+  restart_and_verify $killed
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+write_summary() {
+  local unrecovered=$((REJOINED_TOTAL - REJOINED_OK)) line
+  {
+    echo "=== failure injection summary (scenario: $SCENARIO) ==="
+    echo "targets:${TARGET_LIST:- none}"
+    for line in "${OBSERVATION_LINES[@]+"${OBSERVATION_LINES[@]}"}"; do
+      echo "$line"
+    done
+    for line in "${SUMMARY_LINES[@]+"${SUMMARY_LINES[@]}"}"; do
+      echo "$line"
+    done
+    echo "rejoined: $REJOINED_OK/$REJOINED_TOTAL"
+    echo "unrecovered nodes: $unrecovered"
+  } | tee "$RESULTS_FILE"
+  [ "$unrecovered" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+case "$SCENARIO" in
+  clean|restart-fast|restart-delayed|partition|all) ;;
+  *)
+    echo "ERROR: unknown scenario '$SCENARIO' (expected clean, restart-fast, restart-delayed, partition or all)" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -d "$RUN_DIR" ]; then
+  echo "ERROR: no run dir at $RUN_DIR; start a swarm with run-swarm.sh first." >&2
+  exit 1
+fi
+NODE_TOTAL=$(ls "$RUN_DIR"/node-*.toml 2>/dev/null | wc -l | tr -d ' ')
+if [ "$NODE_TOTAL" -eq 0 ]; then
+  echo "ERROR: no node configs in $RUN_DIR; start a swarm with run-swarm.sh first." >&2
+  exit 1
+fi
+
+if [ "$SCENARIO" = "clean" ]; then
+  log_message "scenario 'clean': no failures injected"
+  write_summary
+  exit $?
+fi
+
+if [ ! -x "$BIN" ]; then
+  echo "ERROR: sim binary not found at $BIN (set PROFILE, or build with run-swarm.sh)." >&2
+  exit 1
+fi
+if [ "$NODE_TOTAL" -lt 3 ]; then
+  echo "ERROR: failure injection needs at least 3 nodes (node 0 is never a target); have $NODE_TOTAL." >&2
+  exit 1
+fi
+
+# Seeded target selection, so a failing nightly is reproducible. Same
+# single-awk-with-srand idiom run-swarm.sh uses for its distributions.
+# Targets are drawn from [1, N-1]; the partition cut keeps at least one node on
+# each side of it.
+read -r TARGET_FAST TARGET_SLOW PARTITION_START PARTITION_WIDTH < <(
+  awk -v seed="$FAILURE_SEED" -v n="$NODE_TOTAL" -v fanout="$DIAL_FANOUT" 'BEGIN {
+    srand(seed + 0)
+    fast = 1 + int(rand() * (n - 1))
+    slow = 1 + int(rand() * (n - 1))
+    while (slow == fast && n > 2) { slow = 1 + int(rand() * (n - 1)) }
+    width = fanout
+    if (width > n - 2) width = n - 2
+    if (width < 1) width = 1
+    max_start = n - width - 1
+    if (max_start < 1) max_start = 1
+    start = 1 + int(rand() * max_start)
+    printf "%d %d %d %d\n", fast, slow, start, width
+  }'
+)
+
+log_message "scenario '$SCENARIO' on $NODE_TOTAL nodes (seed $FAILURE_SEED)"
+log_message "Warming up for ${FAILURE_WARMUP}s before injecting failures..."
+sleep "$FAILURE_WARMUP"
+
+case "$SCENARIO" in
+  restart-fast)    scenario_restart_fast ;;
+  restart-delayed) scenario_restart_delayed ;;
+  partition)       scenario_partition ;;
+  all)
+    scenario_restart_fast
+    scenario_restart_delayed
+    scenario_partition
+    ;;
+esac
+
+write_summary

--- a/load-tests/sim/nightly.sh
+++ b/load-tests/sim/nightly.sh
@@ -367,12 +367,33 @@ check_all_nodes_alive() {
   [ "$ALIVE_COUNT" -eq "$ALIVE_TOTAL" ] && [ "$ALIVE_TOTAL" -gt 0 ]
 }
 
+# Run a p2poolv2_cli query against a store and echo its JSON on stdout.
+#
+# On a non-zero exit the CLI's stderr is surfaced on OUR stderr (so it reaches
+# the console log without polluting the value the caller captures) rather than
+# being discarded. A silently empty result here is indistinguishable from an
+# empty chain, which is what made a failed nightly undiagnosable from its
+# artifact: a locked store, a missing binary and a corrupt chain all looked the
+# same.
+query_store() {
+  local store="$1"
+  shift
+  local stderr_file output status=0
+  stderr_file="$(mktemp)"
+  output=$("$CLI_BIN" --db-path "$store" "$@" 2>"$stderr_file") || status=$?
+  if [ "$status" -ne 0 ]; then
+    log_message "  p2poolv2_cli $* failed on $store (exit $status):" >&2
+    head -5 "$stderr_file" | sed 's/^/    /' >&2
+  fi
+  rm -f "$stderr_file"
+  printf '%s' "$output"
+}
+
 # Confirmed tip height of a store, or empty on error. Uses `shares --num 1`
 # (not `info`, which reads chain-tip metadata that can fail to decode on some
 # stores).
 store_tip_height() {
-  local store="$1"
-  "$CLI_BIN" --db-path "$store" shares --num 1 2>/dev/null \
+  query_store "$1" shares --num 1 \
     | python3 -c "
 import sys, json
 try:
@@ -380,14 +401,14 @@ try:
     print(shares[0]['height'] if shares else '')
 except Exception:
     print('')
-" || true
+"
 }
 
 # Confirmed block hash at a specific height in a store, or empty if the store
 # has no confirmed block at that height (or on error).
 store_hash_at_height() {
   local store="$1" height="$2"
-  "$CLI_BIN" --db-path "$store" shares --to "$height" --num 1 2>/dev/null \
+  query_store "$store" shares --to "$height" --num 1 \
     | python3 -c "
 import sys, json
 want = int(sys.argv[1])
@@ -396,7 +417,7 @@ try:
     print(shares[0]['blockhash'] if shares and shares[0].get('height') == want else '')
 except Exception:
     print('')
-" "$height" || true
+" "$height"
 }
 
 # Convergence is checked against the actual store state, not the logs. Reorgs
@@ -420,6 +441,7 @@ check_chain_converged() {
   done
 
   if [ "${#tips[@]}" -eq 0 ]; then
+    log_message "  no confirmed tip readable from any store in $RUN_DIR (see the p2poolv2_cli errors above)" >&2
     DISTINCT_HASHES=-1
     WITHIN2="0/$NODE_COUNT"
     return 1

--- a/load-tests/sim/nightly.sh
+++ b/load-tests/sim/nightly.sh
@@ -2,43 +2,65 @@
 #
 # Nightly simulation runner: end-to-end automated sim with pass/fail verdict.
 #
-# Starts regtest bitcoind if needed, launches a swarm via run-swarm.sh, waits
-# for convergence, collects metrics via metrics.sh, evaluates pass/fail
-# thresholds, cleans up, and exits 0 (pass) or 1 (fail).
+# Starts regtest bitcoind if needed, launches a swarm via run-swarm.sh, injects
+# a failure scenario via failures.sh, waits for convergence, collects metrics
+# via metrics.sh, evaluates pass/fail thresholds, cleans up, and exits 0 (pass)
+# or 1 (fail).
 #
 # Usage:
-#   load-tests/sim/nightly.sh
+#   load-tests/sim/nightly.sh [scenario]
+#
+# The scenario selects which failure mode to inject; `clean` injects none. The
+# nightly workflow runs this script once per scenario, so each failure mode
+# gets its own swarm, its own verdict and its own artifacts.
 #
 # Env overrides (nightly-specific):
+#   SCENARIO                   failure scenario to inject    (default clean)
+#                              clean | restart-fast | restart-delayed |
+#                              partition | all
 #   NODE_COUNT                 number of sim nodes           (default 20)
-#   CONVERGENCE_WAIT_SECONDS   seconds to let swarm run      (default 60)
+#   CONVERGENCE_WAIT_SECONDS   seconds to settle after the
+#                              scenario, before the checks   (default 60)
 #   UNCLE_RATE_THRESHOLD       max uncle rate % to pass      (default 25)
 #   BITCOIND_DATADIR           regtest data directory        (default /tmp/bitcoind-p2poolv2)
 #   BITCOIND_BIN               path to bitcoind binary       (auto-detected)
 #   BITCOIN_CLI_BIN            path to bitcoin-cli binary    (auto-detected)
 #
 # All run-swarm.sh env vars (RUN_DIR, RPC_URL, RPC_USER, RPC_PASS, ZMQ,
-# SHARES_PER_BLOCK, LATENCY_MS, IDEAL_BLOCK_TIME, etc.) are passed through as-is.
+# SHARES_PER_BLOCK, LATENCY_MS, IDEAL_BLOCK_TIME, etc.) and all failures.sh
+# env vars (FAILURE_SEED, FAILURE_WARMUP, FAILURE_SLOW_DOWN, etc.) are passed
+# through as-is.
 set -euo pipefail
 
 show_help() {
   cat <<'HELP'
 nightly.sh -- automated sim runner with pass/fail verdict
 
-Starts regtest bitcoind if needed, launches a swarm, waits for convergence,
-collects metrics, evaluates thresholds, and exits 0 (pass) or 1 (fail).
+Starts regtest bitcoind if needed, launches a swarm, injects a failure
+scenario, waits for convergence, collects metrics, evaluates thresholds, and
+exits 0 (pass) or 1 (fail).
 
 Usage:
-  load-tests/sim/nightly.sh [--help]
+  load-tests/sim/nightly.sh [scenario] [--help]
+
+Scenarios (see load-tests/sim/failures.sh --help for the details):
+  clean             no failures injected (the default)
+  restart-fast      a node fails and comes back immediately
+  restart-delayed   a node fails and comes back after a long delay
+  partition         several nodes fail at once, cutting the dial chain
+  all               the three failure scenarios in sequence
 
 Examples:
-  ./load-tests/sim/nightly.sh                              # 20 nodes, 60s, default settings
+  ./load-tests/sim/nightly.sh                              # 20 nodes, 60s, no failures
+  ./load-tests/sim/nightly.sh restart-delayed              # long-downtime catch-up
   NODE_COUNT=5 CONVERGENCE_WAIT_SECONDS=30 ./load-tests/sim/nightly.sh
   IDEAL_BLOCK_TIME=1 SHARES_PER_BLOCK=100 ./load-tests/sim/nightly.sh  # time-compressed, frequent blocks
 
 Env vars (nightly-specific):
+  SCENARIO                   failure scenario to inject    (default clean)
   NODE_COUNT                 number of sim nodes           (default 20)
-  CONVERGENCE_WAIT_SECONDS   seconds to let swarm run      (default 60)
+  CONVERGENCE_WAIT_SECONDS   seconds to settle after the
+                             scenario, before the checks   (default 60)
   UNCLE_RATE_THRESHOLD       max uncle rate % to pass      (default 25)
   BITCOIND_DATADIR           regtest data directory        (default /tmp/bitcoind-p2poolv2)
   BITCOIND_BIN               path to bitcoind binary       (auto-detected)
@@ -56,6 +78,7 @@ Env vars (passed through to run-swarm.sh):
 
 Related scripts:
   load-tests/sim/run-swarm.sh N    launch swarm for manual exploration
+  load-tests/sim/failures.sh S     inject scenario S into a running swarm
   load-tests/sim/stop-swarm.sh     stop a running swarm
   load-tests/sim/metrics.sh        show log-based metrics summary
   load-tests/sim/plot-metrics.sh   generate metrics PNG from last run
@@ -70,6 +93,7 @@ fi
 # ---------------------------------------------------------------------------
 # Defaults
 # ---------------------------------------------------------------------------
+SCENARIO="${1:-${SCENARIO:-clean}}"
 NODE_COUNT="${NODE_COUNT:-20}"
 CONVERGENCE_WAIT_SECONDS="${CONVERGENCE_WAIT_SECONDS:-60}"
 UNCLE_RATE_THRESHOLD="${UNCLE_RATE_THRESHOLD:-25}"
@@ -88,6 +112,17 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 STARTED_BITCOIND=0
 SWARM_RUNNING=0
 METRICS_OUTPUT=""
+FAILURE_OUTPUT=""
+
+# Validate the scenario here as well as in failures.sh, so a typo fails now
+# rather than after bitcoind and the swarm have been brought up.
+case "$SCENARIO" in
+  clean|restart-fast|restart-delayed|partition|all) ;;
+  *)
+    echo "ERROR: unknown scenario '$SCENARIO' (expected clean, restart-fast, restart-delayed, partition or all)" >&2
+    exit 2
+    ;;
+esac
 
 # ---------------------------------------------------------------------------
 # Utility functions
@@ -203,6 +238,17 @@ run_swarm() {
   SWARM_RUNNING=1
 }
 
+# Run the failure scenario. Its progress streams straight through so a long
+# scenario is visible in the CI log while it runs; the summary is read back
+# from the results file afterwards.
+inject_failures() {
+  log_message "Injecting failure scenario '$SCENARIO'..."
+  "$SCRIPT_DIR/failures.sh" "$SCENARIO" || true
+  FAILURE_OUTPUT=$(cat "$RUN_DIR/failure-results.txt" 2>/dev/null) || FAILURE_OUTPUT=""
+}
+
+# Settle window between the last injected failure healing and the checks, so
+# the swarm has time to converge on one chain again.
 wait_for_convergence() {
   log_message "Waiting ${CONVERGENCE_WAIT_SECONDS}s for convergence..."
   sleep "$CONVERGENCE_WAIT_SECONDS"
@@ -433,6 +479,21 @@ check_no_rejections() {
   [ "$ASERT_MISMATCH_COUNT" -eq 0 ] && [ "$MERKLE_PAYOUT_COUNT" -eq 0 ]
 }
 
+# Every node killed by the scenario must have come back and caught up to the
+# rest of the swarm within its timeout. Trivially passes for `clean`.
+check_failure_recovery() {
+  UNRECOVERED_COUNT=$(echo "$FAILURE_OUTPUT" \
+    | grep -oE "unrecovered nodes: [0-9]+" \
+    | grep -oE "[0-9]+" || echo "-1")
+  # Empty when failures.sh died before writing its summary; the -1 count above
+  # already fails the run, these just keep the results table readable.
+  FAILURE_TARGETS=$(echo "$FAILURE_OUTPUT" | sed -nE 's/^targets:[[:space:]]*(.*)$/\1/p')
+  FAILURE_TARGETS="${FAILURE_TARGETS:-unknown}"
+  FAILURE_REJOINED=$(echo "$FAILURE_OUTPUT" | sed -nE 's/^rejoined: (.*)$/\1/p')
+  FAILURE_REJOINED="${FAILURE_REJOINED:-unknown}"
+  [ "$UNRECOVERED_COUNT" -eq 0 ]
+}
+
 check_uncle_rate() {
   UNCLE_RATE=$(echo "$METRICS_OUTPUT" \
     | grep -oE "uncle rate \(node 0\): [0-9.]+" \
@@ -486,7 +547,13 @@ evaluate_results() {
     failed=1
   fi
 
-  echo "=== NIGHTLY SIM RESULTS ==="
+  local recovery_result="PASS"
+  if ! check_failure_recovery; then
+    recovery_result="FAIL"
+    failed=1
+  fi
+
+  echo "=== NIGHTLY SIM RESULTS (scenario: $SCENARIO) ==="
   printf "  nodes alive:        %-4s  (%s/%s)\n" \
     "$alive_result" "$ALIVE_COUNT" "$ALIVE_TOTAL"
   printf "  chain converged:    %-4s  (distinct hashes: %s, within 2 of tip: %s)\n" \
@@ -501,6 +568,8 @@ evaluate_results() {
     "$uncle_result" "$UNCLE_RATE" "$UNCLE_RATE_THRESHOLD"
   printf "  verify_chain:       %-4s  (%s/%s passed)\n" \
     "$verify_result" "$((VERIFY_CHAIN_TOTAL - VERIFY_CHAIN_FAILURES))" "$VERIFY_CHAIN_TOTAL"
+  printf "  failure recovery:   %-4s  (targets: %s, rejoined %s, unrecovered %s)\n" \
+    "$recovery_result" "$FAILURE_TARGETS" "$FAILURE_REJOINED" "$UNRECOVERED_COUNT"
 
   if [ "$failed" -eq 0 ]; then
     echo "RESULT: PASS"
@@ -524,6 +593,7 @@ ensure_bitcoind_running
 ensure_wallet_and_coins
 
 run_swarm
+inject_failures
 wait_for_convergence
 check_all_nodes_alive || true
 collect_metrics

--- a/load-tests/sim/run-swarm.sh
+++ b/load-tests/sim/run-swarm.sh
@@ -118,6 +118,10 @@ if [ -n "$existing" ]; then
   sleep 1
 fi
 
+# NOTE: this wipes the whole run dir, including any file a caller is already
+# writing there. Do not point a `tee` (or any other open handle) inside RUN_DIR
+# before calling this script -- the file gets unlinked and its contents are
+# lost even though the writer keeps succeeding.
 rm -rf "$RUN_DIR"
 mkdir -p "$RUN_DIR"
 PIDS_FILE="$RUN_DIR/pids.txt"

--- a/load-tests/sim/stop-swarm.sh
+++ b/load-tests/sim/stop-swarm.sh
@@ -2,12 +2,40 @@
 #
 # Stop a sim swarm started by run-swarm.sh (sends SIGTERM to recorded PIDs).
 #
+# Returns only once the node processes have actually exited. Callers read the
+# RocksDB stores immediately afterwards, and a node that has logged its
+# shutdown sequence but not yet exited still holds the store LOCK -- every
+# read-write open then fails, which looks like an empty/corrupt store rather
+# than a stop that was not waited for.
+#
 # Usage: load-tests/sim/stop-swarm.sh
-# Env:   RUN_DIR  (default /tmp/p2pool-sim)
+# Env:   RUN_DIR              (default /tmp/p2pool-sim)
+#        STOP_GRACE_SECONDS   how long to wait for a clean exit before
+#                             escalating to SIGKILL (default 10)
 set -euo pipefail
 
 RUN_DIR="${RUN_DIR:-/tmp/p2pool-sim}"
+STOP_GRACE_SECONDS="${STOP_GRACE_SECONDS:-10}"
 PIDS_FILE="$RUN_DIR/pids.txt"
+
+# Processes still running for this RUN_DIR, matched on the config path so we
+# don't touch an unrelated single-node run.
+running_nodes() {
+  pgrep -f "$RUN_DIR/node-" 2>/dev/null || true
+}
+
+# Poll until no node processes remain, up to the given number of seconds.
+wait_for_exit() {
+  local deadline="$1" waited=0
+  while [ "$waited" -lt "$deadline" ]; do
+    if [ -z "$(running_nodes)" ]; then
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  [ -z "$(running_nodes)" ]
+}
 
 n=0
 if [ -f "$PIDS_FILE" ]; then
@@ -19,17 +47,25 @@ if [ -f "$PIDS_FILE" ]; then
   done < "$PIDS_FILE"
 fi
 
-# Fallback: catch orphans this RUN_DIR spawned that aren't in pids.txt (e.g.
-# a prior run whose pids file was overwritten). Match on the config path.
-orphans=$(pgrep -f "$RUN_DIR/node-" 2>/dev/null || true)
+# Also catch orphans this RUN_DIR spawned that aren't in pids.txt (e.g. a prior
+# run whose pids file was overwritten).
+orphans="$(running_nodes)"
 if [ -n "$orphans" ]; then
   # shellcheck disable=SC2086
   kill $orphans 2>/dev/null || true
-  sleep 1
-  # SIGKILL any that ignored SIGTERM
-  orphans=$(pgrep -f "$RUN_DIR/node-" 2>/dev/null || true)
-  # shellcheck disable=SC2086
-  [ -n "$orphans" ] && kill -9 $orphans 2>/dev/null || true
 fi
 
-echo "Stopped swarm (pids.txt: $n; plus any orphans matching $RUN_DIR/node-)."
+exit_status=0
+if ! wait_for_exit "$STOP_GRACE_SECONDS"; then
+  survivors="$(running_nodes)"
+  echo "Nodes still running after ${STOP_GRACE_SECONDS}s, sending SIGKILL: $(echo "$survivors" | tr '\n' ' ')"
+  # shellcheck disable=SC2086
+  kill -9 $survivors 2>/dev/null || true
+  if ! wait_for_exit 5; then
+    echo "WARNING: nodes survived SIGKILL and still hold their store locks: $(running_nodes | tr '\n' ' ')" >&2
+    exit_status=1
+  fi
+fi
+
+echo "Stopped swarm (pids.txt: $n; all node processes for $RUN_DIR have exited)."
+exit "$exit_status"


### PR DESCRIPTION
Nightly sims start 10 nodes and then wait for the end.

We now add failure mode to it:

1. Some nodes fail-stop
2. Some nodes fail-restart
3. We also kill some nodes in way to create partition and then heal the partition

Improved logging of simulation results to trace failure reasons when debugging.

Finally, added new nightly actions to run clean, fast stop, fast restart and partition runs as separate actions.