### PR TITLE
Avoid non-determinism in uncle processing

### DIFF
--- a/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
+++ b/p2poolv2_lib/src/shares/chain/chain_store_handle.rs
@@ -27,7 +27,7 @@ use crate::store::dag_store::{BlockValidSearch, ShareDag, UncleInfo};
 use crate::store::transaction_store::PrevoutCheck;
 use crate::store::writer::{StoreError, StoreHandle};
 use bitcoin::{BlockHash, Work};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, info, warn};
 
@@ -575,16 +575,9 @@ impl ChainStoreHandle {
     /// inconsistent enough to break that surfaces one step later regardless:
     /// `get_distribution_from_start_hash` follows the same parent pointers to
     /// build the payout and errors on a missing header.
-    pub fn get_mining_base_and_uncles(
-        &self,
-    ) -> Result<(BlockHash, HashSet<BlockHash>), StoreError> {
+    pub fn get_mining_base_and_uncles(&self) -> Result<(BlockHash, Vec<BlockHash>), StoreError> {
         let mining_base = self.get_mining_base()?;
-        let uncles: HashSet<BlockHash> = self
-            .store_handle
-            .store()
-            .find_uncles(&mining_base)?
-            .into_iter()
-            .collect();
+        let uncles = self.store_handle.store().find_uncles(&mining_base)?;
         Ok((mining_base, uncles))
     }
 
@@ -875,7 +868,7 @@ mockall::mock! {
         pub fn get_candidate_tip_header(&self) -> Result<ShareHeader, StoreError>;
         pub fn is_current(&self) -> bool;
         pub fn get_mining_base(&self) -> Result<BlockHash, StoreError>;
-        pub fn get_mining_base_and_uncles(&self) -> Result<(BlockHash, HashSet<BlockHash>), StoreError>;
+        pub fn get_mining_base_and_uncles(&self) -> Result<(BlockHash, Vec<BlockHash>), StoreError>;
         pub fn get_share_height_and_time(&self, share_hash: &BlockHash) -> Result<(u32, u32), StoreError>;
         pub fn get_genesis_blockhash(&self) -> Option<BlockHash>;
         pub fn get_genesis_header(&self) -> Result<ShareHeader, StoreError>;

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -500,7 +500,7 @@ impl Store {
                 .map(move |child| (*ancestor, child))
         });
 
-        let mut uncles_with_work: Vec<(BlockHash, Work)> = children
+        let uncles_with_work: HashSet<(BlockHash, Work)> = children
             .filter(|(_, blockhash)| {
                 !ancestry.contains(blockhash)
                     && !self.is_confirmed(blockhash)
@@ -518,8 +518,10 @@ impl Store {
             })
             .collect();
 
-        // Sort by chain_work descending and take top MAX_UNCLES
-        uncles_with_work.sort_by_key(|(_, work)| std::cmp::Reverse(*work));
+        // Sort by chain_work descending then blockhash ascending and take top MAX_UNCLES
+        let mut uncles_with_work: Vec<(BlockHash, Work)> = uncles_with_work.into_iter().collect();
+        uncles_with_work.sort_by_key(|(blockhash, work)| (std::cmp::Reverse(*work), *blockhash));
+
         let uncles = uncles_with_work
             .into_iter()
             .take(MAX_UNCLES)

--- a/p2poolv2_lib/src/store/dag_store.rs
+++ b/p2poolv2_lib/src/store/dag_store.rs
@@ -3530,21 +3530,123 @@ mod tests {
         // find_uncles should return exactly 3 uncles, prioritizing higher chain_work
         // uncle_d has work=2, uncle_a/b/c have default work=1
         let uncles = store.find_uncles(&store.get_chain_tip().unwrap()).unwrap();
-        assert_eq!(uncles.len(), 3);
 
-        // uncle_d should be first (highest chain_work)
-        assert_eq!(uncles[0], uncle_d.block_hash());
-
-        // The remaining 2 should be from uncle_a, uncle_b, uncle_c (all same chain_work)
-        let height_1_uncles: HashSet<BlockHash> = [
+        // uncle_d leads on chain_work. uncle_a/b/c tie behind it and only two
+        // of the three fit, so the blockhash tiebreak decides both which pair
+        // is kept and the order it is kept in.
+        let mut tied = [
             uncle_a.block_hash(),
             uncle_b.block_hash(),
             uncle_c.block_hash(),
-        ]
-        .into_iter()
-        .collect();
-        assert!(height_1_uncles.contains(&uncles[1]));
-        assert!(height_1_uncles.contains(&uncles[2]));
+        ];
+        tied.sort();
+        assert_eq!(uncles, vec![uncle_d.block_hash(), tied[0], tied[1]]);
+    }
+
+    /// Uncles of equal chain_work are ordered by blockhash ascending.
+    #[test]
+    fn test_find_uncles_orders_equal_work_uncles_by_blockhash() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        // share0 (confirmed, height 0)
+        //   /   |     |       \
+        // share1 uncle_a uncle_b uncle_c (height 1, all default work)
+        // (confirmed)
+        let share0 = TestShareBlockBuilder::new().nonce(0).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&share0, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let share1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share0.block_hash().to_string())
+            .nonce(1)
+            .build();
+        let uncle_a = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share0.block_hash().to_string())
+            .nonce(100)
+            .build();
+        let uncle_b = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share0.block_hash().to_string())
+            .nonce(101)
+            .build();
+        let uncle_c = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share0.block_hash().to_string())
+            .nonce(102)
+            .build();
+
+        store.store_with_valid_metadata(&uncle_a);
+        store.store_with_valid_metadata(&uncle_b);
+        store.store_with_valid_metadata(&uncle_c);
+        store.push_to_confirmed_chain(&share1).unwrap();
+
+        let uncles = store.find_uncles(&share1.block_hash()).unwrap();
+
+        // Same parent and same work, so chain_work ties and only the blockhash
+        // separates them.
+        let mut expected = vec![
+            uncle_a.block_hash(),
+            uncle_b.block_hash(),
+            uncle_c.block_hash(),
+        ];
+        expected.sort();
+        assert_eq!(uncles, expected);
+    }
+
+    /// When more equal-work candidates exist than MAX_UNCLES, the blockhash
+    /// order decides which are kept, not just how the kept ones are arranged.
+    /// Without the tiebreak this selection differs between nodes.
+    #[test]
+    fn test_find_uncles_keeps_lowest_blockhashes_when_equal_work_exceeds_max() {
+        let temp_dir = tempdir().unwrap();
+        let store = Store::new(temp_dir.path().to_str().unwrap().to_string(), false).unwrap();
+
+        // share0 (confirmed, height 0)
+        //   /   |      |      |      \
+        // share1 uncle_a uncle_b uncle_c uncle_d (height 1, all default work)
+        // (confirmed)
+        let share0 = TestShareBlockBuilder::new().nonce(0).build();
+        let mut batch = Store::get_write_batch();
+        store.setup_genesis(&share0, &mut batch).unwrap();
+        store.commit_batch(batch).unwrap();
+
+        let share1 = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share0.block_hash().to_string())
+            .nonce(1)
+            .build();
+        let uncle_a = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share0.block_hash().to_string())
+            .nonce(100)
+            .build();
+        let uncle_b = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share0.block_hash().to_string())
+            .nonce(101)
+            .build();
+        let uncle_c = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share0.block_hash().to_string())
+            .nonce(102)
+            .build();
+        let uncle_d = TestShareBlockBuilder::new()
+            .prev_share_blockhash(share0.block_hash().to_string())
+            .nonce(103)
+            .build();
+
+        store.store_with_valid_metadata(&uncle_a);
+        store.store_with_valid_metadata(&uncle_b);
+        store.store_with_valid_metadata(&uncle_c);
+        store.store_with_valid_metadata(&uncle_d);
+        store.push_to_confirmed_chain(&share1).unwrap();
+
+        let uncles = store.find_uncles(&share1.block_hash()).unwrap();
+
+        let mut candidates = [
+            uncle_a.block_hash(),
+            uncle_b.block_hash(),
+            uncle_c.block_hash(),
+            uncle_d.block_hash(),
+        ];
+        candidates.sort();
+        assert_eq!(uncles.as_slice(), &candidates[..MAX_UNCLES]);
     }
 
     #[test]
@@ -3787,17 +3889,12 @@ mod tests {
         store.push_to_confirmed_chain(&share2).unwrap();
 
         let uncles = store.find_uncles(&store.get_chain_tip().unwrap()).unwrap();
-        assert_eq!(uncles.len(), 3);
 
-        // uncle_high (work=3) should come first
-        assert_eq!(uncles[0], uncle_high.block_hash());
-
-        // uncle_mid_a and uncle_mid_b (both work=2) should be selected over uncle_low (work=1)
-        let mid_uncles: HashSet<BlockHash> = [uncle_mid_a.block_hash(), uncle_mid_b.block_hash()]
-            .into_iter()
-            .collect();
-        assert!(mid_uncles.contains(&uncles[1]));
-        assert!(mid_uncles.contains(&uncles[2]));
+        // uncle_high (work=3) comes first, then uncle_mid_a and uncle_mid_b
+        // (both work=2) in blockhash order.
+        let mut tied = [uncle_mid_a.block_hash(), uncle_mid_b.block_hash()];
+        tied.sort();
+        assert_eq!(uncles, vec![uncle_high.block_hash(), tied[0], tied[1]]);
 
         // uncle_low at height 2 is excluded despite being at higher height than the mids
         assert!(!uncles.contains(&uncle_low.block_hash()));

--- a/p2poolv2_lib/src/stratum/work/notify.rs
+++ b/p2poolv2_lib/src/stratum/work/notify.rs
@@ -121,7 +121,7 @@ fn build_prepared_notify(
         clean_jobs,
     )
     .prev_share_blockhash(tip)
-    .uncles(uncles.into_iter().collect())
+    .uncles(uncles)
     .bits(target)
     .donation_address(context.config.donation_address().cloned())
     .donation(context.config.donation)
@@ -340,7 +340,7 @@ mod tests {
         let genesis_header = genesis.header.clone();
         chain_store_handle
             .expect_get_mining_base_and_uncles()
-            .returning(move || Ok((genesis_hash, std::collections::HashSet::new())));
+            .returning(move || Ok((genesis_hash, vec![])));
         chain_store_handle
             .expect_get_share_height_and_time()
             .returning(|_| Ok((0, genesis_for_tests().header.time)));
@@ -408,7 +408,7 @@ mod tests {
         let genesis_header = genesis.header.clone();
         chain_store_handle
             .expect_get_mining_base_and_uncles()
-            .returning(move || Ok((genesis_hash, std::collections::HashSet::new())));
+            .returning(move || Ok((genesis_hash, vec![])));
 
         let pool_difficulty =
             pool_difficulty::PoolDifficulty::new(genesis_header.bits, genesis_header.time, 0);
@@ -503,7 +503,7 @@ mod tests {
         let genesis_hash = genesis.block_hash();
         chain_store_handle
             .expect_get_mining_base_and_uncles()
-            .returning(move || Ok((genesis_hash, std::collections::HashSet::new())));
+            .returning(move || Ok((genesis_hash, vec![])));
 
         chain_store_handle
             .expect_get_share_height_and_time()


### PR DESCRIPTION
We used to `HashSet` uncle hashes in `get_mining_base_and_uncles` and that could be a root of non-determinism in uncle processing.

Moved the dedupe up in the chain of calls, to the root `find_uncles` right before the sort and collect into a vec.