### PR TITLE
Add command to generate address from bitcoin-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,7 @@ dependencies = [
  "config",
  "hex",
  "hmac",
+ "p2poolv2_address",
  "p2poolv2_lib",
  "rand 0.8.5",
  "reqwest",

--- a/README.adoc
+++ b/README.adoc
@@ -126,20 +126,34 @@ source is a Bitcoin Core wallet:
 
 [,shell]
 ----
-bitcoin-cli -signet getnewaddress "p2pool share owner" bech32m
-bitcoin-cli -signet getaddressinfo <that address>
+ADDR=$(bitcoin-cli -signet getnewaddress "p2pool share owner" bech32m)
+bitcoin-cli -signet getaddressinfo "$ADDR"    # check "ismine" and "solvable"
+bitcoin-cli -signet getaddressinfo "$ADDR" | jq -r .witness_program \
+  | p2poolv2_cli address --network signet
 ----
 
-Use the `witness_program` field, which is the 32 byte taproot output key.
-Encoding those bytes as bech32m under the `sp2pool` prefix (`p2pool` for
-mainnet, `tp2pool` for testnet4, `rp2pool` for regtest) gives the share
-address for that wallet key. Check `"ismine": true` and `"solvable": true` in
-the same output, or you are assigning shares to a key you cannot sign with.
+`witness_program` is the 32 byte taproot output key; `p2poolv2_cli address`
+encodes it under the share chain prefix for the network you name (`main`,
+`testnet4`, `signet` or `regtest`, as Bitcoin Core names them). Check
+`"ismine": true` and `"solvable": true` in the `getaddressinfo` output, or you
+are assigning shares to a key you cannot sign with.
+
+Use the address either on the node, as `[stratum] miner_address` in
+`config.toml`, or from the miner, as the stratum password:
+
+[,shell]
+----
+p2p=sp2pool1p504yc8zlqs4w077ss6787v8z5zxgke6nc333md75k87t82u5ryqqd9033x,d=1000
+----
+
+The `p2p=` key is case insensitive and the fields may be in any order, comma,
+space, tab or semicolon separated. The stratum *username* stays your bitcoin
+payout address. Note that `p2p=<address>` alone is 71 characters, so check your
+firmware does not truncate the password field; a truncated address fails its
+checksum rather than sending your shares elsewhere.
 
 P2Poolv2 does not generate private keys and ships no tool to do so, by design.
-It also does not yet ship the bech32m encoder for the step above; until it
-does, setting `[stratum] miner_address` once on the node is the simplest route
-for a pool.
+The encoder takes a public output key only, never a private key.
 
 NOTE: A taproot address is not a share chain address. `tb1p...` and
 `sp2pool1p...` encode the same 32 bytes, but the prefix is covered by the

--- a/docs/architecture/address-format.md
+++ b/docs/architecture/address-format.md
@@ -246,19 +246,40 @@ Note that the taproot address is not itself accepted. `tb1p...` and
 checksum, so the strings are not interchangeable and both parsers reject
 the other's form. That is the whole point of the separate type.
 
-**There is no P2Poolv2 tool that performs the bech32m re-encoding
-today.** The format is fully specified above, including verified test
-vectors, so external tooling can implement it. Until such a tool exists,
-the working route for a pool is the operator setting `[stratum]
-miner_address` once, so no miner needs to supply an address at all; see
-"Supplying an address" below.
+### The encoder
 
-A future encoder should take a **public key or output key, never a
-private key and never a bitcoin address**. Public key input keeps every
-private key outside this project, and is a weak spend-capability signal
-in its own right: you cannot produce the pubkey behind someone else's
-exchange deposit address, which is the same argument that ruled out
-deriving `miner_address` from `miner_bitcoin_address`.
+`p2poolv2_cli address` performs the bech32m re-encoding, taking the
+`witness_program` hex on stdin or as an argument:
+
+```sh
+ADDR=$(bitcoin-cli -signet getnewaddress "p2pool share owner" bech32m)
+bitcoin-cli -signet getaddressinfo "$ADDR" \
+  | jq -r .witness_program \
+  | p2poolv2_cli address --network signet
+```
+
+Networks are named as Bitcoin Core names them, so the flag matches the
+`bitcoin-cli` invocation: `main`, `testnet4`, `signet` or `regtest`. The
+command needs neither a config file nor a running node, and prints the
+address alone so it can be piped.
+
+It takes an **output key, never a private key and never a bitcoin
+address**. Public key input keeps every private key outside this
+project, and is a weak spend-capability signal in its own right: you
+cannot produce the pubkey behind someone else's exchange deposit
+address, which is the same argument that ruled out deriving
+`miner_address` from `miner_bitcoin_address`. A bitcoin address is
+refused for the same reason `Address` has no constructor taking one.
+
+The 32 bytes are checked to be a valid x-only curve point rather than
+re-encoded blindly, so a mistyped key fails here instead of yielding an
+address whose shares nobody can ever spend. The format is fully
+specified above, including verified test vectors, so other tooling can
+implement it independently.
+
+An operator who would rather not have miners supply an address at all
+can set `[stratum] miner_address` once instead; see "Supplying an
+address" below.
 
 ### No P2Poolv2 crate generates private keys
 

--- a/p2poolv2_cli/Cargo.toml
+++ b/p2poolv2_cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 p2poolv2_lib = { workspace = true }
+p2poolv2_address = { workspace = true }
 bitcoin = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/p2poolv2_cli/README.md
+++ b/p2poolv2_cli/README.md
@@ -120,6 +120,37 @@ heights with more than 20 blocks. Retains Confirmed, Candidate, and
 BlockValid blocks, plus HeaderValid blocks that are referenced as
 uncles by other blocks.
 
+### address
+
+Print the share chain address for a taproot output key. Does not
+require a running node or config file.
+
+The input is the `witness_program` field of `bitcoin-cli
+getaddressinfo`: the already tweaked 32 byte taproot output key, in hex.
+No tweak is applied here, because the wallet applied it. The key is
+checked to be a real curve point, so a typo cannot produce an address
+whose shares nobody can ever spend.
+
+```sh
+ADDR=$(bitcoin-cli -signet getnewaddress "p2pool share owner" bech32m)
+bitcoin-cli -signet getaddressinfo "$ADDR" \
+  | jq -r .witness_program \
+  | p2poolv2_cli address --network signet
+```
+
+The output key can also be passed as an argument instead of on stdin:
+
+```sh
+p2poolv2_cli address --network signet a3ea4c1c5f042ae7fbd086bc7f30e2a08c8b6753c4631db7d4b1fcb3ab941900
+```
+
+Networks are named as Bitcoin Core names them: `main`, `testnet4`,
+`signet` or `regtest`. Check `"ismine": true` and `"solvable": true` in
+the same `getaddressinfo` output; those are what tell you the wallet can
+sign for the key. Use the result as `[stratum] miner_address`, or as the
+stratum password `p2p=<address>`. See
+`docs/architecture/address-format.md`.
+
 ### gen-auth
 
 Generate API authentication credentials. Does not require a running

--- a/p2poolv2_cli/src/commands/address.rs
+++ b/p2poolv2_cli/src/commands/address.rs
@@ -1,0 +1,191 @@
+// Copyright (C) 2024-2026 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+//! Encode a taproot output key as a share chain address.
+//!
+//! The input is the `witness_program` field of `bitcoin-cli getaddressinfo`,
+//! which is the already tweaked 32 byte output key that lands in the
+//! `scriptPubKey`. No tweak is applied here, because the wallet applied it.
+//!
+//! Deliberately takes a public key and never a private key: no P2Poolv2 crate
+//! generates or handles private keys. See `docs/architecture/address-format.md`.
+
+use bitcoin::Network;
+use bitcoin::hex::FromHex;
+use bitcoin::secp256k1::XOnlyPublicKey;
+use p2poolv2_address::Address;
+use std::error::Error;
+use std::io::Read;
+
+/// Length of a taproot output key, the only witness program this encodes.
+const OUTPUT_KEY_LENGTH: usize = 32;
+
+/// Parse a network the way the config and `bitcoin-cli -chain=` name it.
+///
+/// Used as a clap value parser, so the error names the accepted values rather
+/// than leaving a typo to fail as an unknown network.
+pub fn parse_network(value: &str) -> Result<Network, String> {
+    Network::from_core_arg(value).map_err(|_| {
+        format!("unknown network '{value}', expected main, testnet4, signet or regtest")
+    })
+}
+
+/// Build the share chain address for a taproot output key on `network`.
+///
+/// Rejects a key that is not a curve point. Those 32 bytes would encode an
+/// output nobody can ever spend, so a share paid to it would be lost.
+fn encode(output_key_hex: &str, network: Network) -> Result<Address, Box<dyn Error>> {
+    let output_key_bytes = Vec::from_hex(output_key_hex)
+        .map_err(|error| format!("witness program is not hex: {error}"))?;
+
+    if output_key_bytes.len() != OUTPUT_KEY_LENGTH {
+        return Err(format!(
+            "witness program is {} bytes, expected {OUTPUT_KEY_LENGTH} for a taproot output key. \
+             Ask the wallet for a bech32m address, not an older type.",
+            output_key_bytes.len()
+        )
+        .into());
+    }
+
+    let output_key = XOnlyPublicKey::from_slice(&output_key_bytes)
+        .map_err(|error| format!("witness program is not a valid taproot output key: {error}"))?;
+
+    Ok(Address::from_output_key(output_key, network)?)
+}
+
+/// Read the output key from the argument, or from stdin when none was given.
+fn read_output_key_hex(output_key_hex: Option<String>) -> Result<String, Box<dyn Error>> {
+    let raw = match output_key_hex {
+        Some(value) => value,
+        None => {
+            let mut buffer = String::new();
+            std::io::stdin().read_to_string(&mut buffer)?;
+            buffer
+        }
+    };
+
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("no witness program given. Pass one as an argument or on stdin.".into());
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Execute the address command, printing the share chain address alone so it
+/// can be piped or copied into `[stratum] miner_address`.
+pub fn execute(output_key_hex: Option<String>, network: Network) -> Result<(), Box<dyn Error>> {
+    let output_key_hex = read_output_key_hex(output_key_hex)?;
+    println!("{}", encode(&output_key_hex, network)?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The worked example in docs/architecture/address-format.md: the witness
+    /// program of tb1p504yc8zlqs4w077ss6787v8z5zxgke6nc333md75k87t82u5ryqq0gh57d.
+    const WALLET_OUTPUT_KEY: &str =
+        "a3ea4c1c5f042ae7fbd086bc7f30e2a08c8b6753c4631db7d4b1fcb3ab941900";
+
+    #[test]
+    fn encodes_the_signet_worked_example_from_the_address_format_doc() {
+        assert_eq!(
+            encode(WALLET_OUTPUT_KEY, Network::Signet)
+                .unwrap()
+                .to_string(),
+            "sp2pool1p504yc8zlqs4w077ss6787v8z5zxgke6nc333md75k87t82u5ryqqd9033x"
+        );
+    }
+
+    #[test]
+    fn encodes_the_same_key_under_the_mainnet_prefix() {
+        assert!(
+            encode(WALLET_OUTPUT_KEY, Network::Bitcoin)
+                .unwrap()
+                .to_string()
+                .starts_with("p2pool1p504yc8zlqs4w077ss6787v8z5zxgke6nc333md75k87t82u5ryqq")
+        );
+    }
+
+    #[test]
+    fn produces_the_same_script_pubkey_as_the_wallet_address() {
+        let address = encode(WALLET_OUTPUT_KEY, Network::Signet).unwrap();
+        assert_eq!(
+            address.script_pubkey().to_string(),
+            format!("OP_PUSHNUM_1 OP_PUSHBYTES_32 {WALLET_OUTPUT_KEY}")
+        );
+    }
+
+    #[test]
+    fn rejects_a_20_byte_witness_program() {
+        let error = encode("751e76e8199196d454941c45d1b3a323f1433bd6", Network::Signet)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("20 bytes"), "{error}");
+    }
+
+    #[test]
+    fn rejects_a_non_hex_witness_program() {
+        let error = encode("not hex at all", Network::Signet)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not hex"), "{error}");
+    }
+
+    #[test]
+    fn rejects_32_bytes_that_are_not_a_curve_point() {
+        let error = encode(
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            Network::Signet,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("not a valid taproot output key"), "{error}");
+    }
+
+    #[test]
+    fn rejects_testnet3_which_has_no_prefix() {
+        assert!(encode(WALLET_OUTPUT_KEY, Network::Testnet).is_err());
+    }
+
+    #[test]
+    fn parses_the_core_chain_name_for_signet() {
+        assert_eq!(parse_network("signet").unwrap(), Network::Signet);
+    }
+
+    #[test]
+    fn parses_main_as_the_bitcoin_network() {
+        assert_eq!(parse_network("main").unwrap(), Network::Bitcoin);
+    }
+
+    #[test]
+    fn rejects_an_unknown_network_name_by_listing_the_accepted_ones() {
+        let error = parse_network("mainnet").unwrap_err();
+        assert!(
+            error.contains("expected main, testnet4, signet or regtest"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn trims_the_trailing_newline_jq_writes() {
+        assert_eq!(
+            read_output_key_hex(Some(format!("{WALLET_OUTPUT_KEY}\n"))).unwrap(),
+            WALLET_OUTPUT_KEY
+        );
+    }
+}

--- a/p2poolv2_cli/src/commands/mod.rs
+++ b/p2poolv2_cli/src/commands/mod.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod address;
 pub mod api_client;
 pub mod blocked_ips;
 pub mod candidates;
@@ -30,6 +31,7 @@ pub mod shares;
 pub mod transactions;
 
 use crate::commands;
+use bitcoin::Network;
 use clap::{ArgGroup, Parser, Subcommand};
 use p2poolv2_lib::config::Config;
 use std::error::Error;
@@ -39,7 +41,7 @@ use std::path::Path;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
-    /// Path to p2poolv2 config file (not required for gen-auth or --db-path commands)
+    /// Path to p2poolv2 config file (not required for address, gen-auth or --db-path commands)
     #[arg(short, long, env("P2POOL_CONFIG"), global = true)]
     pub config: Option<String>,
 
@@ -138,6 +140,18 @@ pub enum Commands {
         #[command(subcommand)]
         command: DbCommands,
     },
+    /// Print the share chain address for a taproot output key
+    ///
+    /// Takes the `witness_program` field of `bitcoin-cli getaddressinfo`, the
+    /// already tweaked 32 byte taproot output key, in hex. Reads it from stdin
+    /// when no argument is given.
+    Address {
+        /// Taproot output key, hex. Omit to read it from stdin.
+        witness_program: Option<String>,
+        /// Network whose prefix to encode under: main, testnet4, signet or regtest
+        #[arg(short, long, value_parser = commands::address::parse_network)]
+        network: Network,
+    },
     /// Generate API authentication credentials (salt, password, HMAC)
     GenAuth {
         /// Username for API authentication
@@ -189,6 +203,12 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
 
     match &cli.command {
+        Some(Commands::Address {
+            witness_program,
+            network,
+        }) => {
+            commands::address::execute(witness_program.clone(), *network)?;
+        }
         Some(Commands::GenAuth { username, password }) => {
             commands::gen_auth::execute(username.clone(), password.clone())?;
         }


### PR DESCRIPTION
We need a quick and dirty way to generate a p2pool hrp address to run a node. This change adds a command to take witness program from bitcoin-cli's getaddressinfo and encode it as a p2poolv2 program.

We don't have spending abilities yet, so all these shares will be unspendable.