### PR TITLE
Adds a native Ansible role for deploying Grafana + Prometheus, and adds Arch Linux support to the nginx role.

### DIFF
--- a/ansible/README.adoc
+++ b/ansible/README.adoc
@@ -112,6 +112,23 @@ Nginx is configured once per host (not per instance). The config includes:
 - Let's Encrypt certificates via certbot
 - Basic auth header injection toward the API backend (derived from vault credentials)
 
+== Grafana
+
+Installs Prometheus and Grafana natively (via the system package manager, not Docker), and deploys the existing dashboards from `prometheus/grafana/dashboards/` and the datasource/dashboard provisioning from `prometheus/grafana/provisioning/`.
+
+- Prometheus is available in the default repositories on both Debian/Ubuntu and Arch, so no extra repository setup is needed for it
+- Grafana requires its own official repository, which this role adds automatically
+- Both services are enabled and started via systemd (`prometheus`, `grafana-server`)
+- Deploy just this role with:
++
+[source,bash]
+----
+ansible-playbook -i inventory/hosts.yml playbook.yml --tags grafana
+----
+- To expose Grafana externally, set `p2poolv2_grafana_domain` and see the Nginx section above for the reverse proxy setup
+
+This is intentionally kept separate from the Docker-based `docker/docker-compose.metrics.yml` setup, which is meant for fully-Docker deployments (where p2poolv2 itself also runs in Docker). This Ansible role targets natively-run (systemd) p2poolv2 instances instead.
+
 == Secrets
 
 All credentials are stored in `inventory/group_vars/all/vault.yml`, encrypted with ansible-vault. The vault file is gitignored.
@@ -128,7 +145,7 @@ Store the username, password, and resulting token in the vault. The nginx basic 
 == Prerequisites
 
 * Ansible 2.12+
-* A target host running Ubuntu (tested on 22.04)
+* A target host running Ubuntu (tested on 22.04) or Arch Linux
 * SSH access with sudo privileges
 * A running Bitcoin Core node on the target (not managed by this playbook)
 * DNS records pointing your domain(s) to the target host (for Let's Encrypt)

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -11,6 +11,7 @@
 # To deploy only a specific role:
 #   ansible-playbook -i inventory/hosts.yml playbook.yml --tags p2poolv2
 #   ansible-playbook -i inventory/hosts.yml playbook.yml --tags nginx
+#   ansible-playbook -i inventory/hosts.yml playbook.yml --tags grafana
 
 - name: Deploy P2Poolv2
   hosts: p2poolv2_nodes
@@ -58,3 +59,7 @@
       ansible.builtin.include_role:
         name: nginx_p2poolv2
       tags: [nginx]
+    - name: Deploy Grafana and Prometheus
+      ansible.builtin.include_role:
+        name: grafana_p2poolv2
+      tags: [grafana]

--- a/ansible/roles/grafana_p2poolv2/handlers/main.yml
+++ b/ansible/roles/grafana_p2poolv2/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: restart prometheus
+  ansible.builtin.systemd:
+    name: prometheus
+    state: restarted
+
+- name: restart grafana-server
+  ansible.builtin.systemd:
+    name: grafana-server
+    state: restarted

--- a/ansible/roles/grafana_p2poolv2/tasks/main.yml
+++ b/ansible/roles/grafana_p2poolv2/tasks/main.yml
@@ -1,0 +1,111 @@
+---
+# Grafana + Prometheus role -- native install and configuration for
+# monitoring p2poolv2 metrics
+
+# --- Grafana repository setup (Debian/Ubuntu) ---
+
+- name: Ensure keyring directory exists (Debian/Ubuntu)
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+  when: ansible_os_family == "Debian"
+
+- name: Download Grafana GPG key (Debian/Ubuntu)
+  ansible.builtin.get_url:
+    url: https://apt.grafana.com/gpg.key
+    dest: /etc/apt/keyrings/grafana.asc
+    mode: "0644"
+  when: ansible_os_family == "Debian"
+
+- name: Add Grafana apt repository (Debian/Ubuntu)
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/etc/apt/keyrings/grafana.asc] https://apt.grafana.com stable main"
+    state: present
+    filename: grafana
+  when: ansible_os_family == "Debian"
+
+- name: Update apt cache after adding Grafana repo (Debian/Ubuntu)
+  ansible.builtin.apt:
+    update_cache: true
+  when: ansible_os_family == "Debian"
+
+# --- Install packages ---
+# Prometheus is available in default repos on both Debian/Ubuntu (universe)
+# and Arch (extra), so no extra repo setup is needed for it.
+
+- name: Install prometheus and grafana
+  ansible.builtin.package:
+    name:
+      - prometheus
+      - grafana
+    state: present
+
+# --- Deploy Prometheus config ---
+
+- name: Deploy prometheus.yml
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../prometheus/prometheus.yml"
+    dest: /etc/prometheus/prometheus.yml
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart prometheus
+
+# --- Deploy Grafana provisioning and dashboards ---
+
+- name: Ensure Grafana provisioning directory exists
+  ansible.builtin.file:
+    path: /etc/grafana/provisioning
+    state: directory
+    mode: "0755"
+
+- name: Deploy Grafana datasource provisioning
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../prometheus/grafana/provisioning/datasources/"
+    dest: /etc/grafana/provisioning/datasources/
+    owner: root
+    group: grafana
+    mode: "0644"
+  notify: restart grafana-server
+
+- name: Deploy Grafana dashboard provisioning config
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../prometheus/grafana/provisioning/dashboards/"
+    dest: /etc/grafana/provisioning/dashboards/
+    owner: root
+    group: grafana
+    mode: "0644"
+  notify: restart grafana-server
+
+- name: Ensure Grafana dashboards directory exists
+  ansible.builtin.file:
+    path: /var/lib/grafana/dashboards
+    state: directory
+    owner: grafana
+    group: grafana
+    mode: "0755"
+
+- name: Deploy Grafana dashboard JSON files
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../prometheus/grafana/dashboards/"
+    dest: /var/lib/grafana/dashboards/
+    owner: grafana
+    group: grafana
+    mode: "0644"
+  notify: restart grafana-server
+
+# --- Enable and start services ---
+
+- name: Enable and start prometheus service
+  ansible.builtin.systemd:
+    name: prometheus
+    enabled: true
+    state: started
+
+- name: Enable and start grafana-server service
+  ansible.builtin.systemd:
+    name: grafana-server
+    enabled: true
+    state: started
+

--- a/ansible/roles/nginx_p2poolv2/tasks/main.yml
+++ b/ansible/roles/nginx_p2poolv2/tasks/main.yml
@@ -8,19 +8,35 @@
 #   4. Deploy full SSL config
 #   5. Reload nginx
 
-- name: Install nginx
+- name: Update apt cache (Debian/Ubuntu)
   ansible.builtin.apt:
+    update_cache: true
+  when: ansible_os_family == "Debian"
+
+- name: Install nginx
+  ansible.builtin.package:
     name: nginx
     state: present
-    update_cache: true
 
-- name: Install certbot and nginx plugin
-  ansible.builtin.apt:
+- name: Install certbot and nginx plugin (Debian/Ubuntu)
+  ansible.builtin.package:
     name:
       - certbot
       - python3-certbot-nginx
     state: present
-  when: p2poolv2_certbot_email | default('') | length > 0
+  when: >
+    ansible_os_family == "Debian" and
+    p2poolv2_certbot_email | default('') | length > 0
+
+- name: Install certbot and nginx plugin (Arch)
+  ansible.builtin.package:
+    name:
+      - certbot
+      - certbot-nginx
+    state: present
+  when: >
+    ansible_os_family == "Archlinux" and
+    p2poolv2_certbot_email | default('') | length > 0
 
 - name: Check if SSL certificate exists
   ansible.builtin.stat:


### PR DESCRIPTION
## Grafana/Prometheus role (`grafana_p2poolv2`)

- Installs Prometheus and Grafana natively via the system package manager, not Docker (per discussion, keeping Ansible fully systemd-based, separate from the Docker Compose path)
- Prometheus is available in the default repos on both Debian/Ubuntu and Arch, so no extra repo setup needed there
- Grafana requires its own official repository, which this role adds automatically (GPG key + apt source on Debian/Ubuntu; confirmed available directly via pacman on Arch)
- Deploys the existing dashboards (`prometheus/grafana/dashboards/`) and provisioning config (`prometheus/grafana/provisioning/`) that were already in the repo, nothing built from scratch there
- Both services enabled/started via systemd, with proper Ansible handlers (`restart prometheus`, `restart grafana-server`) triggered only when their respective config actually changes
- Deploy with: `ansible-playbook -i inventory/hosts.yml playbook.yml --tags grafana`
- Intentionally kept separate from `docker/docker-compose.metrics.yml`, which is for fully-Docker deployments where p2poolv2 itself also runs in Docker

## Arch Linux support (`nginx_p2poolv2`)

- Replaced the two Debian-specific `apt` tasks with the distro-agnostic `package` module
- Split the certbot nginx plugin package name per distro (`python3-certbot-nginx` on Debian/Ubuntu, `certbot-nginx` on Arch), since they're named differently
- Updated the README prerequisites to mention Arch as a supported target host

## Not tested against a real server yet

I don't currently have a test server to run this against, so this hasn't been verified end-to-end (installing the packages, confirming the dashboard actually renders in a browser, etc.). Happy to test against a real target if one's available, or if you get to it first, let me know how it goes.