### PR TITLE
Streamline release builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,23 +73,13 @@ jobs:
           - platform: linux/amd64
             runner: ubuntu-latest
             arch: amd64
-            qemu: false
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             arch: arm64
-            qemu: false
-          - platform: linux/arm/v7
-            runner: ubuntu-24.04-arm
-            arch: armv7
-            qemu: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           persist-credentials: false
-
-      - name: Set up QEMU
-        if: matrix.qemu
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: Build and verify
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:

--- a/.github/workflows/docker/cleanup-temp-tags.sh
+++ b/.github/workflows/docker/cleanup-temp-tags.sh
@@ -17,7 +17,7 @@ else
   BASE="/users/${OWNER}/packages/container/${PKG}"
 fi
 
-for ARCH in amd64 arm64 armv7; do
+for ARCH in amd64 arm64; do
   TAG="${IMAGE_SHA}-${ARCH}"
   VID=$(gh api "${BASE}/versions" \
     --jq ".[] | select(.metadata.container.tags | index(\"${TAG}\")) | .id" \

--- a/.github/workflows/docker/create-manifests.sh
+++ b/.github/workflows/docker/create-manifests.sh
@@ -16,8 +16,7 @@ docker buildx imagetools create \
   --annotation "${ANNOTATION_SOURCE}" \
   --annotation "${ANNOTATION_DESC}" \
   "${SRC_TAG}-amd64" \
-  "${SRC_TAG}-arm64" \
-  "${SRC_TAG}-armv7"
+  "${SRC_TAG}-arm64"
 
 echo "=== 2/5 Docker Hub: copy multi-arch manifest (self-contained) ==="
 docker buildx imagetools create -t "${DH_TAG}" "${SRC_TAG}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.15.2] - 2026-09-06
+
+### Fixed
+
+- Increase docker action timeout on github
+
+### Removed
+
+- x86_64 macOS (Intel) release binaries
+- linux/arm/v7 docker images
+
 ## [v0.15.1] - 2026-09-06
 
 ### Breaking
@@ -1075,7 +1086,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 We used tags like hydrapool.v0.x.0 and we didn't keep a changelog.
 
-[Unreleased]: https://github.com/p2poolv2/p2poolv2/compare/v0.15.1...HEAD
+[Unreleased]: https://github.com/p2poolv2/p2poolv2/compare/v0.15.2...HEAD
+[v0.15.2]: https://github.com/p2poolv2/p2poolv2/compare/v0.15.1...v0.15.2
 [v0.15.1]: https://github.com/p2poolv2/p2poolv2/compare/v0.14.1...v0.15.1
 [v0.14.1]: https://github.com/p2poolv2/p2poolv2/compare/v0.14.0...v0.14.1
 [v0.14.0]: https://github.com/p2poolv2/p2poolv2/compare/v0.13.0...v0.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoindrpc"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "base64 0.23.1",
  "bitcoin",
@@ -3011,7 +3011,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "p2poolv2_address"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "bitcoin",
  "hex",
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_api"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "axum",
  "base64 0.23.1",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_cli"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "base64 0.23.1",
  "bitcoin",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_config"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_lib"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_node"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "base64 0.23.1",
  "bitcoin",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_sim"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "bitcoin",
  "bitcoindrpc",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "p2poolv2_tests"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "base64 0.23.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.15.2"
 edition = "2024"
 authors = ["Kulpreet Singh<kp@opdup.com>"]
 license = "AGPL-3.0-or-later"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program


### PR DESCRIPTION
Remove Apple Intel native builds.
Remove 32 bit arm builds.
Extend docker timeout to 30m